### PR TITLE
e2e tests: use image tag provided by CI

### DIFF
--- a/.github/workflows/orchestrator.yaml
+++ b/.github/workflows/orchestrator.yaml
@@ -92,6 +92,4 @@ jobs:
           go-version: '1.22'
       - name: Run E2E tests
         working-directory: ./e2e-tests
-        run: go test -v ./...
-          
-
+        run: ORCHESTRATOR_IMAGE=${{needs.docker-image.outputs.fully_qualified}} go test -v ./...


### PR DESCRIPTION
Was there previously, got cleaned up by accident.