### PR TITLE
Abstract Nuts support through Profile abstraction refactor

### DIFF
--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -4,11 +4,9 @@ package careplancontributor
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/SanteonNL/nuts-policy-enforcement-point/middleware"
 	"github.com/SanteonNL/orca/orchestrator/applaunch/clients"
-	"github.com/SanteonNL/orca/orchestrator/lib/auth"
+	"github.com/SanteonNL/orca/orchestrator/cmd/profile"
 	"github.com/SanteonNL/orca/orchestrator/user"
-	"github.com/nuts-foundation/go-nuts-client/oauth2"
 	"net/http"
 	"net/url"
 
@@ -19,99 +17,79 @@ import (
 	"github.com/samply/golang-fhir-models/fhir-models/fhir"
 )
 
-const LandingURL = "/contrib/"
-const CarePlanServiceOAuth2Scope = "careplanservice"
+const basePath = "/contrib"
+const LandingURL = basePath + "/"
 
-var tokenIntrospectionClient = http.DefaultClient
+const CarePlanServiceOAuth2Scope = "careplanservice"
 
 func New(
 	config Config,
-	nutsPublicURL *url.URL,
+	profile profile.Provider,
 	orcaPublicURL *url.URL,
-	nutsAPIURL *url.URL,
-	ownDID string,
-	sessionManager *user.SessionManager,
-	carePlanServiceHttpClient *http.Client) (*Service, error) {
+	sessionManager *user.SessionManager) (*Service, error) {
 
 	fhirURL, _ := url.Parse(config.FHIR.BaseURL)
 	cpsURL, _ := url.Parse(config.CarePlanService.URL)
-	carePlanServiceClient := fhirclient.New(cpsURL, carePlanServiceHttpClient, coolfhir.Config())
 	fhirClientConfig := coolfhir.Config()
-	transport, _, err := coolfhir.NewAuthRoundTripper(config.FHIR, fhirClientConfig)
+	localFHIRStoreTransport, _, err := coolfhir.NewAuthRoundTripper(config.FHIR, fhirClientConfig)
 	if err != nil {
 		return nil, err
 	}
+	httpClient := profile.HttpClient()
 	return &Service{
-		orcaPublicURL:             orcaPublicURL,
-		nutsPublicURL:             nutsPublicURL,
-		nutsAPIURL:                nutsAPIURL,
-		ownDID:                    ownDID,
-		carePlanServiceURL:        cpsURL,
-		SessionManager:            sessionManager,
-		carePlanService:           carePlanServiceClient,
-		carePlanServiceHttpClient: carePlanServiceHttpClient,
-		frontendUrl:               config.FrontendConfig.URL,
-		fhirURL:                   fhirURL,
-		transport:                 transport,
+		orcaPublicURL:      orcaPublicURL,
+		carePlanServiceURL: cpsURL,
+		SessionManager:     sessionManager,
+		scpHttpClient:      httpClient,
+		profile:            profile,
+		frontendUrl:        config.FrontendConfig.URL,
+		fhirURL:            fhirURL,
+		transport:          localFHIRStoreTransport,
 	}, nil
 }
 
 type Service struct {
-	orcaPublicURL             *url.URL
-	nutsPublicURL             *url.URL
-	nutsAPIURL                *url.URL
-	ownDID                    string
-	SessionManager            *user.SessionManager
-	frontendUrl               string
-	carePlanService           fhirclient.Client
-	carePlanServiceURL        *url.URL
-	carePlanServiceHttpClient *http.Client
-	fhirURL                   *url.URL
-	transport                 http.RoundTripper
+	profile            profile.Provider
+	orcaPublicURL      *url.URL
+	SessionManager     *user.SessionManager
+	frontendUrl        string
+	carePlanServiceURL *url.URL
+	// scpHttpClient is used to call remote Care Plan Contributors or Care Plan Service, used to:
+	// - proxy requests from the Frontend application (e.g. initiating task workflow)
+	// - proxy requests from EHR (e.g. fetching remote FHIR data)
+	scpHttpClient *http.Client
+	fhirURL       *url.URL
+	// transport is used to call the local FHIR store, used to:
+	// - proxy requests from the Frontend application (e.g. initiating task workflow)
+	// - proxy requests from EHR (e.g. fetching remote FHIR data)
+	transport http.RoundTripper
 }
 
 func (s Service) RegisterHandlers(mux *http.ServeMux) {
-	fhirProxy := coolfhir.NewProxy(log.Logger, s.fhirURL, "/contrib/fhir", s.transport)
-	authConfig := middleware.Config{
-		TokenIntrospectionEndpoint: s.nutsAPIURL.JoinPath("internal/auth/v2/accesstoken/introspect").String(),
-		TokenIntrospectionClient:   tokenIntrospectionClient,
-		BaseURL:                    s.orcaPublicURL.JoinPath("contrib"),
-	}
-
-	//
-	// Unauthorized endpoints
-	//
-	mux.HandleFunc("GET /cps/.well-known/oauth-protected-resource", func(writer http.ResponseWriter, request *http.Request) {
-		writer.Header().Add("Content-Type", "application/json")
-		writer.WriteHeader(http.StatusOK)
-		md := oauth2.ProtectedResourceMetadata{
-			Resource:               s.orcaPublicURL.JoinPath("cps").String(),
-			AuthorizationServers:   []string{s.nutsPublicURL.JoinPath("oauth2", s.ownDID).String()},
-			BearerMethodsSupported: []string{"header"},
-		}
-		_ = json.NewEncoder(writer).Encode(md)
-	})
+	fhirProxy := coolfhir.NewProxy(log.Logger, s.fhirURL, basePath+"/fhir", s.transport)
+	baseURL := s.orcaPublicURL.JoinPath(basePath)
+	s.profile.RegisterHTTPHandlers(basePath, baseURL, mux)
 	//
 	// Authorized endpoints
 	//
 	// TODO: Determine auth from Nuts node and access token
 	// TODO: Modify this and other URLs to /cpc/* in future change
-	mux.HandleFunc("/contrib/fhir/*", auth.Middleware(authConfig, func(writer http.ResponseWriter, request *http.Request) {
+	mux.HandleFunc(basePath+"/fhir/*", s.profile.Authenticator(baseURL, func(writer http.ResponseWriter, request *http.Request) {
 		fhirProxy.ServeHTTP(writer, request)
 	}))
 	//
 	// FE/Session Authorized Endpoints
 	//
-	mux.HandleFunc("GET /contrib/context", s.withSession(s.handleGetContext))
-	mux.HandleFunc("GET /contrib/patient", s.withSession(s.handleGetPatient))
-	mux.HandleFunc("GET /contrib/practitioner", s.withSession(s.handleGetPractitioner))
-	mux.HandleFunc("GET /contrib/serviceRequest", s.withSession(s.handleGetServiceRequest))
-	mux.HandleFunc("/contrib/ehr/fhir/*", s.withSession(s.handleProxyToEPD))
-	carePlanServiceProxy := coolfhir.NewProxy(log.Logger, s.carePlanServiceURL, "/contrib/cps/fhir", s.carePlanServiceHttpClient.Transport)
-	mux.HandleFunc("/contrib/cps/fhir/*", s.withSession(func(writer http.ResponseWriter, request *http.Request, _ *user.SessionData) {
+	mux.HandleFunc("GET "+basePath+"/context", s.withSession(s.handleGetContext))
+	mux.HandleFunc("GET "+basePath+"/patient", s.withSession(s.handleGetPatient))
+	mux.HandleFunc("GET "+basePath+"/practitioner", s.withSession(s.handleGetPractitioner))
+	mux.HandleFunc("GET "+basePath+"/serviceRequest", s.withSession(s.handleGetServiceRequest))
+	mux.HandleFunc(basePath+"/ehr/fhir/*", s.withSession(s.handleProxyToEPD))
+	carePlanServiceProxy := coolfhir.NewProxy(log.Logger, s.carePlanServiceURL, basePath+"/cps/fhir", s.scpHttpClient.Transport)
+	mux.HandleFunc(basePath+"/cps/fhir/*", s.withSession(func(writer http.ResponseWriter, request *http.Request, _ *user.SessionData) {
 		carePlanServiceProxy.ServeHTTP(writer, request)
 	}))
-	mux.HandleFunc("/contrib/", func(response http.ResponseWriter, request *http.Request) {
+	mux.HandleFunc(basePath+"/", func(response http.ResponseWriter, request *http.Request) {
 		log.Info().Msgf("Redirecting to %s", s.frontendUrl)
 		http.Redirect(response, request, s.frontendUrl, http.StatusFound)
 	})
@@ -133,7 +111,7 @@ func (s Service) withSession(next func(response http.ResponseWriter, request *ht
 
 func (s Service) handleProxyToEPD(writer http.ResponseWriter, request *http.Request, session *user.SessionData) {
 	clientFactory := clients.Factories[session.FHIRLauncher](session.Values)
-	proxy := coolfhir.NewProxy(log.Logger, clientFactory.BaseURL, "/contrib/ehr/fhir", clientFactory.Client)
+	proxy := coolfhir.NewProxy(log.Logger, clientFactory.BaseURL, basePath+"/ehr/fhir", clientFactory.Client)
 	proxy.ServeHTTP(writer, request)
 }
 

--- a/orchestrator/careplancontributor/service_test.go
+++ b/orchestrator/careplancontributor/service_test.go
@@ -1,13 +1,11 @@
 package careplancontributor
 
 import (
-	"encoding/json"
 	"github.com/SanteonNL/orca/orchestrator/applaunch/clients"
 	"github.com/SanteonNL/orca/orchestrator/cmd/profile"
 	"github.com/SanteonNL/orca/orchestrator/lib/auth"
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
 	"github.com/SanteonNL/orca/orchestrator/user"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -21,8 +19,6 @@ import (
 var orcaPublicURL, _ = url.Parse("https://example.com/orca")
 
 func TestService_Proxy(t *testing.T) {
-	//tokenIntrospectionEndpoint := setupAuthorizationServer(t)
-
 	// Test that the service registers the /contrib URL that proxies to the backing FHIR server
 	// Setup: configure backing FHIR server to which the service proxies
 	fhirServerMux := http.NewServeMux()
@@ -56,8 +52,6 @@ func TestService_Proxy(t *testing.T) {
 }
 
 func TestService_ProxyToEHR(t *testing.T) {
-	//tokenIntrospectionEndpoint := setupAuthorizationServer(t)
-
 	// Test that the service registers the EHR FHIR proxy URL that proxies to the backing FHIR server of the EHR
 	// Setup: configure backing EHR FHIR server to which the service proxies
 	fhirServerMux := http.NewServeMux()
@@ -98,8 +92,6 @@ func TestService_ProxyToEHR(t *testing.T) {
 }
 
 func TestService_ProxyToCPS(t *testing.T) {
-	//tokenIntrospectionEndpoint := setupAuthorizationServer(t)
-
 	// Test that the service registers the CarePlanService FHIR proxy URL that proxies to the CarePlanService
 	// Setup: configure CarePlanService to which the service proxies
 	carePlanServiceMux := http.NewServeMux()
@@ -168,31 +160,4 @@ func createTestSession() (*user.SessionManager, string) {
 	cookieValue = strings.Split(cookieValue, ";")[0]
 	cookieValue = strings.Split(cookieValue, "=")[1]
 	return sessionManager, cookieValue
-}
-
-// setupAuthorizationServer starts a test OAuth2 authorization server and returns its OAuth2 Token Introspection URL.
-func setupAuthorizationServer(t *testing.T) *url.URL {
-	authorizationServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		requestData, _ := io.ReadAll(request.Body)
-		switch string(requestData) {
-		case "token=valid":
-			writer.Header().Set("Content-Type", "application/json")
-			responseData, _ := json.Marshal(map[string]interface{}{
-				"active":            true,
-				"organization_ura":  "1",
-				"organization_name": "Hospital",
-				"organization_city": "CareTown",
-			})
-			writer.WriteHeader(http.StatusOK)
-			_, _ = writer.Write(responseData)
-		default:
-			writer.WriteHeader(http.StatusUnauthorized)
-			return
-		}
-	}))
-	t.Cleanup(func() {
-		authorizationServer.Close()
-	})
-	u, _ := url.Parse(authorizationServer.URL)
-	return u
 }

--- a/orchestrator/careplanservice/integration_test.go
+++ b/orchestrator/careplanservice/integration_test.go
@@ -2,8 +2,8 @@ package careplanservice
 
 import (
 	"context"
-	"encoding/json"
 	fhirclient "github.com/SanteonNL/go-fhir-client"
+	"github.com/SanteonNL/orca/orchestrator/cmd/profile"
 	"github.com/SanteonNL/orca/orchestrator/lib/auth"
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
 	"github.com/SanteonNL/orca/orchestrator/lib/to"
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 	testcontainers "github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
-	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -204,12 +203,10 @@ func Test_Integration_TaskLifecycle(t *testing.T) {
 }
 func setupIntegrationTest(t *testing.T) (*fhirclient.BaseClient, *fhirclient.BaseClient) {
 	fhirBaseURL := setupHAPI(t)
-	tokenIntrospectionEndpoint := setupAuthorizationServer(t)
-
 	config := DefaultConfig()
 	config.Enabled = true
 	config.FHIR.BaseURL = fhirBaseURL.String()
-	service, err := New(config, nutsPublicURL, orcaPublicURL, tokenIntrospectionEndpoint, "did:web:example.com/careplanservice")
+	service, err := New(config, profile.TestProfile{}, orcaPublicURL)
 	require.NoError(t, err)
 
 	serverMux := http.NewServeMux()
@@ -218,8 +215,8 @@ func setupIntegrationTest(t *testing.T) (*fhirclient.BaseClient, *fhirclient.Bas
 
 	carePlanServiceURL, _ := url.Parse(httpService.URL + "/cps")
 
-	transport1 := auth.AuthenticatedTestRoundTripper(httpService.Client().Transport, "1")
-	transport2 := auth.AuthenticatedTestRoundTripper(httpService.Client().Transport, "2")
+	transport1 := auth.AuthenticatedTestRoundTripper(httpService.Client().Transport, auth.TestPrincipal1)
+	transport2 := auth.AuthenticatedTestRoundTripper(httpService.Client().Transport, auth.TestPrincipal2)
 
 	carePlanContributor1 := fhirclient.New(carePlanServiceURL, &http.Client{Transport: transport1}, nil)
 	carePlanContributor2 := fhirclient.New(carePlanServiceURL, &http.Client{Transport: transport2}, nil)
@@ -257,45 +254,6 @@ outer:
 		}
 		t.Errorf("expected participant not found: %s", *expectedMember.OnBehalfOf.Identifier.Value)
 	}
-}
-
-// setupAuthorizationServer starts a test OAuth2 authorization server and returns its OAuth2 Token Introspection URL.
-func setupAuthorizationServer(t *testing.T) *url.URL {
-	authorizationServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		requestData, _ := io.ReadAll(request.Body)
-		switch string(requestData) {
-		case "token=valid":
-			fallthrough
-		case "token=1":
-			writer.Header().Set("Content-Type", "application/json")
-			responseData, _ := json.Marshal(map[string]interface{}{
-				"active":            true,
-				"organization_ura":  "1",
-				"organization_name": "Hospital",
-				"organization_city": "CareTown",
-			})
-			writer.WriteHeader(http.StatusOK)
-			_, _ = writer.Write(responseData)
-		case "token=2":
-			writer.Header().Set("Content-Type", "application/json")
-			responseData, _ := json.Marshal(map[string]interface{}{
-				"active":            true,
-				"organization_ura":  "2",
-				"organization_name": "Hospital",
-				"organization_city": "CareTown",
-			})
-			writer.WriteHeader(http.StatusOK)
-			_, _ = writer.Write(responseData)
-		default:
-			writer.WriteHeader(http.StatusUnauthorized)
-			return
-		}
-	}))
-	t.Cleanup(func() {
-		authorizationServer.Close()
-	})
-	u, _ := url.Parse(authorizationServer.URL)
-	return u
 }
 
 func setupHAPI(t *testing.T) *url.URL {

--- a/orchestrator/careplanservice/service.go
+++ b/orchestrator/careplanservice/service.go
@@ -3,21 +3,19 @@ package careplanservice
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/SanteonNL/orca/orchestrator/cmd/profile"
 	"io"
 	"net/http"
 	"net/url"
 
 	fhirclient "github.com/SanteonNL/go-fhir-client"
-	"github.com/SanteonNL/nuts-policy-enforcement-point/middleware"
-	"github.com/SanteonNL/orca/orchestrator/lib/auth"
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
-	"github.com/nuts-foundation/go-nuts-client/oauth2"
 	"github.com/rs/zerolog/log"
 )
 
-var tokenIntrospectionClient = http.DefaultClient
+const basePath = "/cps"
 
-func New(config Config, nutsPublicURL *url.URL, orcaPublicURL *url.URL, nutsAPIURL *url.URL, ownDID string) (*Service, error) {
+func New(config Config, profile profile.Provider, orcaPublicURL *url.URL) (*Service, error) {
 	fhirURL, _ := url.Parse(config.FHIR.BaseURL)
 	fhirClientConfig := coolfhir.Config()
 	transport, fhirClient, err := coolfhir.NewAuthRoundTripper(config.FHIR, fhirClientConfig)
@@ -25,11 +23,9 @@ func New(config Config, nutsPublicURL *url.URL, orcaPublicURL *url.URL, nutsAPIU
 		return nil, err
 	}
 	return &Service{
+		profile:         profile,
 		fhirURL:         fhirURL,
 		orcaPublicURL:   orcaPublicURL,
-		nutsPublicURL:   nutsPublicURL,
-		nutsAPIURL:      nutsAPIURL,
-		ownDID:          ownDID,
 		transport:       transport,
 		fhirClient:      fhirClient,
 		maxReadBodySize: fhirClientConfig.MaxResponseSize,
@@ -38,60 +34,42 @@ func New(config Config, nutsPublicURL *url.URL, orcaPublicURL *url.URL, nutsAPIU
 
 type Service struct {
 	orcaPublicURL   *url.URL
-	nutsPublicURL   *url.URL
-	nutsAPIURL      *url.URL
-	ownDID          string
 	fhirURL         *url.URL
 	transport       http.RoundTripper
 	fhirClient      fhirclient.Client
+	profile         profile.Provider
 	maxReadBodySize int
 }
 
 func (s Service) RegisterHandlers(mux *http.ServeMux) {
-	proxy := coolfhir.NewProxy(log.Logger, s.fhirURL, "/cps", s.transport)
-	authConfig := middleware.Config{
-		TokenIntrospectionEndpoint: s.nutsAPIURL.JoinPath("internal/auth/v2/accesstoken/introspect").String(),
-		TokenIntrospectionClient:   tokenIntrospectionClient,
-		BaseURL:                    s.orcaPublicURL.JoinPath("cps"),
-	}
-	//
-	// Unauthorized endpoints
-	//
-	mux.HandleFunc("GET /cps/.well-known/oauth-protected-resource", func(writer http.ResponseWriter, request *http.Request) {
-		writer.Header().Add("Content-Type", "application/json")
-		writer.WriteHeader(http.StatusOK)
-		md := oauth2.ProtectedResourceMetadata{
-			Resource:               s.orcaPublicURL.JoinPath("cps").String(),
-			AuthorizationServers:   []string{s.nutsPublicURL.JoinPath("oauth2", s.ownDID).String()},
-			BearerMethodsSupported: []string{"header"},
-		}
-		_ = json.NewEncoder(writer).Encode(md)
-	})
+	proxy := coolfhir.NewProxy(log.Logger, s.fhirURL, basePath, s.transport)
+	baseURL := s.orcaPublicURL.JoinPath(basePath)
+	s.profile.RegisterHTTPHandlers(basePath, baseURL, mux)
 	//
 	// Authorized endpoints
 	//
-	mux.HandleFunc("POST /cps/Task", auth.Middleware(authConfig, func(writer http.ResponseWriter, request *http.Request) {
+	mux.HandleFunc("POST "+basePath+"/Task", s.profile.Authenticator(baseURL, func(writer http.ResponseWriter, request *http.Request) {
 		err := s.handleCreateTask(writer, request)
 		if err != nil {
 			s.writeOperationOutcomeFromError(err, "CarePlanService/CreateTask", writer)
 			return
 		}
 	}))
-	mux.HandleFunc("PUT /cps/Task/{id}", auth.Middleware(authConfig, func(writer http.ResponseWriter, request *http.Request) {
+	mux.HandleFunc("PUT "+basePath+"/Task/{id}", s.profile.Authenticator(baseURL, func(writer http.ResponseWriter, request *http.Request) {
 		err := s.handleUpdateTask(writer, request)
 		if err != nil {
 			s.writeOperationOutcomeFromError(err, "CarePlanService/UpdateTask", writer)
 			return
 		}
 	}))
-	mux.HandleFunc("POST /cps/CarePlan", auth.Middleware(authConfig, func(writer http.ResponseWriter, request *http.Request) {
+	mux.HandleFunc("POST "+basePath+"/CarePlan", s.profile.Authenticator(baseURL, func(writer http.ResponseWriter, request *http.Request) {
 		err := s.handleCreateCarePlan(writer, request)
 		if err != nil {
 			s.writeOperationOutcomeFromError(err, "CarePlanService/CreateCarePlan", writer)
 			return
 		}
 	}))
-	mux.HandleFunc("/cps/*", auth.Middleware(authConfig, func(writer http.ResponseWriter, request *http.Request) {
+	mux.HandleFunc(basePath+"/*", s.profile.Authenticator(baseURL, func(writer http.ResponseWriter, request *http.Request) {
 		// TODO: Authorize request here
 		log.Warn().Msgf("Unmanaged FHIR operation at CarePlanService: %s %s", request.Method, request.URL.String())
 		proxy.ServeHTTP(writer, request)

--- a/orchestrator/careplanservice/service_test.go
+++ b/orchestrator/careplanservice/service_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 var orcaPublicURL, _ = url.Parse("https://example.com/orca")
-var nutsPublicURL, _ = url.Parse("https://example.com/nuts")
 
 var taskJSON = `{"resourceType":"Task","id":"cps-task-01","meta":{"versionId":"1","profile":["http://santeonnl.github.io/shared-care-planning/StructureDefinition/SCPTask"]},"text":{"status":"generated","div":"<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative</div>"},"status":"requested","intent":"order","code":{"coding":[{"system":"http://hl7.org/fhir/CodeSystem/task-code","code":"fullfill"}]},"focus":{"reference":"urn:uuid:456"},"for":{"identifier":{"system":"http://fhir.nl/fhir/NamingSystem/bsn","value":"111222333"}},"requester":{"identifier":{"system":"http://fhir.nl/fhir/NamingSystem/uzi","value":"UZI-1"}},"owner":{"identifier":{"system":"http://fhir.nl/fhir/NamingSystem/ura","value":"URA-2"}},"reasonReference":{"reference":"urn:uuid:789"}}`
 

--- a/orchestrator/careplanservice/service_test.go
+++ b/orchestrator/careplanservice/service_test.go
@@ -2,6 +2,7 @@ package careplanservice
 
 import (
 	"encoding/json"
+	"github.com/SanteonNL/orca/orchestrator/cmd/profile"
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
 	"net/http"
 	"net/http/httptest"
@@ -20,8 +21,6 @@ var nutsPublicURL, _ = url.Parse("https://example.com/nuts")
 var taskJSON = `{"resourceType":"Task","id":"cps-task-01","meta":{"versionId":"1","profile":["http://santeonnl.github.io/shared-care-planning/StructureDefinition/SCPTask"]},"text":{"status":"generated","div":"<div xmlns=\"http://www.w3.org/1999/xhtml\">Generated Narrative</div>"},"status":"requested","intent":"order","code":{"coding":[{"system":"http://hl7.org/fhir/CodeSystem/task-code","code":"fullfill"}]},"focus":{"reference":"urn:uuid:456"},"for":{"identifier":{"system":"http://fhir.nl/fhir/NamingSystem/bsn","value":"111222333"}},"requester":{"identifier":{"system":"http://fhir.nl/fhir/NamingSystem/uzi","value":"UZI-1"}},"owner":{"identifier":{"system":"http://fhir.nl/fhir/NamingSystem/ura","value":"URA-2"}},"reasonReference":{"reference":"urn:uuid:789"}}`
 
 func TestService_Proxy(t *testing.T) {
-	tokenIntrospectionEndpoint := setupAuthorizationServer(t)
-
 	// Test that the service registers the /cps URL that proxies to the backing FHIR server
 	// Setup: configure backing FHIR server to which the service proxies
 	fhirServerMux := http.NewServeMux()
@@ -37,7 +36,7 @@ func TestService_Proxy(t *testing.T) {
 		FHIR: coolfhir.ClientConfig{
 			BaseURL: fhirServer.URL + "/fhir",
 		},
-	}, nutsPublicURL, orcaPublicURL, tokenIntrospectionEndpoint, "")
+	}, profile.TestProfile{}, orcaPublicURL)
 	require.NoError(t, err)
 	// Setup: configure the service to proxy to the backing FHIR server
 	frontServerMux := http.NewServeMux()
@@ -45,7 +44,7 @@ func TestService_Proxy(t *testing.T) {
 	frontServer := httptest.NewServer(frontServerMux)
 
 	httpClient := frontServer.Client()
-	httpClient.Transport = auth.AuthenticatedTestRoundTripper(frontServer.Client().Transport, "")
+	httpClient.Transport = auth.AuthenticatedTestRoundTripper(frontServer.Client().Transport, auth.TestPrincipal1)
 
 	httpResponse, err := httpClient.Get(frontServer.URL + "/cps/Patient")
 	require.NoError(t, err)
@@ -98,17 +97,14 @@ func TestService_Post_Task_Error(t *testing.T) {
 	}
 
 	// Setup: configure the service
-	tokenIntrospectionEndpoint := setupAuthorizationServer(t)
 	service, err := New(
 		Config{
 			FHIR: coolfhir.ClientConfig{
 				BaseURL: "http://example.com",
 			},
 		},
-		nutsPublicURL,
-		orcaPublicURL,
-		tokenIntrospectionEndpoint,
-		"did:web:example.com")
+		profile.TestProfile{},
+		orcaPublicURL)
 	require.NoError(t, err)
 	serverMux := http.NewServeMux()
 	service.RegisterHandlers(serverMux)
@@ -116,7 +112,7 @@ func TestService_Post_Task_Error(t *testing.T) {
 
 	// Setup: configure the client
 	httpClient := server.Client()
-	httpClient.Transport = auth.AuthenticatedTestRoundTripper(server.Client().Transport, "")
+	httpClient.Transport = auth.AuthenticatedTestRoundTripper(server.Client().Transport, auth.TestPrincipal1)
 
 	for _, tt := range tests {
 		// Make an invalid call (not providing JSON payload)
@@ -140,25 +136,4 @@ func TestService_Post_Task_Error(t *testing.T) {
 		require.NotEmpty(t, target.Issue)
 		require.Equal(t, tt.expectedMessage, *target.Issue[0].Diagnostics)
 	}
-}
-
-func Test_HandleProtectedResourceMetadata(t *testing.T) {
-	// Test that the service handles the protected resource metadata URL
-	tokenIntrospectionEndpoint := setupAuthorizationServer(t)
-	// Setup: configure the service
-	service, err := New(Config{
-		FHIR: coolfhir.ClientConfig{
-			BaseURL: "http://example.com",
-		},
-	}, nutsPublicURL, orcaPublicURL, tokenIntrospectionEndpoint, "did:web:example.com")
-	require.NoError(t, err)
-	// Setup: configure the service to handle the protected resource metadata URL
-	serverMux := http.NewServeMux()
-	service.RegisterHandlers(serverMux)
-	server := httptest.NewServer(serverMux)
-
-	httpResponse, err := server.Client().Get(server.URL + "/cps/.well-known/oauth-protected-resource")
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, httpResponse.StatusCode)
-
 }

--- a/orchestrator/cmd/config.go
+++ b/orchestrator/cmd/config.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor"
 	"github.com/SanteonNL/orca/orchestrator/careplanservice"
+	"github.com/SanteonNL/orca/orchestrator/cmd/profile/nuts"
 	koanf "github.com/knadh/koanf/v2"
 	"net/url"
 	"strings"
@@ -14,7 +15,7 @@ import (
 
 type Config struct {
 	// Nuts holds the configuration for communicating with the Nuts API.
-	Nuts NutsConfig `koanf:"nuts"`
+	Nuts nuts.Config `koanf:"nuts"`
 	// Public holds the configuration for the public interface.
 	Public InterfaceConfig `koanf:"public"`
 	// CarePlanContributor holds the configuration for the CarePlanContributor.
@@ -26,7 +27,7 @@ type Config struct {
 
 func (c Config) Validate() error {
 	_, err := url.Parse(c.Nuts.API.URL)
-	if c.Nuts.OwnDID == "" {
+	if c.Nuts.OwnSubject == "" {
 		return errors.New("invalid/empty Nuts DID")
 	}
 	if err != nil || c.Nuts.API.URL == "" {
@@ -59,30 +60,6 @@ type InterfaceConfig struct {
 
 func (i InterfaceConfig) ParseURL() *url.URL {
 	u, _ := url.Parse(i.URL)
-	return u
-}
-
-type NutsConfig struct {
-	API    NutsAPIConfig    `koanf:"api"`
-	Public NutsPublicConfig `koanf:"public"`
-	OwnDID string           `koanf:"did"`
-}
-
-type NutsPublicConfig struct {
-	URL string `koanf:"url"`
-}
-
-func (c NutsPublicConfig) Parse() *url.URL {
-	u, _ := url.Parse(c.URL)
-	return u
-}
-
-type NutsAPIConfig struct {
-	URL string `koanf:"url"`
-}
-
-func (n NutsAPIConfig) Parse() *url.URL {
-	u, _ := url.Parse(n.URL)
 	return u
 }
 

--- a/orchestrator/cmd/profile/nuts/auth.go
+++ b/orchestrator/cmd/profile/nuts/auth.go
@@ -1,0 +1,77 @@
+package nuts
+
+import (
+	"errors"
+	"github.com/SanteonNL/nuts-policy-enforcement-point/middleware"
+	"github.com/SanteonNL/orca/orchestrator/lib/auth"
+	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
+	"github.com/SanteonNL/orca/orchestrator/lib/to"
+	"github.com/rs/zerolog/log"
+	"github.com/samply/golang-fhir-models/fhir-models/fhir"
+	"net/http"
+	"net/url"
+)
+
+var tokenIntrospectionClient = http.DefaultClient
+
+// Authenticator authenticates the caller according to the Nuts authentication.
+// The caller is required to provide an OAuth2 access token in the Authorization header, which is introspected at the Nuts node.
+// The result is then mapped to a FHIR Organization resource, using Dutch coding systems (URA).
+func (d DutchNutsProfile) Authenticator(resourceServerURL *url.URL, fn func(writer http.ResponseWriter, request *http.Request)) func(writer http.ResponseWriter, request *http.Request) {
+	authConfig := middleware.Config{
+		TokenIntrospectionEndpoint: d.Config.API.Parse().JoinPath("internal/auth/v2/accesstoken/introspect").String(),
+		TokenIntrospectionClient:   tokenIntrospectionClient,
+		BaseURL:                    resourceServerURL,
+	}
+	return middleware.Secure(authConfig, func(response http.ResponseWriter, request *http.Request) {
+		userInfo := middleware.UserInfo(request.Context())
+		if userInfo == nil {
+			// would be weird, should've been handled by middleware.Secure()
+			log.Error().Msg("User info not found in context")
+			http.Error(response, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+
+		organization, err := claimsToOrganization(userInfo)
+		if err != nil {
+			log.Error().Err(err).Msg("Invalid user info in context")
+			http.Error(response, "Unauthorized", http.StatusUnauthorized)
+			return
+		}
+		principal := auth.Principal{
+			Organization: *organization,
+		}
+		log.Info().Msgf("Authenticated user: %v", principal)
+		fn(response, request.WithContext(auth.WithPrincipal(request.Context(), principal)))
+	})
+}
+
+func claimsToOrganization(claims map[string]interface{}) (*fhir.Organization, error) {
+	ura, ok := claims["organization_ura"].(string)
+	if !ok || ura == "" {
+		return nil, errors.New("missing organization_ura claim in user info")
+	}
+	name, ok := claims["organization_name"].(string)
+	if !ok || ura == "" {
+		return nil, errors.New("missing organization_name claim in user info")
+	}
+	city, ok := claims["organization_city"].(string)
+	if !ok || ura == "" {
+		return nil, errors.New("missing organization_city claim in user info")
+	}
+
+	return &fhir.Organization{
+		Identifier: []fhir.Identifier{
+			{
+				System: to.Ptr(coolfhir.URANamingSystem),
+				Value:  to.Ptr(ura),
+			},
+		},
+		Name: to.Ptr(name),
+		Address: []fhir.Address{
+			{
+				City: to.Ptr(city),
+			},
+		},
+	}, nil
+}

--- a/orchestrator/cmd/profile/nuts/auth_test.go
+++ b/orchestrator/cmd/profile/nuts/auth_test.go
@@ -1,0 +1,97 @@
+package nuts
+
+import (
+	"encoding/json"
+	"github.com/SanteonNL/orca/orchestrator/lib/auth"
+	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestDutchNutsProfile_Authenticator(t *testing.T) {
+	introspectionEndpoint := setupAuthorizationServer(t)
+	resourceServerURL, _ := url.Parse("http://example.com/resource")
+	t.Run("authenticated", func(t *testing.T) {
+		profile := DutchNutsProfile{
+			Config: Config{
+				API: APIConfig{
+					URL: introspectionEndpoint.String(),
+				},
+			},
+		}
+
+		var capturedPrincipal auth.Principal
+		var capturedError error
+		handler := profile.Authenticator(resourceServerURL, func(writer http.ResponseWriter, request *http.Request) {
+			capturedPrincipal, capturedError = auth.PrincipalFromContext(request.Context())
+			_, _ = io.ReadAll(request.Body)
+			writer.WriteHeader(http.StatusOK)
+		})
+		httpRequest := httptest.NewRequest("GET", "/", nil)
+		httpRequest.Header.Add("Authorization", "Bearer valid")
+
+		handler(httptest.NewRecorder(), httpRequest)
+
+		require.NoError(t, capturedError)
+		require.Equal(t, *capturedPrincipal.Organization.Name, "Hospital")
+		require.Len(t, capturedPrincipal.Organization.Identifier, 1)
+		require.Equal(t, *capturedPrincipal.Organization.Identifier[0].System, coolfhir.URANamingSystem)
+		require.Equal(t, *capturedPrincipal.Organization.Identifier[0].Value, "1")
+		require.Len(t, capturedPrincipal.Organization.Address, 1)
+		require.Equal(t, *capturedPrincipal.Organization.Address[0].City, "CareTown")
+	})
+	t.Run("invalid token", func(t *testing.T) {
+		profile := DutchNutsProfile{
+			Config: Config{
+				API: APIConfig{
+					URL: introspectionEndpoint.String(),
+				},
+			},
+		}
+
+		var capturedError error
+		handler := profile.Authenticator(resourceServerURL, func(writer http.ResponseWriter, request *http.Request) {
+			assert.Fail(t, "Should not reach here")
+		})
+		httpRequest := httptest.NewRequest("GET", "/", nil)
+		httpRequest.Header.Add("Authorization", "Bearer invalid")
+		httpResponse := httptest.NewRecorder()
+
+		handler(httpResponse, httpRequest)
+
+		require.NoError(t, capturedError)
+		require.Equal(t, http.StatusUnauthorized, httpResponse.Code)
+	})
+}
+
+// setupAuthorizationServer starts a test OAuth2 authorization server and returns its OAuth2 Token Introspection URL.
+func setupAuthorizationServer(t *testing.T) *url.URL {
+	authorizationServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		requestData, _ := io.ReadAll(request.Body)
+		switch string(requestData) {
+		case "token=valid":
+			writer.Header().Set("Content-Type", "application/json")
+			responseData, _ := json.Marshal(map[string]interface{}{
+				"active":            true,
+				"organization_ura":  "1",
+				"organization_name": "Hospital",
+				"organization_city": "CareTown",
+			})
+			writer.WriteHeader(http.StatusOK)
+			_, _ = writer.Write(responseData)
+		default:
+			writer.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+	}))
+	t.Cleanup(func() {
+		authorizationServer.Close()
+	})
+	u, _ := url.Parse(authorizationServer.URL)
+	return u
+}

--- a/orchestrator/cmd/profile/nuts/config.go
+++ b/orchestrator/cmd/profile/nuts/config.go
@@ -1,0 +1,27 @@
+package nuts
+
+import "net/url"
+
+type Config struct {
+	API        APIConfig    `koanf:"api"`
+	Public     PublicConfig `koanf:"public"`
+	OwnSubject string       `koanf:"subject"`
+}
+
+type PublicConfig struct {
+	URL string `koanf:"url"`
+}
+
+func (c PublicConfig) Parse() *url.URL {
+	u, _ := url.Parse(c.URL)
+	return u
+}
+
+type APIConfig struct {
+	URL string `koanf:"url"`
+}
+
+func (n APIConfig) Parse() *url.URL {
+	u, _ := url.Parse(n.URL)
+	return u
+}

--- a/orchestrator/cmd/profile/nuts/csd_test.go
+++ b/orchestrator/cmd/profile/nuts/csd_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 )
 
-func TestNutsDirectory_LookupEndpoint(t *testing.T) {
+func TestCsdDirectory_LookupEndpoint(t *testing.T) {
 	ownerUnsupportedCodingSystem := fhir.Identifier{
 		System: to.Ptr("custom"),
 		Value:  to.Ptr("123456789"),
@@ -46,7 +46,7 @@ func TestNutsDirectory_LookupEndpoint(t *testing.T) {
 	})
 	discoveryServer := httptest.NewServer(discoveryServerRouter)
 	apiClient, _ := discovery.NewClientWithResponses(discoveryServer.URL)
-	directory := NutsDirectory{
+	directory := CsdDirectory{
 		IdentifierCredentialMapping: map[string]string{
 			"http://fhir.nl/fhir/NamingSystem/ura": "credentialSubject.organization.ura", // URACredential
 		},

--- a/orchestrator/cmd/profile/nuts/httpclient.go
+++ b/orchestrator/cmd/profile/nuts/httpclient.go
@@ -1,0 +1,24 @@
+package nuts
+
+import (
+	"github.com/SanteonNL/orca/orchestrator/careplancontributor"
+	"github.com/nuts-foundation/go-nuts-client/nuts"
+	"github.com/nuts-foundation/go-nuts-client/oauth2"
+	"net/http"
+)
+
+func (d DutchNutsProfile) HttpClient() *http.Client {
+	return &http.Client{
+		Transport: &oauth2.Transport{
+			TokenSource: nuts.OAuth2TokenSource{
+				OwnDID:     d.Config.OwnSubject,
+				NutsAPIURL: d.Config.API.URL,
+			},
+			MetadataLoader: &oauth2.MetadataLoader{},
+			AuthzServerLocators: []oauth2.AuthorizationServerLocator{
+				oauth2.ProtectedResourceMetadataLocator,
+			},
+			Scope: careplancontributor.CarePlanServiceOAuth2Scope,
+		},
+	}
+}

--- a/orchestrator/cmd/profile/nuts/profile.go
+++ b/orchestrator/cmd/profile/nuts/profile.go
@@ -1,0 +1,30 @@
+package nuts
+
+import (
+	"encoding/json"
+	"github.com/nuts-foundation/go-nuts-client/oauth2"
+	"net/http"
+	"net/url"
+	"path"
+)
+
+// DutchNutsProfile is the Profile for running the SCP-node using the Nuts, with Dutch Verifiable Credential configuration and code systems.
+// - Authentication: Nuts RFC021 Access Tokens
+// - Care Services Discovery: Nuts Discovery Service
+type DutchNutsProfile struct {
+	Config Config
+}
+
+// RegisterHTTPHandlers registers an
+func (d DutchNutsProfile) RegisterHTTPHandlers(basePath string, resourceServerURL *url.URL, mux *http.ServeMux) {
+	mux.HandleFunc("GET "+path.Join("/", basePath, "/.well-known/oauth-protected-resource"), func(writer http.ResponseWriter, request *http.Request) {
+		writer.Header().Add("Content-Type", "application/json")
+		writer.WriteHeader(http.StatusOK)
+		md := oauth2.ProtectedResourceMetadata{
+			Resource:               resourceServerURL.String(),
+			AuthorizationServers:   []string{d.Config.Public.Parse().JoinPath("oauth2", d.Config.OwnSubject).String()},
+			BearerMethodsSupported: []string{"header"},
+		}
+		_ = json.NewEncoder(writer).Encode(md)
+	})
+}

--- a/orchestrator/cmd/profile/nuts/profile_test.go
+++ b/orchestrator/cmd/profile/nuts/profile_test.go
@@ -1,0 +1,25 @@
+package nuts
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestDutchNutsProfile_RegisterHTTPHandlers(t *testing.T) {
+	const basePath = "/basement"
+	var baseURL, _ = url.Parse("http://example.com" + basePath)
+	serverMux := http.NewServeMux()
+	DutchNutsProfile{}.RegisterHTTPHandlers("/basement", baseURL, serverMux)
+	server := httptest.NewServer(serverMux)
+
+	httpResponse, err := http.Get(server.URL + "/basement/.well-known/oauth-protected-resource")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, httpResponse.StatusCode)
+	data, _ := io.ReadAll(httpResponse.Body)
+	assert.JSONEq(t, `{"resource":"http://example.com/basement","authorization_servers":["oauth2"],"bearer_methods_supported":["header"]}`, string(data))
+}

--- a/orchestrator/cmd/profile/profile.go
+++ b/orchestrator/cmd/profile/profile.go
@@ -1,0 +1,24 @@
+package profile
+
+import (
+	"github.com/SanteonNL/orca/orchestrator/lib/csd"
+	"net/http"
+	"net/url"
+)
+
+type Provider interface {
+	// Authenticator returns a middleware http.HandlerFunc that authenticates the caller according to the profile's authentication method.
+	// It sets the authenticate user as auth.Principal in the request context.
+	// The resourceServerURL is the external base URL of the resource being accessed.
+	Authenticator(resourceServerURL *url.URL, fn func(writer http.ResponseWriter, request *http.Request)) func(writer http.ResponseWriter, request *http.Request)
+	// RegisterHTTPHandlers register's the Profile's custom HTTP handlers on the given router.
+	// The resourceServerURL and basePath are there to support multiple contexts (e.g. CarePlanContributor and CarePlanService), for instance:
+	// resourceServerURL: https://example.com/cpc
+	// basePath: /cpc
+	RegisterHTTPHandlers(basePath string, resourceServerURL *url.URL, mux *http.ServeMux)
+	// HttpClient returns an HTTP Client that can be used to perform Shared Care Planning transactions at a Care Plan Contributor or Care Plan Service.
+	// The HTTP client handles acquiring the required authentication credentials (e.g. OAuth2 access tokens).
+	HttpClient() *http.Client
+	// CsdDirectory returns the directory service for finding endpoints and organizations through Care Service Discovery (IHE-CSD).
+	CsdDirectory() csd.Directory
+}

--- a/orchestrator/cmd/profile/test.go
+++ b/orchestrator/cmd/profile/test.go
@@ -1,0 +1,73 @@
+package profile
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"github.com/SanteonNL/orca/orchestrator/lib/auth"
+	"github.com/SanteonNL/orca/orchestrator/lib/csd"
+	"github.com/samply/golang-fhir-models/fhir-models/fhir"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+var _ Provider = TestProfile{}
+
+// TestProfile is a Profile implementation for testing purposes, that does very basic authentication that asserts the right HTTP Client is used.
+type TestProfile struct {
+	Principal *auth.Principal
+}
+
+func (t TestProfile) CsdDirectory() csd.Directory {
+	panic("implement me")
+}
+
+func (t TestProfile) Authenticator(_ *url.URL, fn func(writer http.ResponseWriter, request *http.Request)) func(writer http.ResponseWriter, request *http.Request) {
+	return func(writer http.ResponseWriter, request *http.Request) {
+		authHeader := request.Header.Get("Authorization")
+		if authHeader == "" {
+			writer.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		// Parse auth header
+		if !strings.HasPrefix(authHeader, "Bearer ") {
+			println("Authentication header does not start with 'Bearer '")
+			writer.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		accessToken := authHeader[len("Bearer "):]
+		data, err := base64.StdEncoding.DecodeString(accessToken)
+		if err != nil {
+			println(err)
+			writer.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		var user fhir.Organization
+		err = json.Unmarshal(data, &user)
+		if err != nil {
+			println(err)
+			writer.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		request = request.WithContext(auth.WithPrincipal(request.Context(), auth.Principal{
+			Organization: user,
+		}))
+		fn(writer, request)
+	}
+}
+
+func (t TestProfile) RegisterHTTPHandlers(_ string, _ *url.URL, _ *http.ServeMux) {
+
+}
+
+func (t TestProfile) HttpClient() *http.Client {
+	var principal *auth.Principal
+	if t.Principal == nil {
+		principal = auth.TestPrincipal1
+	} else {
+		principal = t.Principal
+	}
+	return &http.Client{
+		Transport: auth.AuthenticatedTestRoundTripper(nil, principal),
+	}
+}

--- a/orchestrator/cmd/server.go
+++ b/orchestrator/cmd/server.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"github.com/SanteonNL/orca/orchestrator/cmd/profile"
+	"github.com/SanteonNL/orca/orchestrator/cmd/profile/nuts"
 	"net/http"
 
 	"github.com/SanteonNL/orca/orchestrator/applaunch/demo"
@@ -11,8 +13,6 @@ import (
 	"github.com/SanteonNL/orca/orchestrator/careplanservice"
 	"github.com/SanteonNL/orca/orchestrator/healthcheck"
 	"github.com/SanteonNL/orca/orchestrator/user"
-	"github.com/nuts-foundation/go-nuts-client/nuts"
-	"github.com/nuts-foundation/go-nuts-client/oauth2"
 )
 
 func Start(config Config) error {
@@ -27,34 +27,21 @@ func Start(config Config) error {
 	if err := config.Validate(); err != nil {
 		return err
 	}
-	nutsOAuth2HttpClient := &http.Client{
-		Transport: &oauth2.Transport{
-			TokenSource: nuts.OAuth2TokenSource{
-				OwnDID:     config.Nuts.OwnDID,
-				NutsAPIURL: config.Nuts.API.URL,
-			},
-			MetadataLoader: &oauth2.MetadataLoader{},
-			AuthzServerLocators: []oauth2.AuthorizationServerLocator{
-				oauth2.ProtectedResourceMetadataLocator,
-			},
-			Scope: careplancontributor.CarePlanServiceOAuth2Scope,
-		},
-	}
 
 	// Register services
 	var services []Service
 
 	services = append(services, healthcheck.New())
 
+	var activeProfile profile.Provider = nuts.DutchNutsProfile{
+		Config: config.Nuts,
+	}
 	if config.CarePlanContributor.Enabled {
 		carePlanContributor, err := careplancontributor.New(
 			config.CarePlanContributor,
-			config.Nuts.Public.Parse(),
+			activeProfile,
 			config.Public.ParseURL(),
-			config.Nuts.API.Parse(),
-			config.Nuts.OwnDID,
-			sessionManager,
-			nutsOAuth2HttpClient)
+			sessionManager)
 		if err != nil {
 			return err
 		}
@@ -66,8 +53,7 @@ func Start(config Config) error {
 		}
 	}
 	if config.CarePlanService.Enabled {
-		carePlanService, err := careplanservice.New(config.CarePlanService, config.Nuts.Public.Parse(),
-			config.Public.ParseURL(), config.Nuts.API.Parse(), config.Nuts.OwnDID)
+		carePlanService, err := careplanservice.New(config.CarePlanService, activeProfile, config.Public.ParseURL())
 		if err != nil {
 			return fmt.Errorf("failed to create CarePlanService: %w", err)
 		}

--- a/orchestrator/lib/auth/auth.go
+++ b/orchestrator/lib/auth/auth.go
@@ -4,12 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/SanteonNL/nuts-policy-enforcement-point/middleware"
-	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
-	"github.com/SanteonNL/orca/orchestrator/lib/to"
-	"github.com/rs/zerolog/log"
 	"github.com/samply/golang-fhir-models/fhir-models/fhir"
-	"net/http"
 )
 
 type principalContextKeyType struct{}
@@ -17,34 +12,6 @@ type principalContextKeyType struct{}
 var principalContextKey = principalContextKeyType{}
 
 var ErrNotAuthenticated = errors.New("not authenticated")
-
-// Middleware returns a http.HandlerFunc that retrieves the user info from the request header.
-// The user info is to be provided by an API Gateway/reverse proxy that validated the authentication token in the request.
-// It sets the decoded user info in the request context.
-func Middleware(authConfig middleware.Config, fn http.HandlerFunc) func(writer http.ResponseWriter, request *http.Request) {
-	return middleware.Secure(authConfig, func(response http.ResponseWriter, request *http.Request) {
-		userInfo := middleware.UserInfo(request.Context())
-		if userInfo == nil {
-			// would be weird, should've been handled by middleware.Secure()
-			log.Error().Msg("User info not found in context")
-			http.Error(response, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
-
-		organization, err := claimsToOrganization(userInfo)
-		if err != nil {
-			log.Error().Err(err).Msg("Invalid user info in context")
-			http.Error(response, "Unauthorized", http.StatusUnauthorized)
-			return
-		}
-		principal := Principal{
-			Organization: *organization,
-		}
-		log.Info().Msgf("Authenticated user: %v", principal)
-		newCtx := context.WithValue(request.Context(), principalContextKey, principal)
-		fn(response, request.WithContext(newCtx))
-	})
-}
 
 // PrincipalFromContext returns the principal from the request context.
 func PrincipalFromContext(ctx context.Context) (Principal, error) {
@@ -55,36 +22,8 @@ func PrincipalFromContext(ctx context.Context) (Principal, error) {
 	return principal, nil
 }
 
-func claimsToOrganization(claims map[string]interface{}) (*fhir.Organization, error) {
-	// TODO: these properties are from a specific credential for a specific country (the Netherlands),
-	//       so this should be made configurable.
-	ura, ok := claims["organization_ura"].(string)
-	if !ok || ura == "" {
-		return nil, errors.New("missing organization_ura claim in user info")
-	}
-	name, ok := claims["organization_name"].(string)
-	if !ok || ura == "" {
-		return nil, errors.New("missing organization_name claim in user info")
-	}
-	city, ok := claims["organization_city"].(string)
-	if !ok || ura == "" {
-		return nil, errors.New("missing organization_city claim in user info")
-	}
-
-	return &fhir.Organization{
-		Identifier: []fhir.Identifier{
-			{
-				System: to.Ptr(coolfhir.URANamingSystem),
-				Value:  to.Ptr(ura),
-			},
-		},
-		Name: to.Ptr(name),
-		Address: []fhir.Address{
-			{
-				City: to.Ptr(city),
-			},
-		},
-	}, nil
+func WithPrincipal(ctx context.Context, principal Principal) context.Context {
+	return context.WithValue(ctx, principalContextKey, principal)
 }
 
 var _ fmt.Stringer = Principal{}

--- a/orchestrator/lib/auth/test.go
+++ b/orchestrator/lib/auth/test.go
@@ -1,37 +1,77 @@
 package auth
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
+	"github.com/SanteonNL/orca/orchestrator/lib/to"
+	"github.com/samply/golang-fhir-models/fhir-models/fhir"
 	"net/http"
 )
 
+var TestPrincipal1 = &Principal{
+	Organization: fhir.Organization{
+		Name: to.Ptr("Test Organization 1"),
+		Identifier: []fhir.Identifier{
+			{
+				System: to.Ptr(coolfhir.URANamingSystem),
+				Value:  to.Ptr("1"),
+			},
+		},
+		Address: []fhir.Address{
+			{
+				City: to.Ptr("Bugland"),
+			},
+		},
+	},
+}
+
+var TestPrincipal2 = &Principal{
+	Organization: fhir.Organization{
+		Name: to.Ptr("Test Organization 2"),
+		Identifier: []fhir.Identifier{
+			{
+				System: to.Ptr(coolfhir.URANamingSystem),
+				Value:  to.Ptr("2"),
+			},
+		},
+		Address: []fhir.Address{
+			{
+				City: to.Ptr("Testland"),
+			},
+		},
+	},
+}
+
 // AuthenticatedTestRoundTripper returns a RoundTripper that adds a X-Userinfo header to the request
 // with static user information. This is useful for testing purposes.
-func AuthenticatedTestRoundTripper(underlying http.RoundTripper, bearerToken string) http.RoundTripper {
+func AuthenticatedTestRoundTripper(underlying http.RoundTripper, principal *Principal) http.RoundTripper {
 	if underlying == nil {
 		underlying = http.DefaultTransport
 	}
 
-	if bearerToken == "" {
-		bearerToken = "Bearer valid"
-	} else {
-		bearerToken = "Bearer " + bearerToken
+	if principal == nil {
+		principal = TestPrincipal1
 	}
-	return headerDecoratorRoundTripper{
+
+	data, _ := json.Marshal(principal.Organization)
+	bearerToken := base64.StdEncoding.EncodeToString(data)
+	return HeaderDecoratorRoundTripper{
 		inner: underlying,
 		header: map[string]string{
-			"Authorization": bearerToken,
+			"Authorization": "Bearer " + bearerToken,
 		},
 	}
 }
 
-var _ http.RoundTripper = headerDecoratorRoundTripper{}
+var _ http.RoundTripper = HeaderDecoratorRoundTripper{}
 
-type headerDecoratorRoundTripper struct {
+type HeaderDecoratorRoundTripper struct {
 	inner  http.RoundTripper
 	header map[string]string
 }
 
-func (h headerDecoratorRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+func (h HeaderDecoratorRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
 	for name, value := range h.header {
 		request.Header.Set(name, value)
 	}

--- a/orchestrator/lib/auth/test.go
+++ b/orchestrator/lib/auth/test.go
@@ -56,7 +56,7 @@ func AuthenticatedTestRoundTripper(underlying http.RoundTripper, principal *Prin
 
 	data, _ := json.Marshal(principal.Organization)
 	bearerToken := base64.StdEncoding.EncodeToString(data)
-	return HeaderDecoratorRoundTripper{
+	return headerDecoratorRoundTripper{
 		inner: underlying,
 		header: map[string]string{
 			"Authorization": "Bearer " + bearerToken,
@@ -64,14 +64,14 @@ func AuthenticatedTestRoundTripper(underlying http.RoundTripper, principal *Prin
 	}
 }
 
-var _ http.RoundTripper = HeaderDecoratorRoundTripper{}
+var _ http.RoundTripper = headerDecoratorRoundTripper{}
 
-type HeaderDecoratorRoundTripper struct {
+type headerDecoratorRoundTripper struct {
 	inner  http.RoundTripper
 	header map[string]string
 }
 
-func (h HeaderDecoratorRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+func (h headerDecoratorRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
 	for name, value := range h.header {
 		request.Header.Set(name, value)
 	}


### PR DESCRIPTION
This PR introduces a `Profile` concept that allows you to "configure" (although it's still in code) how to authenticate and find endpoints of other SCP nodes. The only implementation is "Dutch-Nuts";
- Nuts provides authentication through its OAuth2 access tokens
- Nuts provides CSD endpoint lookup through its Discovery Service
- Dutch provides a mapping of URA naming system to fields in the URACredential, required to find organizations in the Nuts Discovery Service given their URACredential.

This also moves all authentication concerns from tests in the (CPC and CPS) service layer to the profile implementation.