### PR TITLE
INT-238: Implement state transition validation for Task update in CPS

### DIFF
--- a/orchestrator/careplanservice/handle_createtask.go
+++ b/orchestrator/careplanservice/handle_createtask.go
@@ -23,8 +23,6 @@ func (s *Service) handleCreateTask(httpResponse http.ResponseWriter, httpRequest
 		return fmt.Errorf("invalid Task: %w", err)
 	}
 	switch task["status"] {
-	case fhir.TaskStatusDraft.String():
-		task["status"] = fhir.TaskStatusRequested.String()
 	case fhir.TaskStatusRequested.String():
 	case fhir.TaskStatusReady.String():
 	default:

--- a/orchestrator/careplanservice/handle_createtask.go
+++ b/orchestrator/careplanservice/handle_createtask.go
@@ -28,7 +28,7 @@ func (s *Service) handleCreateTask(httpResponse http.ResponseWriter, httpRequest
 	case fhir.TaskStatusRequested.String():
 	case fhir.TaskStatusReady.String():
 	default:
-		return errors.New(fmt.Sprintf("cannot create task with status %s, must be %s or %s", task["status"], fhir.TaskStatusRequested.String(), fhir.TaskStatusReady.String()))
+		return errors.New(fmt.Sprintf("cannot create Task with status %s, must be %s or %s", task["status"], fhir.TaskStatusRequested.String(), fhir.TaskStatusReady.String()))
 	}
 	// Resolve the CarePlan
 	carePlanRef, err := basedOn(task)

--- a/orchestrator/careplanservice/handle_createtask.go
+++ b/orchestrator/careplanservice/handle_createtask.go
@@ -22,6 +22,14 @@ func (s *Service) handleCreateTask(httpResponse http.ResponseWriter, httpRequest
 	if err := s.readRequest(httpRequest, &task); err != nil {
 		return fmt.Errorf("invalid Task: %w", err)
 	}
+	switch task["status"] {
+	case fhir.TaskStatusDraft.String():
+		task["status"] = fhir.TaskStatusRequested.String()
+	case fhir.TaskStatusRequested.String():
+	case fhir.TaskStatusReady.String():
+	default:
+		return errors.New(fmt.Sprintf("cannot create task with status %s, must be %s or %s", task["status"], fhir.TaskStatusRequested.String(), fhir.TaskStatusReady.String()))
+	}
 	// Resolve the CarePlan
 	carePlanRef, err := basedOn(task)
 	if err != nil {

--- a/orchestrator/careplanservice/handle_updatetask_test.go
+++ b/orchestrator/careplanservice/handle_updatetask_test.go
@@ -1,0 +1,387 @@
+package careplanservice
+
+import (
+	"testing"
+
+	"github.com/samply/golang-fhir-models/fhir-models/fhir"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_isValidTransition(t *testing.T) {
+	type args struct {
+		from        fhir.TaskStatus
+		to          fhir.TaskStatus
+		isOwner     bool
+		isRequester bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		// Positive cases
+		{
+			name: "requested -> received : owner (OK)",
+			args: args{
+				from:        fhir.TaskStatusRequested,
+				to:          fhir.TaskStatusReceived,
+				isOwner:     true,
+				isRequester: false,
+			},
+			want: true,
+		},
+		{
+			name: "requested -> accepted : owner (OK)",
+			args: args{
+				from:        fhir.TaskStatusRequested,
+				to:          fhir.TaskStatusAccepted,
+				isOwner:     true,
+				isRequester: false,
+			},
+			want: true,
+		},
+		{
+			name: "requested -> rejected : owner (OK)",
+			args: args{
+				from:        fhir.TaskStatusRequested,
+				to:          fhir.TaskStatusRejected,
+				isOwner:     true,
+				isRequester: false,
+			},
+			want: true,
+		},
+		{
+			name: "requested -> cancelled : owner (OK)",
+			args: args{
+				from:        fhir.TaskStatusRequested,
+				to:          fhir.TaskStatusCancelled,
+				isOwner:     true,
+				isRequester: false,
+			},
+			want: true,
+		},
+		{
+			name: "requested -> cancelled : requester (OK)",
+			args: args{
+				from:        fhir.TaskStatusRequested,
+				to:          fhir.TaskStatusCancelled,
+				isOwner:     false,
+				isRequester: true,
+			},
+			want: true,
+		},
+		{
+			name: "requested -> cancelled : owner & requester (OK)",
+			args: args{
+				from:        fhir.TaskStatusRequested,
+				to:          fhir.TaskStatusCancelled,
+				isOwner:     true,
+				isRequester: true,
+			},
+			want: true,
+		},
+		{
+			name: "received -> accepted : owner (OK)",
+			args: args{
+				from:        fhir.TaskStatusReceived,
+				to:          fhir.TaskStatusAccepted,
+				isOwner:     true,
+				isRequester: false,
+			},
+			want: true,
+		},
+		{
+			name: "received -> rejected : owner (OK)",
+			args: args{
+				from:        fhir.TaskStatusReceived,
+				to:          fhir.TaskStatusRejected,
+				isOwner:     true,
+				isRequester: false,
+			},
+			want: true,
+		},
+		{
+			name: "received -> cancelled : owner (OK)",
+			args: args{
+				from:        fhir.TaskStatusReceived,
+				to:          fhir.TaskStatusCancelled,
+				isOwner:     true,
+				isRequester: false,
+			},
+			want: true,
+		},
+		{
+			name: "received -> cancelled : requester (OK)",
+			args: args{
+				from:        fhir.TaskStatusReceived,
+				to:          fhir.TaskStatusCancelled,
+				isOwner:     false,
+				isRequester: true,
+			},
+			want: true,
+		},
+		{
+			name: "received -> cancelled : owner & requester (OK)",
+			args: args{
+				from:        fhir.TaskStatusReceived,
+				to:          fhir.TaskStatusCancelled,
+				isOwner:     true,
+				isRequester: true,
+			},
+			want: true,
+		},
+		{
+			name: "accepted -> in-progress : owner (OK)",
+			args: args{
+				from:        fhir.TaskStatusAccepted,
+				to:          fhir.TaskStatusInProgress,
+				isOwner:     true,
+				isRequester: false,
+			},
+			want: true,
+		},
+		{
+			name: "accepted -> cancelled : owner (OK)",
+			args: args{
+				from:        fhir.TaskStatusAccepted,
+				to:          fhir.TaskStatusCancelled,
+				isOwner:     true,
+				isRequester: false,
+			},
+			want: true,
+		},
+		{
+			name: "accepted -> cancelled : requester (OK)",
+			args: args{
+				from:        fhir.TaskStatusAccepted,
+				to:          fhir.TaskStatusCancelled,
+				isOwner:     false,
+				isRequester: true,
+			},
+			want: true,
+		},
+		{
+			name: "accepted -> cancelled : owner & requester (OK)",
+			args: args{
+				from:        fhir.TaskStatusAccepted,
+				to:          fhir.TaskStatusCancelled,
+				isOwner:     true,
+				isRequester: true,
+			},
+			want: true,
+		},
+		{
+			name: "in-progress -> completed : owner (OK)",
+			args: args{
+				from:        fhir.TaskStatusInProgress,
+				to:          fhir.TaskStatusCompleted,
+				isOwner:     true,
+				isRequester: false,
+			},
+			want: true,
+		},
+		{
+			name: "in-progress -> failed : owner (OK)",
+			args: args{
+				from:        fhir.TaskStatusInProgress,
+				to:          fhir.TaskStatusFailed,
+				isOwner:     true,
+				isRequester: false,
+			},
+			want: true,
+		},
+		{
+			name: "in-progress -> on-hold : owner (OK)",
+			args: args{
+				from:        fhir.TaskStatusInProgress,
+				to:          fhir.TaskStatusOnHold,
+				isOwner:     true,
+				isRequester: false,
+			},
+			want: true,
+		},
+		{
+			name: "in-progress -> on-hold : requester (OK)",
+			args: args{
+				from:        fhir.TaskStatusInProgress,
+				to:          fhir.TaskStatusOnHold,
+				isOwner:     false,
+				isRequester: true,
+			},
+			want: true,
+		},
+		{
+			name: "in-progress -> on-hold : owner & requester (OK)",
+			args: args{
+				from:        fhir.TaskStatusInProgress,
+				to:          fhir.TaskStatusOnHold,
+				isOwner:     true,
+				isRequester: true,
+			},
+			want: true,
+		},
+		{
+			name: "on-hold -> in-progress : owner (OK)",
+			args: args{
+				from:        fhir.TaskStatusOnHold,
+				to:          fhir.TaskStatusInProgress,
+				isOwner:     true,
+				isRequester: false,
+			},
+			want: true,
+		},
+		{
+			name: "on-hold -> in-progress : requester (OK)",
+			args: args{
+				from:        fhir.TaskStatusOnHold,
+				to:          fhir.TaskStatusInProgress,
+				isOwner:     false,
+				isRequester: true,
+			},
+			want: true,
+		},
+		{
+			name: "on-hold -> in-progress : owner & requester (OK)",
+			args: args{
+				from:        fhir.TaskStatusOnHold,
+				to:          fhir.TaskStatusInProgress,
+				isOwner:     true,
+				isRequester: true,
+			},
+			want: true,
+		},
+		{
+			name: "ready -> completed : owner (OK)",
+			args: args{
+				from:        fhir.TaskStatusReady,
+				to:          fhir.TaskStatusCompleted,
+				isOwner:     true,
+				isRequester: false,
+			},
+			want: true,
+		},
+		{
+			name: "ready -> failed : owner (OK)",
+			args: args{
+				from:        fhir.TaskStatusReady,
+				to:          fhir.TaskStatusFailed,
+				isOwner:     true,
+				isRequester: false,
+			},
+			want: true,
+		},
+		// Negative cases -> Invalid requester/owner
+		{
+			name: "requested -> received : requester (FAIL)",
+			args: args{
+				from:        fhir.TaskStatusRequested,
+				to:          fhir.TaskStatusReceived,
+				isOwner:     false,
+				isRequester: true,
+			},
+			want: false,
+		},
+		{
+			name: "requested -> accepted : requester (FAIL)",
+			args: args{
+				from:        fhir.TaskStatusRequested,
+				to:          fhir.TaskStatusAccepted,
+				isOwner:     false,
+				isRequester: true,
+			},
+			want: false,
+		},
+		{
+			name: "requested -> rejected : requester (FAIL)",
+			args: args{
+				from:        fhir.TaskStatusRequested,
+				to:          fhir.TaskStatusRejected,
+				isOwner:     false,
+				isRequester: true,
+			},
+			want: false,
+		},
+		{
+			name: "received -> accepted : requester (FAIL)",
+			args: args{
+				from:        fhir.TaskStatusReceived,
+				to:          fhir.TaskStatusAccepted,
+				isOwner:     false,
+				isRequester: true,
+			},
+			want: false,
+		},
+		{
+			name: "received -> rejected : requester (FAIL)",
+			args: args{
+				from:        fhir.TaskStatusReceived,
+				to:          fhir.TaskStatusRejected,
+				isOwner:     false,
+				isRequester: true,
+			},
+			want: false,
+		},
+		{
+			name: "accepted -> in-progress : requester (FAIL)",
+			args: args{
+				from:        fhir.TaskStatusAccepted,
+				to:          fhir.TaskStatusInProgress,
+				isOwner:     false,
+				isRequester: true,
+			},
+			want: false,
+		},
+		{
+			name: "in-progress -> completed : requester (FAIL)",
+			args: args{
+				from:        fhir.TaskStatusInProgress,
+				to:          fhir.TaskStatusCompleted,
+				isOwner:     false,
+				isRequester: true,
+			},
+			want: false,
+		},
+		{
+			name: "in-progress -> failed : requester (FAIL)",
+			args: args{
+				from:        fhir.TaskStatusInProgress,
+				to:          fhir.TaskStatusFailed,
+				isOwner:     false,
+				isRequester: true,
+			},
+			want: false,
+		},
+		{
+			name: "ready -> completed : requester (FAIL)",
+			args: args{
+				from:        fhir.TaskStatusReady,
+				to:          fhir.TaskStatusCompleted,
+				isOwner:     false,
+				isRequester: true,
+			},
+			want: false,
+		},
+		{
+			name: "ready -> failed : owner (OK)",
+			args: args{
+				from:        fhir.TaskStatusReady,
+				to:          fhir.TaskStatusFailed,
+				isOwner:     false,
+				isRequester: true,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isValidTransition(tt.args.from, tt.args.to, tt.args.isOwner, tt.args.isRequester)
+			require.Equal(t, tt.want, got)
+			// Validate that the opposite direction fails, besides in-progress <-> on-hold
+			if (tt.args.from == fhir.TaskStatusOnHold && tt.args.to == fhir.TaskStatusInProgress) || (tt.args.from == fhir.TaskStatusInProgress && tt.args.to == fhir.TaskStatusOnHold) {
+				return
+			}
+			got = isValidTransition(tt.args.to, tt.args.from, tt.args.isOwner, tt.args.isRequester)
+			require.Equal(t, false, got)
+		})
+	}
+}

--- a/orchestrator/careplanservice/integration_test.go
+++ b/orchestrator/careplanservice/integration_test.go
@@ -66,7 +66,7 @@ func Test_Integration_TaskLifecycle(t *testing.T) {
 		require.NotNil(t, createdCareTeams[0].Id)
 	}
 
-	t.Log("Creating Task - Invalid status")
+	t.Log("Creating Task - Invalid status Accepted")
 	{
 		task = fhir.Task{
 			BasedOn: []fhir.Reference{
@@ -76,6 +76,24 @@ func Test_Integration_TaskLifecycle(t *testing.T) {
 				},
 			},
 			Status:    fhir.TaskStatusAccepted,
+			Requester: coolfhir.LogicalReference("Organization", coolfhir.URANamingSystem, "1"),
+			Owner:     coolfhir.LogicalReference("Organization", coolfhir.URANamingSystem, "2"),
+		}
+
+		err := carePlanContributor1.Create(task, &task)
+		require.Error(t, err)
+	}
+
+	t.Log("Creating Task - Invalid status Draft")
+	{
+		task = fhir.Task{
+			BasedOn: []fhir.Reference{
+				{
+					Type:      to.Ptr("CarePlan"),
+					Reference: to.Ptr("CarePlan/" + *carePlan.Id),
+				},
+			},
+			Status:    fhir.TaskStatusDraft,
 			Requester: coolfhir.LogicalReference("Organization", coolfhir.URANamingSystem, "1"),
 			Owner:     coolfhir.LogicalReference("Organization", coolfhir.URANamingSystem, "2"),
 		}

--- a/orchestrator/careplanservice/integration_test.go
+++ b/orchestrator/careplanservice/integration_test.go
@@ -19,12 +19,13 @@ import (
 	"testing"
 )
 
+// TODO: Set up 2 FHIR clients
 func Test_Integration_TaskLifecycle(t *testing.T) {
 	// Note: this test consists of multiple steps that look like subtests, but they can't be subtests:
 	//       in Golang, running a single Subtest causes the other tests not to run.
 	//       This causes issues, since each test step (e.g. accepting Task) requires the previous step (test) to succeed (e.g. creating Task).
 	t.Log("This test requires creates a new CarePlan and Task, then runs the Task through requested->accepted->completed lifecycle.")
-	carePlanContributor := setupIntegrationTest(t)
+	carePlanContributor1, carePlanContributor2 := setupIntegrationTest(t)
 
 	participant1 := fhir.CareTeamParticipant{
 		OnBehalfOf: coolfhir.LogicalReference("Organization", coolfhir.URANamingSystem, "1"),
@@ -53,13 +54,13 @@ func Test_Integration_TaskLifecycle(t *testing.T) {
 				Value:  to.Ptr("123456789"),
 			},
 		}
-		err := carePlanContributor.Create(carePlan, &carePlan)
+		err := carePlanContributor1.Create(carePlan, &carePlan)
 		require.NoError(t, err)
 
 		// Check the CarePlan and CareTeam exist
 		var createdCarePlan fhir.CarePlan
 		var createdCareTeams []fhir.CareTeam
-		err = carePlanContributor.Read("CarePlan/"+*carePlan.Id, &createdCarePlan, fhirclient.ResolveRef("careTeam", &createdCareTeams))
+		err = carePlanContributor1.Read("CarePlan/"+*carePlan.Id, &createdCarePlan, fhirclient.ResolveRef("careTeam", &createdCareTeams))
 		require.NoError(t, err)
 		require.NotNil(t, createdCarePlan.Id)
 		require.Len(t, createdCareTeams, 1, "expected 1 CareTeam")
@@ -80,7 +81,7 @@ func Test_Integration_TaskLifecycle(t *testing.T) {
 			Owner:     coolfhir.LogicalReference("Organization", coolfhir.URANamingSystem, "2"),
 		}
 
-		err := carePlanContributor.Create(task, &task)
+		err := carePlanContributor1.Create(task, &task)
 		require.Error(t, err)
 	}
 
@@ -98,9 +99,9 @@ func Test_Integration_TaskLifecycle(t *testing.T) {
 			Owner:     coolfhir.LogicalReference("Organization", coolfhir.URANamingSystem, "2"),
 		}
 
-		err := carePlanContributor.Create(task, &task)
+		err := carePlanContributor1.Create(task, &task)
 		require.NoError(t, err)
-		err = carePlanContributor.Read("CarePlan/"+*carePlan.Id, &carePlan)
+		err = carePlanContributor1.Read("CarePlan/"+*carePlan.Id, &carePlan)
 		require.NoError(t, err)
 
 		t.Run("Check Task properties", func(t *testing.T) {
@@ -113,7 +114,7 @@ func Test_Integration_TaskLifecycle(t *testing.T) {
 			require.Equal(t, "Task/"+*task.Id, *carePlan.Activity[0].Reference.Reference)
 		})
 		t.Run("Check that CareTeam now contains the requesting party", func(t *testing.T) {
-			assertCareTeam(t, carePlanContributor, *carePlan.CareTeam[0].Reference, participant1)
+			assertCareTeam(t, carePlanContributor1, *carePlan.CareTeam[0].Reference, participant1)
 		})
 	}
 
@@ -121,7 +122,7 @@ func Test_Integration_TaskLifecycle(t *testing.T) {
 	{
 		task.Status = fhir.TaskStatusAccepted
 		var updatedTask fhir.Task
-		err := carePlanContributor.Update("Task/"+*task.Id, task, &updatedTask)
+		err := carePlanContributor2.Update("Task/"+*task.Id, task, &updatedTask)
 		require.NoError(t, err)
 		task = updatedTask
 
@@ -130,7 +131,7 @@ func Test_Integration_TaskLifecycle(t *testing.T) {
 			require.Equal(t, fhir.TaskStatusAccepted, updatedTask.Status)
 		})
 		t.Run("Check that CareTeam now contains the 2 parties", func(t *testing.T) {
-			assertCareTeam(t, carePlanContributor, *carePlan.CareTeam[0].Reference, participant1, participant2)
+			assertCareTeam(t, carePlanContributor2, *carePlan.CareTeam[0].Reference, participant1, participant2)
 		})
 	}
 
@@ -138,7 +139,7 @@ func Test_Integration_TaskLifecycle(t *testing.T) {
 	{
 		task.Status = fhir.TaskStatusCompleted
 		var updatedTask fhir.Task
-		err := carePlanContributor.Update("Task/"+*task.Id, task, &updatedTask)
+		err := carePlanContributor1.Update("Task/"+*task.Id, task, &updatedTask)
 		require.Error(t, err)
 	}
 
@@ -146,7 +147,7 @@ func Test_Integration_TaskLifecycle(t *testing.T) {
 	{
 		task.Status = fhir.TaskStatusInProgress
 		var updatedTask fhir.Task
-		err := carePlanContributor.Update("Task/"+*task.Id, task, &updatedTask)
+		err := carePlanContributor2.Update("Task/"+*task.Id, task, &updatedTask)
 		require.NoError(t, err)
 		task = updatedTask
 
@@ -155,7 +156,7 @@ func Test_Integration_TaskLifecycle(t *testing.T) {
 			require.Equal(t, fhir.TaskStatusInProgress, updatedTask.Status)
 		})
 		t.Run("Check that CareTeam still contains the 2 parties", func(t *testing.T) {
-			assertCareTeam(t, carePlanContributor, *carePlan.CareTeam[0].Reference, participant1, participant2)
+			assertCareTeam(t, carePlanContributor2, *carePlan.CareTeam[0].Reference, participant1, participant2)
 		})
 	}
 
@@ -163,7 +164,7 @@ func Test_Integration_TaskLifecycle(t *testing.T) {
 	{
 		task.Status = fhir.TaskStatusCompleted
 		var updatedTask fhir.Task
-		err := carePlanContributor.Update("Task/"+*task.Id, task, &updatedTask)
+		err := carePlanContributor1.Update("Task/"+*task.Id, task, &updatedTask)
 		require.NoError(t, err)
 		task = updatedTask
 
@@ -172,11 +173,11 @@ func Test_Integration_TaskLifecycle(t *testing.T) {
 			require.Equal(t, fhir.TaskStatusCompleted, updatedTask.Status)
 		})
 		t.Run("Check that CareTeam now contains the 2 parties", func(t *testing.T) {
-			assertCareTeam(t, carePlanContributor, *carePlan.CareTeam[0].Reference, participant1, participant2WithEndDate)
+			assertCareTeam(t, carePlanContributor1, *carePlan.CareTeam[0].Reference, participant1, participant2WithEndDate)
 		})
 	}
 }
-func setupIntegrationTest(t *testing.T) *fhirclient.BaseClient {
+func setupIntegrationTest(t *testing.T) (*fhirclient.BaseClient, *fhirclient.BaseClient) {
 	fhirBaseURL := setupHAPI(t)
 	tokenIntrospectionEndpoint := setupAuthorizationServer(t)
 
@@ -191,11 +192,16 @@ func setupIntegrationTest(t *testing.T) *fhirclient.BaseClient {
 	service.RegisterHandlers(serverMux)
 
 	carePlanServiceURL, _ := url.Parse(httpService.URL + "/cps")
-	httpClient := httpService.Client()
-	httpClient.Transport = auth.AuthenticatedTestRoundTripper(httpService.Client().Transport)
 
-	carePlanContributor := fhirclient.New(carePlanServiceURL, httpClient, nil)
-	return carePlanContributor
+	httpClient1 := httpService.Client()
+	httpClient1.Transport = auth.AuthenticatedTestRoundTripper(httpService.Client().Transport, "1")
+
+	httpClient2 := httpService.Client()
+	httpClient2.Transport = auth.AuthenticatedTestRoundTripper(httpService.Client().Transport, "2")
+
+	carePlanContributor1 := fhirclient.New(carePlanServiceURL, httpClient1, nil)
+	carePlanContributor2 := fhirclient.New(carePlanServiceURL, httpClient2, nil)
+	return carePlanContributor1, carePlanContributor2
 }
 
 func assertCareTeam(t *testing.T, fhirClient fhirclient.Client, careTeamRef string, expectedMembers ...fhir.CareTeamParticipant) {
@@ -235,19 +241,36 @@ outer:
 func setupAuthorizationServer(t *testing.T) *url.URL {
 	authorizationServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 		requestData, _ := io.ReadAll(request.Body)
-		if string(requestData) != "token=valid" {
+		// TODO: Switch on orgs to set owner/requester (maybe use token as URA)
+		t.Log("REQUEST DATA: " + string(requestData))
+		switch string(requestData) {
+		case "token=valid":
+			fallthrough
+		case "token=1":
+			writer.Header().Set("Content-Type", "application/json")
+			responseData, _ := json.Marshal(map[string]interface{}{
+				"active":            true,
+				"organization_ura":  "1",
+				"organization_name": "Hospital",
+				"organization_city": "CareTown",
+			})
+			writer.WriteHeader(http.StatusOK)
+			_, _ = writer.Write(responseData)
+		case "token=2":
+			writer.Header().Set("Content-Type", "application/json")
+			responseData, _ := json.Marshal(map[string]interface{}{
+				"active":            true,
+				"organization_ura":  "2",
+				"organization_name": "Hospital",
+				"organization_city": "CareTown",
+			})
+			writer.WriteHeader(http.StatusOK)
+			_, _ = writer.Write(responseData)
+		default:
 			writer.WriteHeader(http.StatusUnauthorized)
 			return
 		}
-		writer.Header().Set("Content-Type", "application/json")
-		responseData, _ := json.Marshal(map[string]interface{}{
-			"active":            true,
-			"organization_ura":  "1234",
-			"organization_name": "Hospital",
-			"organization_city": "CareTown",
-		})
-		writer.WriteHeader(http.StatusOK)
-		_, _ = writer.Write(responseData)
+		// TODO: Hardcode 2 organisations, return depending on the token passed in
 	}))
 	t.Cleanup(func() {
 		authorizationServer.Close()

--- a/orchestrator/careplanservice/integration_test.go
+++ b/orchestrator/careplanservice/integration_test.go
@@ -164,7 +164,7 @@ func Test_Integration_TaskLifecycle(t *testing.T) {
 	{
 		task.Status = fhir.TaskStatusCompleted
 		var updatedTask fhir.Task
-		err := carePlanContributor1.Update("Task/"+*task.Id, task, &updatedTask)
+		err := carePlanContributor2.Update("Task/"+*task.Id, task, &updatedTask)
 		require.NoError(t, err)
 		task = updatedTask
 
@@ -193,14 +193,11 @@ func setupIntegrationTest(t *testing.T) (*fhirclient.BaseClient, *fhirclient.Bas
 
 	carePlanServiceURL, _ := url.Parse(httpService.URL + "/cps")
 
-	httpClient1 := httpService.Client()
-	httpClient1.Transport = auth.AuthenticatedTestRoundTripper(httpService.Client().Transport, "1")
+	transport1 := auth.AuthenticatedTestRoundTripper(httpService.Client().Transport, "1")
+	transport2 := auth.AuthenticatedTestRoundTripper(httpService.Client().Transport, "2")
 
-	httpClient2 := httpService.Client()
-	httpClient2.Transport = auth.AuthenticatedTestRoundTripper(httpService.Client().Transport, "2")
-
-	carePlanContributor1 := fhirclient.New(carePlanServiceURL, httpClient1, nil)
-	carePlanContributor2 := fhirclient.New(carePlanServiceURL, httpClient2, nil)
+	carePlanContributor1 := fhirclient.New(carePlanServiceURL, &http.Client{Transport: transport1}, nil)
+	carePlanContributor2 := fhirclient.New(carePlanServiceURL, &http.Client{Transport: transport2}, nil)
 	return carePlanContributor1, carePlanContributor2
 }
 

--- a/orchestrator/careplanservice/service.go
+++ b/orchestrator/careplanservice/service.go
@@ -95,7 +95,7 @@ func (s Service) RegisterHandlers(mux *http.ServeMux) {
 			return
 		}
 	}))
-	mux.HandleFunc("PUT /cps/Task/{id}", func(writer http.ResponseWriter, request *http.Request) {
+	mux.HandleFunc("PUT /cps/Task/{id}", auth.Middleware(authConfig, func(writer http.ResponseWriter, request *http.Request) {
 		err := s.handleUpdateTask(writer, request)
 		if err != nil {
 			// TODO: proper OperationOutcome
@@ -103,7 +103,7 @@ func (s Service) RegisterHandlers(mux *http.ServeMux) {
 			http.Error(writer, "Update Task at CarePlanService failed: "+err.Error(), http.StatusBadRequest)
 			return
 		}
-	})
+	}))
 	mux.HandleFunc("POST /cps/CarePlan", auth.Middleware(authConfig, func(writer http.ResponseWriter, request *http.Request) {
 		err := s.handleCreateCarePlan(writer, request)
 		if err != nil {

--- a/orchestrator/careplanservice/service_test.go
+++ b/orchestrator/careplanservice/service_test.go
@@ -38,7 +38,7 @@ func TestService_Proxy(t *testing.T) {
 	frontServer := httptest.NewServer(frontServerMux)
 
 	httpClient := frontServer.Client()
-	httpClient.Transport = auth.AuthenticatedTestRoundTripper(frontServer.Client().Transport)
+	httpClient.Transport = auth.AuthenticatedTestRoundTripper(frontServer.Client().Transport, "")
 
 	httpResponse, err := httpClient.Get(frontServer.URL + "/cps/Patient")
 	require.NoError(t, err)

--- a/orchestrator/lib/auth/auth.go
+++ b/orchestrator/lib/auth/auth.go
@@ -16,6 +16,8 @@ type principalContextKeyType struct{}
 
 var principalContextKey = principalContextKeyType{}
 
+var ErrNotAuthenticated = errors.New("not authenticated")
+
 // Middleware returns a http.HandlerFunc that retrieves the user info from the request header.
 // The user info is to be provided by an API Gateway/reverse proxy that validated the authentication token in the request.
 // It sets the decoded user info in the request context.
@@ -42,6 +44,15 @@ func Middleware(authConfig middleware.Config, fn http.HandlerFunc) func(writer h
 		newCtx := context.WithValue(request.Context(), principalContextKey, principal)
 		fn(response, request.WithContext(newCtx))
 	})
+}
+
+// PrincipalFromContext returns the principal from the request context.
+func PrincipalFromContext(ctx context.Context) (Principal, error) {
+	principal, ok := ctx.Value(principalContextKey).(Principal)
+	if !ok {
+		return Principal{}, ErrNotAuthenticated
+	}
+	return principal, nil
 }
 
 func claimsToOrganization(claims map[string]interface{}) (*fhir.Organization, error) {

--- a/orchestrator/lib/auth/test.go
+++ b/orchestrator/lib/auth/test.go
@@ -6,14 +6,18 @@ import (
 
 // AuthenticatedTestRoundTripper returns a RoundTripper that adds a X-Userinfo header to the request
 // with static user information. This is useful for testing purposes.
-func AuthenticatedTestRoundTripper(underlying http.RoundTripper) http.RoundTripper {
+func AuthenticatedTestRoundTripper(underlying http.RoundTripper, bearerToken string) http.RoundTripper {
 	if underlying == nil {
 		underlying = http.DefaultTransport
+	}
+
+	if bearerToken == "" {
+		bearerToken = "Bearer valid"
 	}
 	return headerDecoratorRoundTripper{
 		inner: underlying,
 		header: map[string]string{
-			"Authorization": "Bearer valid",
+			"Authorization": "Bearer " + bearerToken,
 		},
 	}
 }

--- a/orchestrator/lib/auth/test.go
+++ b/orchestrator/lib/auth/test.go
@@ -13,11 +13,13 @@ func AuthenticatedTestRoundTripper(underlying http.RoundTripper, bearerToken str
 
 	if bearerToken == "" {
 		bearerToken = "Bearer valid"
+	} else {
+		bearerToken = "Bearer " + bearerToken
 	}
 	return headerDecoratorRoundTripper{
 		inner: underlying,
 		header: map[string]string{
-			"Authorization": "Bearer " + bearerToken,
+			"Authorization": bearerToken,
 		},
 	}
 }

--- a/orchestrator/lib/coolfhir/util.go
+++ b/orchestrator/lib/coolfhir/util.go
@@ -68,6 +68,14 @@ func IsLogicalReference(reference *fhir.Reference) bool {
 	return reference != nil && reference.Type != nil && reference.Identifier != nil && reference.Identifier.System != nil && reference.Identifier.Value != nil
 }
 
+// LogicalReferenceEquals checks if two references are contain the same logical identifier, given their system and value.
+// It does not compare identifier type.
+func LogicalReferenceEquals(ref, other fhir.Reference) bool {
+	return ref.Identifier != nil && other.Identifier != nil &&
+		ref.Identifier.System != nil && other.Identifier.System != nil && *ref.Identifier.System == *other.Identifier.System &&
+		ref.Identifier.Value != nil && other.Identifier.Value != nil && *ref.Identifier.Value == *other.Identifier.Value
+}
+
 // IdentifierEquals compares two logical identifiers based on their system and value.
 // If any of the identifiers is nil or any of the system or value fields is nil, it returns false.
 // If the system and value fields of both identifiers are equal, it returns true.


### PR DESCRIPTION
When updating a task in CarePlanService there are only certain status transitions that are valid, otherwise return error.

Adds unit tests and updates integration test

To follow: Fetch owner and requester of task to validate that they are allowed to make the status change