### PR TITLE
Enable Azure KeyVault in Bicep deployment

### DIFF
--- a/deployments/azure_bicep/modules/apps-nutsnode.bicep
+++ b/deployments/azure_bicep/modules/apps-nutsnode.bicep
@@ -5,7 +5,7 @@ param location string = resourceGroup().location
 param resourceName string = 'nutsnode'
 
 @description('Nuts Node Docker image to deploy')
-param nodeImage string = 'nutsfoundation/nuts-node:6.0.0-beta.2'
+param nodeImage string = 'nutsfoundation/nuts-node:6.0.0-beta.3'
 
 // @description('Port to open on the container and the public IP address.')
 // param port int = 80
@@ -147,6 +147,10 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
             {
               name: 'NUTS_CRYPTO_AZUREKV_URL'
               value: keyVault.properties.vaultUri
+            }
+            {
+              name: 'NUTS_CRYPTO_AZUREKV_AUTH_TYPE'
+              value: 'managed_identity'
             }
             {
               name: 'NUTS_AUTH_CONTRACTVALIDATORS'


### PR DESCRIPTION
- Pins Nuts node to specific version (v6.0.0-beta.2). A new master image didn't cause a pull, so pinning for now.
- Switches fs crypto storage for Azure Key Vault
- Removes FHIR service dependency from Nuts node (Nuts node does not use it)