### PR TITLE
CarePlanContributor: have proxy endpoints

### DIFF
--- a/orchestrator/applaunch/clients/factory.go
+++ b/orchestrator/applaunch/clients/factory.go
@@ -1,0 +1,15 @@
+package clients
+
+import (
+	"net/http"
+	"net/url"
+)
+
+type ClientProperties struct {
+	BaseURL *url.URL
+	Client  http.RoundTripper
+}
+
+type ClientCreator func(properties map[string]string) ClientProperties
+
+var Factories = map[string]ClientCreator{}

--- a/orchestrator/applaunch/demo/service.go
+++ b/orchestrator/applaunch/demo/service.go
@@ -1,9 +1,8 @@
 package demo
 
 import (
-	fhirclient "github.com/SanteonNL/go-fhir-client"
+	"github.com/SanteonNL/orca/orchestrator/applaunch/clients"
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor"
-	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
 	"github.com/SanteonNL/orca/orchestrator/lib/tinyhttp"
 	"github.com/SanteonNL/orca/orchestrator/user"
 	"github.com/rs/zerolog/log"
@@ -15,11 +14,12 @@ const fhirLauncherKey = "demo"
 
 func init() {
 	// Register FHIR client factory that can create FHIR clients when the Demo AppLaunch is used
-	coolfhir.ClientFactories[fhirLauncherKey] = func(properties map[string]string) fhirclient.Client {
+	clients.Factories[fhirLauncherKey] = func(properties map[string]string) clients.ClientProperties {
 		fhirServerURL, _ := url.Parse(properties["iss"])
-		// Demo AppLaunch connects to backing FHIR server without any authentication,
-		// so http.DefaultClient can be used.
-		return fhirclient.New(fhirServerURL, http.DefaultClient, coolfhir.Config())
+		return clients.ClientProperties{
+			BaseURL: fhirServerURL,
+			Client:  http.DefaultTransport,
+		}
 	}
 }
 

--- a/orchestrator/applaunch/smartonfhir/service.go
+++ b/orchestrator/applaunch/smartonfhir/service.go
@@ -114,6 +114,7 @@ func (s *Service) handleSmartAppLaunchRedirect(response http.ResponseWriter, req
 
 	// 1) Extract the type of launch that is being performed, for example an enrollment, or a data view
 	// 2) switch type - call the apropriate service to handle the request
+	// TODO: Need to provide "patient", "serviceRequest", "practitioner" in the "values" map
 	s.sessionManager.Create(response, user.SessionData{
 		FHIRLauncher: fhirLauncherKey,
 		Values: map[string]string{

--- a/orchestrator/applaunch/smartonfhir/service.go
+++ b/orchestrator/applaunch/smartonfhir/service.go
@@ -3,9 +3,8 @@ package smartonfhir
 import (
 	"encoding/json"
 	"errors"
-	fhirclient "github.com/SanteonNL/go-fhir-client"
+	"github.com/SanteonNL/orca/orchestrator/applaunch/clients"
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor"
-	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
 	"github.com/SanteonNL/orca/orchestrator/user"
 	"net/http"
 	"net/url"
@@ -19,8 +18,11 @@ const fhirLauncherKey = "smartonfhir"
 
 func init() {
 	// Register FHIR client factory that can create FHIR clients when the SMART on FHIR AppLaunch is used
-	coolfhir.ClientFactories[fhirLauncherKey] = func(properties map[string]string) fhirclient.Client {
-		panic("TODO: create http.Client that adds the access token to the Authorization header")
+	clients.Factories[fhirLauncherKey] = func(properties map[string]string) clients.ClientProperties {
+		// TODO: create http.Client that adds the access token to the Authorization header
+		return clients.ClientProperties{
+			Client: http.DefaultTransport,
+		}
 	}
 }
 

--- a/orchestrator/careplancontributor/config.go
+++ b/orchestrator/careplancontributor/config.go
@@ -9,6 +9,9 @@ type Config struct {
 }
 
 func (c Config) Validate() error {
+	if !c.Enabled {
+		return nil
+	}
 	if c.CarePlanService.URL == "" {
 		return errors.New("careplancontributor.careplanservice.url is not configured")
 	}

--- a/orchestrator/careplancontributor/config.go
+++ b/orchestrator/careplancontributor/config.go
@@ -1,15 +1,25 @@
 package careplancontributor
 
+import "errors"
+
 type Config struct {
 	CarePlanService CarePlanServiceConfig `koanf:"careplanservice"`
 	FrontendConfig  FrontendConfig        `koanf:"frontend"`
 	Enabled         bool                  `koanf:"enabled"`
 }
 
+func (c Config) Validate() error {
+	if c.CarePlanService.URL == "" {
+		return errors.New("careplancontributor.careplanservice.url is not configured")
+	}
+	return nil
+}
+
 type CarePlanServiceConfig struct {
 	// URL is the base URL of the CarePlanService at which the CarePlanContributor creates/reads CarePlans.
 	URL string `koanf:"url"`
 }
+
 type FrontendConfig struct {
 	// URL is the base URL of the frontend for ORCA
 	URL string `koanf:"url"`

--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/SanteonNL/orca/orchestrator/applaunch/clients"
 	"net/http"
 	"net/url"
 	"time"
@@ -22,35 +23,39 @@ import (
 
 const LandingURL = "/contrib/"
 
-func New(config Config, sessionManager *user.SessionManager, didResolver addressing.StaticDIDResolver) (*Service, error) {
-	if config.CarePlanService.URL == "" {
-		return nil, errors.New("careplancontributor.careplanservice.url is not configured")
-	}
+func New(config Config, sessionManager *user.SessionManager, didResolver addressing.StaticDIDResolver) *Service {
 	cpsURL, _ := url.Parse(config.CarePlanService.URL)
 	// TODO: Replace with client doing authentication
 	carePlanServiceClient := fhirclient.New(cpsURL, http.DefaultClient, coolfhir.Config())
 	return &Service{
-		SessionManager:  sessionManager,
-		CarePlanService: carePlanServiceClient,
-		frontendUrl:     config.FrontendConfig.URL,
-	}, nil
+		carePlanServiceURL: cpsURL,
+		SessionManager:     sessionManager,
+		CarePlanService:    carePlanServiceClient,
+		frontendUrl:        config.FrontendConfig.URL,
+	}
 }
 
 type Service struct {
-	SessionManager  *user.SessionManager
-	CarePlanService fhirclient.Client
-	frontendUrl     string
+	SessionManager     *user.SessionManager
+	CarePlanService    fhirclient.Client
+	frontendUrl        string
+	carePlanServiceURL *url.URL
 }
 
 func (s Service) RegisterHandlers(mux *http.ServeMux) {
-	mux.HandleFunc("/contrib/", func(response http.ResponseWriter, request *http.Request) {
-		log.Info().Msgf("Redirecting to %s", s.frontendUrl)
-		http.Redirect(response, request, s.frontendUrl, http.StatusFound)
-	})
 	mux.HandleFunc("GET /contrib/patient", s.withSession(s.handleGetPatient))
 	mux.HandleFunc("GET /contrib/practitioner", s.withSession(s.handleGetPractitioner))
 	mux.HandleFunc("GET /contrib/serviceRequest", s.withSession(s.handleGetServiceRequest))
 	mux.HandleFunc("POST /contrib/confirm", s.withSession(s.handleConfirm))
+	mux.HandleFunc("/contrib/ehr/fhir/*", s.withSession(s.handleProxyToEPD))
+	carePlanServiceProxy := coolfhir.NewProxy(log.Logger, s.carePlanServiceURL, "/contrib/cps/fhir", http.DefaultTransport)
+	mux.HandleFunc("/contrib/cps/fhir/*", s.withSession(func(writer http.ResponseWriter, request *http.Request, _ *user.SessionData) {
+		carePlanServiceProxy.ServeHTTP(writer, request)
+	}))
+	mux.HandleFunc("/contrib/", func(response http.ResponseWriter, request *http.Request) {
+		log.Info().Msgf("Redirecting to %s", s.frontendUrl)
+		http.Redirect(response, request, s.frontendUrl, http.StatusFound)
+	})
 }
 
 // withSession is a middleware that retrieves the session for the given request.
@@ -67,9 +72,18 @@ func (s Service) withSession(next func(response http.ResponseWriter, request *ht
 	}
 }
 
+func (s Service) handleProxyToEPD(writer http.ResponseWriter, request *http.Request, session *user.SessionData) {
+	clientFactory := clients.Factories[session.FHIRLauncher](session.Values)
+	proxy := coolfhir.NewProxy(log.Logger, clientFactory.BaseURL, "/contrib/ehr/fhir", clientFactory.Client)
+	proxy.ServeHTTP(writer, request)
+}
+
 // handleGetPatient is the REST API handler that returns the FHIR Patient.
 func (s Service) handleGetPatient(response http.ResponseWriter, request *http.Request, session *user.SessionData) {
-	fhirClient := coolfhir.ClientFactories[session.FHIRLauncher](session.Values)
+	// TODO: Remove this when frontend works on the proxy endpoint
+	clientProperties := clients.Factories[session.FHIRLauncher](session.Values)
+	fhirClient := fhirclient.New(clientProperties.BaseURL, &http.Client{Transport: clientProperties.Client}, coolfhir.Config())
+
 	var patient fhir.Patient
 	if err := fhirClient.Read(session.Values["patient"], &patient); err != nil {
 		http.Error(response, err.Error(), http.StatusInternalServerError)
@@ -83,7 +97,9 @@ func (s Service) handleGetPatient(response http.ResponseWriter, request *http.Re
 
 // handleGetPractitioner is the REST API handler that returns the FHIR Practitioner.
 func (s Service) handleGetPractitioner(response http.ResponseWriter, request *http.Request, session *user.SessionData) {
-	fhirClient := coolfhir.ClientFactories[session.FHIRLauncher](session.Values)
+	// TODO: Remove this when frontend works on the proxy endpoint
+	clientProperties := clients.Factories[session.FHIRLauncher](session.Values)
+	fhirClient := fhirclient.New(clientProperties.BaseURL, &http.Client{Transport: clientProperties.Client}, coolfhir.Config())
 	var practitioner fhir.Practitioner
 	if err := fhirClient.Read(session.Values["practitioner"], &practitioner); err != nil {
 		http.Error(response, err.Error(), http.StatusInternalServerError)
@@ -97,7 +113,9 @@ func (s Service) handleGetPractitioner(response http.ResponseWriter, request *ht
 
 // handleGetServiceRequest is the REST API handler that returns the FHIR ServiceRequest.
 func (s Service) handleGetServiceRequest(response http.ResponseWriter, request *http.Request, session *user.SessionData) {
-	fhirClient := coolfhir.ClientFactories[session.FHIRLauncher](session.Values)
+	// TODO: Remove this when frontend works on the proxy endpoint
+	clientProperties := clients.Factories[session.FHIRLauncher](session.Values)
+	fhirClient := fhirclient.New(clientProperties.BaseURL, &http.Client{Transport: clientProperties.Client}, coolfhir.Config())
 	var serviceRequest fhir.ServiceRequest
 	if err := fhirClient.Read(session.Values["serviceRequest"], &serviceRequest); err != nil {
 		http.Error(response, err.Error(), http.StatusInternalServerError)
@@ -112,7 +130,9 @@ func (s Service) handleGetServiceRequest(response http.ResponseWriter, request *
 // handleConfirm is the REST API handler that handles workflow invocation confirmation,
 // and initiates the workflow.
 func (s Service) handleConfirm(response http.ResponseWriter, request *http.Request, session *user.SessionData) {
-	fhirClient := coolfhir.ClientFactories[session.FHIRLauncher](session.Values)
+	// TODO: Remove this when frontend works on the proxy endpoint
+	clientProperties := clients.Factories[session.FHIRLauncher](session.Values)
+	fhirClient := fhirclient.New(clientProperties.BaseURL, &http.Client{Transport: clientProperties.Client}, coolfhir.Config())
 	err := s.confirm(fhirClient, session.Values["serviceRequest"], session.Values["patient"])
 	if err != nil {
 		http.Error(response, err.Error(), http.StatusInternalServerError)

--- a/orchestrator/careplancontributor/service_test.go
+++ b/orchestrator/careplancontributor/service_test.go
@@ -2,6 +2,7 @@ package careplancontributor
 
 import (
 	"encoding/json"
+	"github.com/SanteonNL/orca/orchestrator/applaunch/clients"
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
 	"github.com/SanteonNL/orca/orchestrator/lib/to"
 	"io"
@@ -28,6 +29,87 @@ func init() {
 	if serviceRequestBundleJSON, err = os.ReadFile("test/servicerequest-bundle.json"); err != nil {
 		panic(err)
 	}
+}
+
+func TestService_ProxyToEHR(t *testing.T) {
+	// Test that the service registers the EHR FHIR proxy URL that proxies to the backing FHIR server of the EHR
+	// Setup: configure backing EHR FHIR server to which the service proxies
+	fhirServerMux := http.NewServeMux()
+	capturedHost := ""
+	fhirServerMux.HandleFunc("GET /fhir/Patient", func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+		capturedHost = request.Host
+	})
+	fhirServer := httptest.NewServer(fhirServerMux)
+	fhirServerURL, _ := url.Parse(fhirServer.URL)
+	fhirServerURL.Path = "/fhir"
+	// Setup: create the service
+
+	clients.Factories["test"] = func(properties map[string]string) clients.ClientProperties {
+		return clients.ClientProperties{
+			Client:  fhirServer.Client().Transport,
+			BaseURL: fhirServerURL,
+		}
+	}
+	sessionManager, sessionID := createTestSession()
+
+	service := New(Config{}, sessionManager, nil)
+	// Setup: configure the service to proxy to the backing FHIR server
+	frontServerMux := http.NewServeMux()
+	service.RegisterHandlers(frontServerMux)
+	frontServer := httptest.NewServer(frontServerMux)
+
+	httpRequest, _ := http.NewRequest("GET", frontServer.URL+"/contrib/ehr/fhir/Patient", nil)
+	httpRequest.AddCookie(&http.Cookie{
+		Name:  "sid",
+		Value: sessionID,
+	})
+	httpResponse, err := frontServer.Client().Do(httpRequest)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, httpResponse.StatusCode)
+	require.Equal(t, fhirServerURL.Host, capturedHost)
+}
+
+func TestService_ProxyToCPS(t *testing.T) {
+	// Test that the service registers the CarePlanService FHIR proxy URL that proxies to the CarePlanService
+	// Setup: configure CarePlanService to which the service proxies
+	carePlanServiceMux := http.NewServeMux()
+	capturedHost := ""
+	carePlanServiceMux.HandleFunc("GET /fhir/Patient", func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+		capturedHost = request.Host
+	})
+	carePlanService := httptest.NewServer(carePlanServiceMux)
+	carePlanServiceURL, _ := url.Parse(carePlanService.URL)
+	carePlanServiceURL.Path = "/fhir"
+
+	clients.Factories["test"] = func(properties map[string]string) clients.ClientProperties {
+		return clients.ClientProperties{
+			Client:  carePlanService.Client().Transport,
+			BaseURL: carePlanServiceURL,
+		}
+	}
+	sessionManager, sessionID := createTestSession()
+
+	service := New(Config{
+		CarePlanService: CarePlanServiceConfig{
+			URL: carePlanServiceURL.String(),
+		},
+	}, sessionManager, nil)
+	// Setup: configure the service to proxy to the upstream CarePlanService
+	frontServerMux := http.NewServeMux()
+	service.RegisterHandlers(frontServerMux)
+	frontServer := httptest.NewServer(frontServerMux)
+
+	httpRequest, _ := http.NewRequest("GET", frontServer.URL+"/contrib/cps/fhir/Patient", nil)
+	httpRequest.AddCookie(&http.Cookie{
+		Name:  "sid",
+		Value: sessionID,
+	})
+	httpResponse, err := frontServer.Client().Do(httpRequest)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, httpResponse.StatusCode)
+	require.Equal(t, carePlanServiceURL.Host, capturedHost)
 }
 
 func TestService_confirm(t *testing.T) {
@@ -182,4 +264,17 @@ func Test_shouldStopPollingOnAccepted(t *testing.T) {
 
 	err := service.pollTaskStatus(taskID)
 	assert.NoError(t, err)
+}
+
+func createTestSession() (*user.SessionManager, string) {
+	sessionManager := user.NewSessionManager()
+	sessionHttpResponse := httptest.NewRecorder()
+	sessionManager.Create(sessionHttpResponse, user.SessionData{
+		FHIRLauncher: "test",
+	})
+	// extract session ID; sid=<something>;
+	cookieValue := sessionHttpResponse.Header().Get("Set-Cookie")
+	cookieValue = strings.Split(cookieValue, ";")[0]
+	cookieValue = strings.Split(cookieValue, "=")[1]
+	return sessionManager, cookieValue
 }

--- a/orchestrator/careplancontributor/service_test.go
+++ b/orchestrator/careplancontributor/service_test.go
@@ -152,6 +152,24 @@ func TestService_confirm(t *testing.T) {
 	})
 }
 
+func TestService_handleGetContext(t *testing.T) {
+	httpResponse := httptest.NewRecorder()
+	Service{}.handleGetContext(httpResponse, nil, &user.SessionData{
+		Values: map[string]string{
+			"test":           "value",
+			"practitioner":   "the-doctor",
+			"serviceRequest": "ServiceRequest/1",
+			"patient":        "Patient/1",
+		},
+	})
+	assert.Equal(t, http.StatusOK, httpResponse.Code)
+	assert.JSONEq(t, `{
+		"practitioner": "the-doctor",
+		"serviceRequest": "ServiceRequest/1",	
+		"patient": "Patient/1"
+	}`, httpResponse.Body.String())
+}
+
 func startLocalFHIRServer(t *testing.T) fhirclient.Client {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /ServiceRequest", func(w http.ResponseWriter, r *http.Request) {

--- a/orchestrator/cmd/config.go
+++ b/orchestrator/cmd/config.go
@@ -23,6 +23,13 @@ type Config struct {
 	AppLaunch       applaunch.Config       `koanf:"applaunch"`
 }
 
+func (c Config) Validate() error {
+	if err := c.CarePlanContributor.Validate(); err != nil {
+		return err
+	}
+	return nil
+}
+
 // InterfaceConfig holds the configuration for an HTTP interface.
 type InterfaceConfig struct {
 	// Address holds the address to listen on.

--- a/orchestrator/cmd/server.go
+++ b/orchestrator/cmd/server.go
@@ -13,6 +13,10 @@ import (
 )
 
 func Start(config Config) error {
+	if config.Validate() != nil {
+		return fmt.Errorf("invalid configuration: %w", config.Validate())
+	}
+
 	// Set up dependencies
 	httpHandler := http.NewServeMux()
 	didResolver := addressing.StaticDIDResolver(map[string]string{})
@@ -21,10 +25,7 @@ func Start(config Config) error {
 	// Register services
 	var services []Service
 	if config.CarePlanContributor.Enabled {
-		carePlanContributor, err := careplancontributor.New(config.CarePlanContributor, sessionManager, didResolver)
-		if err != nil {
-			return fmt.Errorf("failed to create CarePlanContributor: %w", err)
-		}
+		carePlanContributor := careplancontributor.New(config.CarePlanContributor, sessionManager, didResolver)
 		services = append(services, carePlanContributor)
 		// App Launches
 		services = append(services, smartonfhir.New(config.AppLaunch.SmartOnFhir, sessionManager))

--- a/orchestrator/lib/coolfhir/client.go
+++ b/orchestrator/lib/coolfhir/client.go
@@ -6,10 +6,6 @@ import (
 	"net/http"
 )
 
-type ClientCreator func(properties map[string]string) fhirclient.Client
-
-var ClientFactories = map[string]ClientCreator{}
-
 func Config() *fhirclient.Config {
 	config := fhirclient.DefaultConfig()
 	config.Non2xxStatusHandler = func(response *http.Response, responseBody []byte) {

--- a/orchestrator/lib/coolfhir/proxy.go
+++ b/orchestrator/lib/coolfhir/proxy.go
@@ -1,5 +1,62 @@
 package coolfhir
 
+import (
+	"fmt"
+	"github.com/rs/zerolog"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+)
+
+func NewProxy(logger zerolog.Logger, targetFHIRBaseURL *url.URL, proxyBasePath string, transport http.RoundTripper) *httputil.ReverseProxy {
+	return &httputil.ReverseProxy{
+		Rewrite: func(r *httputil.ProxyRequest) {
+			r.Out.URL = targetFHIRBaseURL.JoinPath("/", strings.TrimPrefix(r.In.URL.Path, proxyBasePath))
+			r.Out.Host = targetFHIRBaseURL.Host
+		},
+		Transport: loggingRoundTripper{
+			next: transport,
+		},
+		ErrorHandler: func(writer http.ResponseWriter, request *http.Request, err error) {
+			logger.Warn().Err(err).Msgf("FHIR request failed (url=%s)", request.URL.String())
+			http.Error(writer, "FHIR request failed: "+err.Error(), http.StatusBadGateway)
+		},
+	}
+}
+
+var _ http.RoundTripper = &loggingRoundTripper{}
+
+type loggingRoundTripper struct {
+	logger zerolog.Logger
+	next   http.RoundTripper
+}
+
+func (l loggingRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	l.logger.Info().Msgf("Proxying FHIR request: %s %s", request.Method, request.URL.String())
+	if l.logger.Debug().Enabled() {
+		var headers []string
+		for key, values := range request.Header {
+			headers = append(headers, fmt.Sprintf("(%s: %s)", key, strings.Join(values, ", ")))
+		}
+		l.logger.Debug().Msgf("Proxy request headers: %s", strings.Join(headers, ", "))
+	}
+	response, err := l.next.RoundTrip(request)
+	if err != nil {
+		l.logger.Warn().Err(err).Msgf("Proxied FHIR request failed (url=%s)", request.URL.String())
+	} else {
+		if l.logger.Debug().Enabled() {
+			l.logger.Debug().Msgf("Proxied FHIR request response: %s", response.Status)
+			var headers []string
+			for key, values := range response.Header {
+				headers = append(headers, fmt.Sprintf("(%s: %s)", key, strings.Join(values, ", ")))
+			}
+			l.logger.Debug().Msgf("Proxy response headers: %s", strings.Join(headers, ", "))
+		}
+	}
+	return response, err
+}
+
 //func CreateProxy(fhirBaseURL *url.URL) {
 //	result := &httputil.ReverseProxy{
 //		Rewrite: func(r *httputil.ProxyRequest) {


### PR DESCRIPTION
That forward calls to CarePlanService and local EHR FHIR API.

For EHR: `/contrib/ehr/fhir`
For CPS: `/contrib/cps/fhir`

Proxy code did already exist for the CarePlanService, moved it to `lib` to be reusable, made authentication dependent on app launch.

Also introduces an endpoint for the frontend to retrieve the session data (launch context): `/contrib/context`.