### PR TITLE
INT-241: Add FHIR proxy for CPC to CPC calls

### DIFF
--- a/orchestrator/careplancontributor/config.go
+++ b/orchestrator/careplancontributor/config.go
@@ -6,10 +6,10 @@ import (
 )
 
 type Config struct {
-	CarePlanService CarePlanServiceConfig           `koanf:"careplanservice"`
-	FrontendConfig  FrontendConfig                  `koanf:"frontend"`
-	FHIR            coolfhir.FHIRRoundTripperConfig `koanf:"fhir"`
-	Enabled         bool                            `koanf:"enabled"`
+	CarePlanService CarePlanServiceConfig `koanf:"careplanservice"`
+	FrontendConfig  FrontendConfig        `koanf:"frontend"`
+	FHIR            coolfhir.ClientConfig `koanf:"fhir"`
+	Enabled         bool                  `koanf:"enabled"`
 }
 
 func (c Config) Validate() error {

--- a/orchestrator/careplancontributor/config.go
+++ b/orchestrator/careplancontributor/config.go
@@ -5,6 +5,7 @@ import "errors"
 type Config struct {
 	CarePlanService CarePlanServiceConfig `koanf:"careplanservice"`
 	FrontendConfig  FrontendConfig        `koanf:"frontend"`
+	FHIR            FHIRConfig            `koanf:"fhir"`
 	Enabled         bool                  `koanf:"enabled"`
 }
 
@@ -26,4 +27,17 @@ type CarePlanServiceConfig struct {
 type FrontendConfig struct {
 	// URL is the base URL of the frontend for ORCA
 	URL string `koanf:"url"`
+}
+
+type FHIRConfig struct {
+	// BaseURL is the base URL of the FHIR server to connect to.
+	BaseURL string `koanf:"url"`
+	// Auth is the authentication configuration for the FHIR server.
+	Auth FHIRAuthConfig `koanf:"auth"`
+}
+
+type FHIRAuthConfig struct {
+	// Type of authentication to use, supported options: azure-managedidentity.
+	// Leave empty for no authentication.
+	Type string `koanf:"type"`
 }

--- a/orchestrator/careplancontributor/config.go
+++ b/orchestrator/careplancontributor/config.go
@@ -1,12 +1,15 @@
 package careplancontributor
 
-import "errors"
+import (
+	"errors"
+	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
+)
 
 type Config struct {
-	CarePlanService CarePlanServiceConfig `koanf:"careplanservice"`
-	FrontendConfig  FrontendConfig        `koanf:"frontend"`
-	FHIR            FHIRConfig            `koanf:"fhir"`
-	Enabled         bool                  `koanf:"enabled"`
+	CarePlanService CarePlanServiceConfig           `koanf:"careplanservice"`
+	FrontendConfig  FrontendConfig                  `koanf:"frontend"`
+	FHIR            coolfhir.FHIRRoundTripperConfig `koanf:"fhir"`
+	Enabled         bool                            `koanf:"enabled"`
 }
 
 func (c Config) Validate() error {
@@ -27,17 +30,4 @@ type CarePlanServiceConfig struct {
 type FrontendConfig struct {
 	// URL is the base URL of the frontend for ORCA
 	URL string `koanf:"url"`
-}
-
-type FHIRConfig struct {
-	// BaseURL is the base URL of the FHIR server to connect to.
-	BaseURL string `koanf:"url"`
-	// Auth is the authentication configuration for the FHIR server.
-	Auth FHIRAuthConfig `koanf:"auth"`
-}
-
-type FHIRAuthConfig struct {
-	// Type of authentication to use, supported options: azure-managedidentity.
-	// Leave empty for no authentication.
-	Type string `koanf:"type"`
 }

--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -39,7 +39,7 @@ func New(
 	cpsURL, _ := url.Parse(config.CarePlanService.URL)
 	carePlanServiceClient := fhirclient.New(cpsURL, carePlanServiceHttpClient, coolfhir.Config())
 	fhirClientConfig := coolfhir.Config()
-	transport, _, err := coolfhir.NewFHIRAuthRoundTripper(config.FHIR, fhirClientConfig)
+	transport, _, err := coolfhir.NewAuthRoundTripper(config.FHIR, fhirClientConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -4,10 +4,12 @@ package careplancontributor
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/SanteonNL/nuts-policy-enforcement-point/middleware"
 	"github.com/SanteonNL/orca/orchestrator/addressing"
 	"github.com/SanteonNL/orca/orchestrator/applaunch/clients"
+	"github.com/SanteonNL/orca/orchestrator/lib/auth"
 	"github.com/SanteonNL/orca/orchestrator/user"
+	"github.com/nuts-foundation/go-nuts-client/oauth2"
 	"net/http"
 	"net/url"
 
@@ -21,25 +23,31 @@ import (
 const LandingURL = "/contrib/"
 const CarePlanServiceOAuth2Scope = "careplanservice"
 
-func New(config Config, sessionManager *user.SessionManager, carePlanServiceHttpClient *http.Client, didResolver addressing.StaticDIDResolver) (*Service, error) {
+var tokenIntrospectionClient = http.DefaultClient
+
+func New(
+	config Config,
+	nutsPublicURL *url.URL,
+	orcaPublicURL *url.URL,
+	nutsAPIURL *url.URL,
+	ownDID string,
+	sessionManager *user.SessionManager,
+	carePlanServiceHttpClient *http.Client,
+	didResolver addressing.StaticDIDResolver) (*Service, error) {
+
 	fhirURL, _ := url.Parse(config.FHIR.BaseURL)
 	cpsURL, _ := url.Parse(config.CarePlanService.URL)
 	carePlanServiceClient := fhirclient.New(cpsURL, carePlanServiceHttpClient, coolfhir.Config())
-	var transport http.RoundTripper
-	switch config.FHIR.Auth.Type {
-	case "azure-managedidentity":
-		credential, err := azidentity.NewManagedIdentityCredential(nil)
-		if err != nil {
-			return nil, fmt.Errorf("unable to get credential for Azure FHIR API client: %w", err)
-		}
-		httpClient := coolfhir.NewAzureHTTPClient(credential, coolfhir.DefaultAzureScope(fhirURL))
-		transport = httpClient.Transport
-	case "":
-		transport = http.DefaultTransport
-	default:
-		return nil, fmt.Errorf("invalid FHIR authentication type: %s", config.FHIR.Auth.Type)
+	fhirClientConfig := coolfhir.Config()
+	transport, _, err := coolfhir.NewFHIRAuthRoundTripper(config.FHIR, fhirClientConfig)
+	if err != nil {
+		return nil, err
 	}
 	return &Service{
+		orcaPublicURL:             orcaPublicURL,
+		nutsPublicURL:             nutsPublicURL,
+		nutsAPIURL:                nutsAPIURL,
+		ownDID:                    ownDID,
 		carePlanServiceURL:        cpsURL,
 		SessionManager:            sessionManager,
 		carePlanService:           carePlanServiceClient,
@@ -51,6 +59,10 @@ func New(config Config, sessionManager *user.SessionManager, carePlanServiceHttp
 }
 
 type Service struct {
+	orcaPublicURL             *url.URL
+	nutsPublicURL             *url.URL
+	nutsAPIURL                *url.URL
+	ownDID                    string
 	SessionManager            *user.SessionManager
 	frontendUrl               string
 	carePlanService           fhirclient.Client
@@ -61,6 +73,37 @@ type Service struct {
 }
 
 func (s Service) RegisterHandlers(mux *http.ServeMux) {
+	fhirProxy := coolfhir.NewProxy(log.Logger, s.fhirURL, "/contrib/fhir", s.transport)
+	authConfig := middleware.Config{
+		TokenIntrospectionEndpoint: s.nutsAPIURL.JoinPath("internal/auth/v2/accesstoken/introspect").String(),
+		TokenIntrospectionClient:   tokenIntrospectionClient,
+		BaseURL:                    s.orcaPublicURL.JoinPath("contrib"),
+	}
+
+	//
+	// Unauthorized endpoints
+	//
+	mux.HandleFunc("GET /cps/.well-known/oauth-protected-resource", func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Add("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusOK)
+		md := oauth2.ProtectedResourceMetadata{
+			Resource:               s.orcaPublicURL.JoinPath("cps").String(),
+			AuthorizationServers:   []string{s.nutsPublicURL.JoinPath("oauth2", s.ownDID).String()},
+			BearerMethodsSupported: []string{"header"},
+		}
+		_ = json.NewEncoder(writer).Encode(md)
+	})
+	//
+	// Authorized endpoints
+	//
+	// TODO: Determine auth from Nuts node and access token
+	// TODO: Modify this and other URLs to /cpc/* in future change
+	mux.HandleFunc("/contrib/fhir/*", auth.Middleware(authConfig, func(writer http.ResponseWriter, request *http.Request) {
+		fhirProxy.ServeHTTP(writer, request)
+	}))
+	//
+	// FE/Session Authorized Endpoints
+	//
 	mux.HandleFunc("GET /contrib/context", s.withSession(s.handleGetContext))
 	mux.HandleFunc("GET /contrib/patient", s.withSession(s.handleGetPatient))
 	mux.HandleFunc("GET /contrib/practitioner", s.withSession(s.handleGetPractitioner))
@@ -69,13 +112,6 @@ func (s Service) RegisterHandlers(mux *http.ServeMux) {
 	carePlanServiceProxy := coolfhir.NewProxy(log.Logger, s.carePlanServiceURL, "/contrib/cps/fhir", s.carePlanServiceHttpClient.Transport)
 	mux.HandleFunc("/contrib/cps/fhir/*", s.withSession(func(writer http.ResponseWriter, request *http.Request, _ *user.SessionData) {
 		carePlanServiceProxy.ServeHTTP(writer, request)
-	}))
-	fhirProxy := coolfhir.NewProxy(log.Logger, s.fhirURL, "/contrib/fhir", s.transport)
-	// TODO: Determine auth. CareTeam can be sent in header but this is not ideal, preferably put it in the access token
-	// TODO: Modify this and other URLs to /cpc/* in future change
-	mux.HandleFunc("/contrib/fhir/*", s.withSession(func(writer http.ResponseWriter, request *http.Request, _ *user.SessionData) {
-		// TODO: Is this correct?
-		fhirProxy.ServeHTTP(writer, request)
 	}))
 	mux.HandleFunc("/contrib/", func(response http.ResponseWriter, request *http.Request) {
 		log.Info().Msgf("Redirecting to %s", s.frontendUrl)
@@ -100,12 +136,6 @@ func (s Service) withSession(next func(response http.ResponseWriter, request *ht
 func (s Service) handleProxyToEPD(writer http.ResponseWriter, request *http.Request, session *user.SessionData) {
 	clientFactory := clients.Factories[session.FHIRLauncher](session.Values)
 	proxy := coolfhir.NewProxy(log.Logger, clientFactory.BaseURL, "/contrib/ehr/fhir", clientFactory.Client)
-	proxy.ServeHTTP(writer, request)
-}
-
-func (s Service) handleProxyToFHIR(writer http.ResponseWriter, request *http.Request, session *user.SessionData) {
-	clientFactory := clients.Factories[session.FHIRLauncher](session.Values)
-	proxy := coolfhir.NewProxy(log.Logger, clientFactory.BaseURL, "/contrib/fhir", clientFactory.Client)
 	proxy.ServeHTTP(writer, request)
 }
 

--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -4,6 +4,7 @@ package careplancontributor
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/SanteonNL/orca/orchestrator/addressing"
 	"github.com/SanteonNL/orca/orchestrator/applaunch/clients"
 	"github.com/SanteonNL/orca/orchestrator/user"
@@ -20,16 +21,33 @@ import (
 const LandingURL = "/contrib/"
 const CarePlanServiceOAuth2Scope = "careplanservice"
 
-func New(config Config, sessionManager *user.SessionManager, carePlanServiceHttpClient *http.Client, didResolver addressing.StaticDIDResolver) *Service {
+func New(config Config, sessionManager *user.SessionManager, carePlanServiceHttpClient *http.Client, didResolver addressing.StaticDIDResolver) (*Service, error) {
+	fhirURL, _ := url.Parse(config.FHIR.BaseURL)
 	cpsURL, _ := url.Parse(config.CarePlanService.URL)
 	carePlanServiceClient := fhirclient.New(cpsURL, carePlanServiceHttpClient, coolfhir.Config())
+	var transport http.RoundTripper
+	switch config.FHIR.Auth.Type {
+	case "azure-managedidentity":
+		credential, err := azidentity.NewManagedIdentityCredential(nil)
+		if err != nil {
+			return nil, fmt.Errorf("unable to get credential for Azure FHIR API client: %w", err)
+		}
+		httpClient := coolfhir.NewAzureHTTPClient(credential, coolfhir.DefaultAzureScope(fhirURL))
+		transport = httpClient.Transport
+	case "":
+		transport = http.DefaultTransport
+	default:
+		return nil, fmt.Errorf("invalid FHIR authentication type: %s", config.FHIR.Auth.Type)
+	}
 	return &Service{
 		carePlanServiceURL:        cpsURL,
 		SessionManager:            sessionManager,
 		carePlanService:           carePlanServiceClient,
 		carePlanServiceHttpClient: carePlanServiceHttpClient,
 		frontendUrl:               config.FrontendConfig.URL,
-	}
+		fhirURL:                   fhirURL,
+		transport:                 transport,
+	}, nil
 }
 
 type Service struct {
@@ -38,6 +56,8 @@ type Service struct {
 	carePlanService           fhirclient.Client
 	carePlanServiceURL        *url.URL
 	carePlanServiceHttpClient *http.Client
+	fhirURL                   *url.URL
+	transport                 http.RoundTripper
 }
 
 func (s Service) RegisterHandlers(mux *http.ServeMux) {
@@ -49,6 +69,13 @@ func (s Service) RegisterHandlers(mux *http.ServeMux) {
 	carePlanServiceProxy := coolfhir.NewProxy(log.Logger, s.carePlanServiceURL, "/contrib/cps/fhir", s.carePlanServiceHttpClient.Transport)
 	mux.HandleFunc("/contrib/cps/fhir/*", s.withSession(func(writer http.ResponseWriter, request *http.Request, _ *user.SessionData) {
 		carePlanServiceProxy.ServeHTTP(writer, request)
+	}))
+	fhirProxy := coolfhir.NewProxy(log.Logger, s.fhirURL, "/contrib/fhir", s.transport)
+	// TODO: Determine auth. CareTeam can be sent in header but this is not ideal, preferably put it in the access token
+	// TODO: Modify this and other URLs to /cpc/* in future change
+	mux.HandleFunc("/contrib/fhir/*", s.withSession(func(writer http.ResponseWriter, request *http.Request, _ *user.SessionData) {
+		// TODO: Is this correct?
+		fhirProxy.ServeHTTP(writer, request)
 	}))
 	mux.HandleFunc("/contrib/", func(response http.ResponseWriter, request *http.Request) {
 		log.Info().Msgf("Redirecting to %s", s.frontendUrl)
@@ -73,6 +100,12 @@ func (s Service) withSession(next func(response http.ResponseWriter, request *ht
 func (s Service) handleProxyToEPD(writer http.ResponseWriter, request *http.Request, session *user.SessionData) {
 	clientFactory := clients.Factories[session.FHIRLauncher](session.Values)
 	proxy := coolfhir.NewProxy(log.Logger, clientFactory.BaseURL, "/contrib/ehr/fhir", clientFactory.Client)
+	proxy.ServeHTTP(writer, request)
+}
+
+func (s Service) handleProxyToFHIR(writer http.ResponseWriter, request *http.Request, session *user.SessionData) {
+	clientFactory := clients.Factories[session.FHIRLauncher](session.Values)
+	proxy := coolfhir.NewProxy(log.Logger, clientFactory.BaseURL, "/contrib/fhir", clientFactory.Client)
 	proxy.ServeHTTP(writer, request)
 }
 

--- a/orchestrator/careplancontributor/service_test.go
+++ b/orchestrator/careplancontributor/service_test.go
@@ -1,8 +1,12 @@
 package careplancontributor
 
 import (
+	"encoding/json"
 	"github.com/SanteonNL/orca/orchestrator/applaunch/clients"
+	"github.com/SanteonNL/orca/orchestrator/lib/auth"
+	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
 	"github.com/SanteonNL/orca/orchestrator/user"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -13,7 +17,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var orcaPublicURL, _ = url.Parse("https://example.com/orca")
+var nutsPublicURL, _ = url.Parse("https://example.com/nuts")
+
 func TestService_Proxy(t *testing.T) {
+	tokenIntrospectionEndpoint := setupAuthorizationServer(t)
+
 	// Test that the service registers the /contrib URL that proxies to the backing FHIR server
 	// Setup: configure backing FHIR server to which the service proxies
 	fhirServerMux := http.NewServeMux()
@@ -25,38 +34,30 @@ func TestService_Proxy(t *testing.T) {
 	fhirServer := httptest.NewServer(fhirServerMux)
 	fhirServerURL, _ := url.Parse(fhirServer.URL)
 	fhirServerURL.Path = "/fhir"
-	// Setup: create the service
-
-	clients.Factories["test"] = func(properties map[string]string) clients.ClientProperties {
-		return clients.ClientProperties{
-			Client:  fhirServer.Client().Transport,
-			BaseURL: fhirServerURL,
-		}
-	}
-	sessionManager, sessionID := createTestSession()
+	sessionManager, _ := createTestSession()
 
 	service, _ := New(Config{
-		FHIR: FHIRConfig{
+		FHIR: coolfhir.FHIRRoundTripperConfig{
 			BaseURL: fhirServer.URL + "/fhir",
 		},
-	}, sessionManager, http.DefaultClient, nil)
+	}, nutsPublicURL, orcaPublicURL, tokenIntrospectionEndpoint, "", sessionManager, http.DefaultClient, nil)
 	// Setup: configure the service to proxy to the backing FHIR server
 	frontServerMux := http.NewServeMux()
 	service.RegisterHandlers(frontServerMux)
 	frontServer := httptest.NewServer(frontServerMux)
 
-	httpRequest, _ := http.NewRequest("GET", frontServer.URL+"/contrib/fhir/Patient", nil)
-	httpRequest.AddCookie(&http.Cookie{
-		Name:  "sid",
-		Value: sessionID,
-	})
-	httpResponse, err := frontServer.Client().Do(httpRequest)
+	httpClient := frontServer.Client()
+	httpClient.Transport = auth.AuthenticatedTestRoundTripper(frontServer.Client().Transport, "")
+
+	httpResponse, err := httpClient.Get(frontServer.URL + "/contrib/fhir/Patient")
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, httpResponse.StatusCode)
 	require.Equal(t, fhirServerURL.Host, capturedHost)
 }
 
 func TestService_ProxyToEHR(t *testing.T) {
+	tokenIntrospectionEndpoint := setupAuthorizationServer(t)
+
 	// Test that the service registers the EHR FHIR proxy URL that proxies to the backing FHIR server of the EHR
 	// Setup: configure backing EHR FHIR server to which the service proxies
 	fhirServerMux := http.NewServeMux()
@@ -78,7 +79,9 @@ func TestService_ProxyToEHR(t *testing.T) {
 	}
 	sessionManager, sessionID := createTestSession()
 
-	service, err := New(Config{}, sessionManager, http.DefaultClient, nil)
+	service, err := New(Config{},
+		nutsPublicURL, orcaPublicURL, tokenIntrospectionEndpoint, "",
+		sessionManager, http.DefaultClient, nil)
 	require.NoError(t, err)
 	// Setup: configure the service to proxy to the backing FHIR server
 	frontServerMux := http.NewServeMux()
@@ -97,6 +100,8 @@ func TestService_ProxyToEHR(t *testing.T) {
 }
 
 func TestService_ProxyToCPS(t *testing.T) {
+	tokenIntrospectionEndpoint := setupAuthorizationServer(t)
+
 	// Test that the service registers the CarePlanService FHIR proxy URL that proxies to the CarePlanService
 	// Setup: configure CarePlanService to which the service proxies
 	carePlanServiceMux := http.NewServeMux()
@@ -117,7 +122,8 @@ func TestService_ProxyToCPS(t *testing.T) {
 		CarePlanService: CarePlanServiceConfig{
 			URL: carePlanServiceURL.String(),
 		},
-	}, sessionManager, carePlanService.Client(), nil)
+	}, nutsPublicURL, orcaPublicURL, tokenIntrospectionEndpoint, "",
+		sessionManager, carePlanService.Client(), nil)
 	require.NoError(t, err)
 	// Setup: configure the service to proxy to the upstream CarePlanService
 	frontServerMux := http.NewServeMux()
@@ -165,4 +171,31 @@ func createTestSession() (*user.SessionManager, string) {
 	cookieValue = strings.Split(cookieValue, ";")[0]
 	cookieValue = strings.Split(cookieValue, "=")[1]
 	return sessionManager, cookieValue
+}
+
+// setupAuthorizationServer starts a test OAuth2 authorization server and returns its OAuth2 Token Introspection URL.
+func setupAuthorizationServer(t *testing.T) *url.URL {
+	authorizationServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requestData, _ := io.ReadAll(request.Body)
+		switch string(requestData) {
+		case "token=valid":
+			writer.Header().Set("Content-Type", "application/json")
+			responseData, _ := json.Marshal(map[string]interface{}{
+				"active":            true,
+				"organization_ura":  "1",
+				"organization_name": "Hospital",
+				"organization_city": "CareTown",
+			})
+			writer.WriteHeader(http.StatusOK)
+			_, _ = writer.Write(responseData)
+		default:
+			writer.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+	}))
+	t.Cleanup(func() {
+		authorizationServer.Close()
+	})
+	u, _ := url.Parse(authorizationServer.URL)
+	return u
 }

--- a/orchestrator/careplancontributor/service_test.go
+++ b/orchestrator/careplancontributor/service_test.go
@@ -37,7 +37,7 @@ func TestService_Proxy(t *testing.T) {
 	sessionManager, _ := createTestSession()
 
 	service, _ := New(Config{
-		FHIR: coolfhir.FHIRRoundTripperConfig{
+		FHIR: coolfhir.ClientConfig{
 			BaseURL: fhirServer.URL + "/fhir",
 		},
 	}, nutsPublicURL, orcaPublicURL, tokenIntrospectionEndpoint, "", sessionManager, http.DefaultClient, nil)

--- a/orchestrator/careplanservice/config.go
+++ b/orchestrator/careplanservice/config.go
@@ -1,14 +1,17 @@
 package careplanservice
 
-import "errors"
+import (
+	"errors"
+	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
+)
 
 func DefaultConfig() Config {
 	return Config{}
 }
 
 type Config struct {
-	FHIR    FHIRConfig `koanf:"fhir"`
-	Enabled bool       `koanf:"enabled"`
+	FHIR    coolfhir.FHIRRoundTripperConfig `koanf:"fhir"`
+	Enabled bool                            `koanf:"enabled"`
 }
 
 func (c Config) Validate() error {
@@ -19,17 +22,4 @@ func (c Config) Validate() error {
 		return errors.New("careplanservice.fhir.url is not configured")
 	}
 	return nil
-}
-
-type FHIRConfig struct {
-	// BaseURL is the base URL of the FHIR server to connect to.
-	BaseURL string `koanf:"url"`
-	// Auth is the authentication configuration for the FHIR server.
-	Auth FHIRAuthConfig `koanf:"auth"`
-}
-
-type FHIRAuthConfig struct {
-	// Type of authentication to use, supported options: azure-managedidentity.
-	// Leave empty for no authentication.
-	Type string `koanf:"type"`
 }

--- a/orchestrator/careplanservice/config.go
+++ b/orchestrator/careplanservice/config.go
@@ -10,8 +10,8 @@ func DefaultConfig() Config {
 }
 
 type Config struct {
-	FHIR    coolfhir.FHIRRoundTripperConfig `koanf:"fhir"`
-	Enabled bool                            `koanf:"enabled"`
+	FHIR    coolfhir.ClientConfig `koanf:"fhir"`
+	Enabled bool                  `koanf:"enabled"`
 }
 
 func (c Config) Validate() error {

--- a/orchestrator/careplanservice/config_test.go
+++ b/orchestrator/careplanservice/config_test.go
@@ -16,7 +16,7 @@ func TestConfig_Validate(t *testing.T) {
 		require.EqualError(t, err, "careplanservice.fhir.url is not configured")
 	})
 	t.Run("ok", func(t *testing.T) {
-		err := Config{Enabled: true, FHIR: coolfhir.FHIRRoundTripperConfig{BaseURL: "http://example.com"}}.Validate()
+		err := Config{Enabled: true, FHIR: coolfhir.ClientConfig{BaseURL: "http://example.com"}}.Validate()
 		require.NoError(t, err)
 	})
 }

--- a/orchestrator/careplanservice/config_test.go
+++ b/orchestrator/careplanservice/config_test.go
@@ -1,6 +1,7 @@
 package careplanservice
 
 import (
+	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
 	"github.com/stretchr/testify/require"
 	"testing"
 )
@@ -15,7 +16,7 @@ func TestConfig_Validate(t *testing.T) {
 		require.EqualError(t, err, "careplanservice.fhir.url is not configured")
 	})
 	t.Run("ok", func(t *testing.T) {
-		err := Config{Enabled: true, FHIR: FHIRConfig{BaseURL: "http://example.com"}}.Validate()
+		err := Config{Enabled: true, FHIR: coolfhir.FHIRRoundTripperConfig{BaseURL: "http://example.com"}}.Validate()
 		require.NoError(t, err)
 	})
 }

--- a/orchestrator/careplanservice/service.go
+++ b/orchestrator/careplanservice/service.go
@@ -21,7 +21,7 @@ var tokenIntrospectionClient = http.DefaultClient
 func New(config Config, nutsPublicURL *url.URL, orcaPublicURL *url.URL, nutsAPIURL *url.URL, ownDID string, didResolver addressing.DIDResolver) (*Service, error) {
 	fhirURL, _ := url.Parse(config.FHIR.BaseURL)
 	fhirClientConfig := coolfhir.Config()
-	transport, fhirClient, err := coolfhir.NewFHIRAuthRoundTripper(config.FHIR, fhirClientConfig)
+	transport, fhirClient, err := coolfhir.NewAuthRoundTripper(config.FHIR, fhirClientConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/orchestrator/careplanservice/service.go
+++ b/orchestrator/careplanservice/service.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	fhirclient "github.com/SanteonNL/go-fhir-client"
 	"github.com/SanteonNL/nuts-policy-enforcement-point/middleware"
 	"github.com/SanteonNL/orca/orchestrator/addressing"
@@ -21,23 +20,10 @@ var tokenIntrospectionClient = http.DefaultClient
 
 func New(config Config, nutsPublicURL *url.URL, orcaPublicURL *url.URL, nutsAPIURL *url.URL, ownDID string, didResolver addressing.DIDResolver) (*Service, error) {
 	fhirURL, _ := url.Parse(config.FHIR.BaseURL)
-	var transport http.RoundTripper
-	var fhirClient fhirclient.Client
 	fhirClientConfig := coolfhir.Config()
-	switch config.FHIR.Auth.Type {
-	case "azure-managedidentity":
-		credential, err := azidentity.NewManagedIdentityCredential(nil)
-		if err != nil {
-			return nil, fmt.Errorf("unable to get credential for Azure FHIR API client: %w", err)
-		}
-		httpClient := coolfhir.NewAzureHTTPClient(credential, coolfhir.DefaultAzureScope(fhirURL))
-		transport = httpClient.Transport
-		fhirClient = fhirclient.New(fhirURL, httpClient, fhirClientConfig)
-	case "":
-		transport = http.DefaultTransport
-		fhirClient = fhirclient.New(fhirURL, http.DefaultClient, fhirClientConfig)
-	default:
-		return nil, fmt.Errorf("invalid FHIR authentication type: %s", config.FHIR.Auth.Type)
+	transport, fhirClient, err := coolfhir.NewFHIRAuthRoundTripper(config.FHIR, fhirClientConfig)
+	if err != nil {
+		return nil, err
 	}
 	return &Service{
 		fhirURL:         fhirURL,

--- a/orchestrator/careplanservice/service_test.go
+++ b/orchestrator/careplanservice/service_test.go
@@ -34,7 +34,7 @@ func TestService_Proxy(t *testing.T) {
 	fhirServerURL, _ := url.Parse(fhirServer.URL)
 	// Setup: create the service
 	service, err := New(Config{
-		FHIR: coolfhir.FHIRRoundTripperConfig{
+		FHIR: coolfhir.ClientConfig{
 			BaseURL: fhirServer.URL + "/fhir",
 		},
 	}, nutsPublicURL, orcaPublicURL, tokenIntrospectionEndpoint, "", nil)
@@ -101,7 +101,7 @@ func TestService_Post_Task_Error(t *testing.T) {
 	tokenIntrospectionEndpoint := setupAuthorizationServer(t)
 	service, err := New(
 		Config{
-			FHIR: coolfhir.FHIRRoundTripperConfig{
+			FHIR: coolfhir.ClientConfig{
 				BaseURL: "http://example.com",
 			},
 		},
@@ -148,7 +148,7 @@ func Test_HandleProtectedResourceMetadata(t *testing.T) {
 	tokenIntrospectionEndpoint := setupAuthorizationServer(t)
 	// Setup: configure the service
 	service, err := New(Config{
-		FHIR: coolfhir.FHIRRoundTripperConfig{
+		FHIR: coolfhir.ClientConfig{
 			BaseURL: "http://example.com",
 		},
 	}, nutsPublicURL, orcaPublicURL, tokenIntrospectionEndpoint, "did:web:example.com", nil)

--- a/orchestrator/careplanservice/service_test.go
+++ b/orchestrator/careplanservice/service_test.go
@@ -2,6 +2,7 @@ package careplanservice
 
 import (
 	"encoding/json"
+	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -33,7 +34,7 @@ func TestService_Proxy(t *testing.T) {
 	fhirServerURL, _ := url.Parse(fhirServer.URL)
 	// Setup: create the service
 	service, err := New(Config{
-		FHIR: FHIRConfig{
+		FHIR: coolfhir.FHIRRoundTripperConfig{
 			BaseURL: fhirServer.URL + "/fhir",
 		},
 	}, nutsPublicURL, orcaPublicURL, tokenIntrospectionEndpoint, "", nil)
@@ -100,7 +101,7 @@ func TestService_Post_Task_Error(t *testing.T) {
 	tokenIntrospectionEndpoint := setupAuthorizationServer(t)
 	service, err := New(
 		Config{
-			FHIR: FHIRConfig{
+			FHIR: coolfhir.FHIRRoundTripperConfig{
 				BaseURL: "http://example.com",
 			},
 		},
@@ -147,7 +148,7 @@ func Test_HandleProtectedResourceMetadata(t *testing.T) {
 	tokenIntrospectionEndpoint := setupAuthorizationServer(t)
 	// Setup: configure the service
 	service, err := New(Config{
-		FHIR: FHIRConfig{
+		FHIR: coolfhir.FHIRRoundTripperConfig{
 			BaseURL: "http://example.com",
 		},
 	}, nutsPublicURL, orcaPublicURL, tokenIntrospectionEndpoint, "did:web:example.com", nil)
@@ -161,16 +162,4 @@ func Test_HandleProtectedResourceMetadata(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, httpResponse.StatusCode)
 
-}
-
-func TestNew(t *testing.T) {
-	t.Run("unknown FHIR server auth type", func(t *testing.T) {
-		_, err := New(Config{
-			FHIR: FHIRConfig{
-				BaseURL: "http://example.com",
-				Auth:    FHIRAuthConfig{Type: "foo"},
-			},
-		}, nutsPublicURL, orcaPublicURL, nil, "", nil)
-		require.EqualError(t, err, "invalid FHIR authentication type: foo")
-	})
 }

--- a/orchestrator/cmd/server.go
+++ b/orchestrator/cmd/server.go
@@ -49,7 +49,15 @@ func Start(config Config) error {
 	services = append(services, healthcheck.New())
 
 	if config.CarePlanContributor.Enabled {
-		carePlanContributor, err := careplancontributor.New(config.CarePlanContributor, sessionManager, nutsOAuth2HttpClient, didResolver)
+		carePlanContributor, err := careplancontributor.New(
+			config.CarePlanContributor,
+			config.Nuts.Public.Parse(),
+			config.Public.ParseURL(),
+			config.Nuts.API.Parse(),
+			config.Nuts.OwnDID,
+			sessionManager,
+			nutsOAuth2HttpClient,
+			didResolver)
 		if err != nil {
 			return err
 		}

--- a/orchestrator/cmd/server.go
+++ b/orchestrator/cmd/server.go
@@ -49,7 +49,10 @@ func Start(config Config) error {
 	services = append(services, healthcheck.New())
 
 	if config.CarePlanContributor.Enabled {
-		carePlanContributor := careplancontributor.New(config.CarePlanContributor, sessionManager, nutsOAuth2HttpClient, didResolver)
+		carePlanContributor, err := careplancontributor.New(config.CarePlanContributor, sessionManager, nutsOAuth2HttpClient, didResolver)
+		if err != nil {
+			return err
+		}
 		services = append(services, carePlanContributor)
 		// App Launches
 		services = append(services, smartonfhir.New(config.AppLaunch.SmartOnFhir, sessionManager))

--- a/orchestrator/lib/coolfhir/azure.go
+++ b/orchestrator/lib/coolfhir/azure.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	fhirclient "github.com/SanteonNL/go-fhir-client"
 	"golang.org/x/oauth2"
 	"net/http"
@@ -53,4 +54,49 @@ func (a azureTokenSource) Token() (*oauth2.Token, error) {
 		TokenType:   "Bearer",
 		Expiry:      accessToken.ExpiresOn,
 	}, nil
+}
+
+type FHIRRoundTripperConfig struct {
+	// BaseURL is the base URL of the FHIR server to connect to.
+	BaseURL string `koanf:"url"`
+	// Auth is the authentication configuration for the FHIR server.
+	Auth FHIRAuthConfig `koanf:"auth"`
+}
+
+type FHIRAuthConfigType string
+
+const (
+	Default              FHIRAuthConfigType = ""
+	AzureManagedIdentity FHIRAuthConfigType = "azure-managedidentity"
+)
+
+type FHIRAuthConfig struct {
+	// Type of authentication to use, supported options: azure-managedidentity.
+	// Leave empty for no authentication.
+	Type FHIRAuthConfigType `koanf:"type"`
+}
+
+func NewFHIRAuthRoundTripper(config FHIRRoundTripperConfig, fhirClientConfig *fhirclient.Config) (http.RoundTripper, fhirclient.Client, error) {
+	var transport http.RoundTripper
+	var fhirClient fhirclient.Client
+	fhirURL, err := url.Parse(config.BaseURL)
+	if err != nil {
+		return nil, nil, err
+	}
+	switch config.Auth.Type {
+	case AzureManagedIdentity:
+		credential, err := azidentity.NewManagedIdentityCredential(nil)
+		if err != nil {
+			return nil, nil, fmt.Errorf("unable to get credential for Azure FHIR API client: %w", err)
+		}
+		httpClient := NewAzureHTTPClient(credential, DefaultAzureScope(fhirURL))
+		transport = httpClient.Transport
+		fhirClient = fhirclient.New(fhirURL, httpClient, fhirClientConfig)
+	case Default:
+		transport = http.DefaultTransport
+		fhirClient = fhirclient.New(fhirURL, http.DefaultClient, fhirClientConfig)
+	default:
+		return nil, nil, fmt.Errorf("invalid FHIR authentication type: %s", config.Auth.Type)
+	}
+	return transport, fhirClient, nil
 }

--- a/orchestrator/lib/coolfhir/azure.go
+++ b/orchestrator/lib/coolfhir/azure.go
@@ -56,27 +56,27 @@ func (a azureTokenSource) Token() (*oauth2.Token, error) {
 	}, nil
 }
 
-type FHIRRoundTripperConfig struct {
+type ClientConfig struct {
 	// BaseURL is the base URL of the FHIR server to connect to.
 	BaseURL string `koanf:"url"`
 	// Auth is the authentication configuration for the FHIR server.
-	Auth FHIRAuthConfig `koanf:"auth"`
+	Auth AuthConfig `koanf:"auth"`
 }
 
-type FHIRAuthConfigType string
+type AuthConfigType string
 
 const (
-	Default              FHIRAuthConfigType = ""
-	AzureManagedIdentity FHIRAuthConfigType = "azure-managedidentity"
+	Default              AuthConfigType = ""
+	AzureManagedIdentity AuthConfigType = "azure-managedidentity"
 )
 
-type FHIRAuthConfig struct {
+type AuthConfig struct {
 	// Type of authentication to use, supported options: azure-managedidentity.
 	// Leave empty for no authentication.
-	Type FHIRAuthConfigType `koanf:"type"`
+	Type AuthConfigType `koanf:"type"`
 }
 
-func NewFHIRAuthRoundTripper(config FHIRRoundTripperConfig, fhirClientConfig *fhirclient.Config) (http.RoundTripper, fhirclient.Client, error) {
+func NewAuthRoundTripper(config ClientConfig, fhirClientConfig *fhirclient.Config) (http.RoundTripper, fhirclient.Client, error) {
 	var transport http.RoundTripper
 	var fhirClient fhirclient.Client
 	fhirURL, err := url.Parse(config.BaseURL)

--- a/orchestrator/lib/coolfhir/azure_test.go
+++ b/orchestrator/lib/coolfhir/azure_test.go
@@ -76,52 +76,52 @@ func Test_azureHttpClient_Do(t *testing.T) {
 
 func Test_NewFHIRAuthRoundTripper(t *testing.T) {
 	t.Run("Invalid RoundTripper - Invalid FHIR URL", func(t *testing.T) {
-		config := FHIRRoundTripperConfig{
+		config := ClientConfig{
 			BaseURL: "ayiwrq284-02uwqa'trki::$juqwa58tp[9{{}{{}{}{Pwa",
-			Auth:    FHIRAuthConfig{},
+			Auth:    AuthConfig{},
 		}
 		fhirClientConfig := Config()
 
-		roundTripper, fhirClient, err := NewFHIRAuthRoundTripper(config, fhirClientConfig)
+		roundTripper, fhirClient, err := NewAuthRoundTripper(config, fhirClientConfig)
 		require.Error(t, err)
 		require.Nil(t, roundTripper)
 		require.Nil(t, fhirClient)
 	})
 	t.Run("Invalid RoundTripper - Invalid Auth Type", func(t *testing.T) {
-		config := FHIRRoundTripperConfig{
+		config := ClientConfig{
 			BaseURL: "",
-			Auth:    FHIRAuthConfig{Type: "foo"},
+			Auth:    AuthConfig{Type: "foo"},
 		}
 		fhirClientConfig := Config()
 
-		roundTripper, fhirClient, err := NewFHIRAuthRoundTripper(config, fhirClientConfig)
+		roundTripper, fhirClient, err := NewAuthRoundTripper(config, fhirClientConfig)
 		require.EqualError(t, err, "invalid FHIR authentication type: foo")
 		require.Nil(t, roundTripper)
 		require.Nil(t, fhirClient)
 	})
 	t.Run("Valid RoundTripper - azuremanaged-identity", func(t *testing.T) {
-		config := FHIRRoundTripperConfig{
+		config := ClientConfig{
 			BaseURL: "",
-			Auth: FHIRAuthConfig{
+			Auth: AuthConfig{
 				Type: AzureManagedIdentity,
 			},
 		}
 		fhirClientConfig := Config()
 
-		roundTripper, fhirClient, err := NewFHIRAuthRoundTripper(config, fhirClientConfig)
+		roundTripper, fhirClient, err := NewAuthRoundTripper(config, fhirClientConfig)
 		require.NoError(t, err)
 		require.NotNil(t, roundTripper)
 		require.NotNil(t, fhirClient)
 		require.Equal(t, fhirClientConfig.MaxResponseSize, 10485760)
 	})
 	t.Run("Valid RoundTripper - default", func(t *testing.T) {
-		config := FHIRRoundTripperConfig{
+		config := ClientConfig{
 			BaseURL: "",
-			Auth:    FHIRAuthConfig{},
+			Auth:    AuthConfig{},
 		}
 		fhirClientConfig := Config()
 
-		roundTripper, fhirClient, err := NewFHIRAuthRoundTripper(config, fhirClientConfig)
+		roundTripper, fhirClient, err := NewAuthRoundTripper(config, fhirClientConfig)
 		require.NoError(t, err)
 		require.NotNil(t, roundTripper)
 		require.Equal(t, roundTripper, http.DefaultTransport)

--- a/orchestrator/lib/coolfhir/azure_test.go
+++ b/orchestrator/lib/coolfhir/azure_test.go
@@ -74,7 +74,7 @@ func Test_azureHttpClient_Do(t *testing.T) {
 	})
 }
 
-func Test_NewFHIRAuthRoundTripper(t *testing.T) {
+func Test_NewAuthRoundTripper(t *testing.T) {
 	t.Run("Invalid RoundTripper - Invalid FHIR URL", func(t *testing.T) {
 		config := ClientConfig{
 			BaseURL: "ayiwrq284-02uwqa'trki::$juqwa58tp[9{{}{{}{}{Pwa",


### PR DESCRIPTION
Adds a FHIR proxy endpoint for method calls from one CPC instance to another.

Still to do: Auth based on provided CareTeam, E2E integ test