### PR TITLE
NextJS: allow nextjs' allowedOrigins to be configured

### DIFF
--- a/hospital_simulator/next.config.js
+++ b/hospital_simulator/next.config.js
@@ -1,7 +1,16 @@
 /** @type {import('next').NextConfig} */
+let allowedOrigins = [];
+if (process.env.NEXT_ALLOWED_ORIGINS) {
+    allowedOrigins = process.env.NEXT_ALLOWED_ORIGINS.split(',');
+}
 const nextConfig = {
   reactStrictMode: true,
-  basePath: process.env.NEXT_PUBLIC_BASE_PATH || ""
+  basePath: process.env.NEXT_PUBLIC_BASE_PATH || "",
+  experimental: {
+    serverActions: {
+      allowedOrigins: allowedOrigins,
+    },
+  },
 };
 
 module.exports = nextConfig;

--- a/hospital_simulator/package-lock.json
+++ b/hospital_simulator/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "zorgbijjou-hospital-simualtor",
+  "name": "zorgbijjou-hospital-simulator",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "zorgbijjou-hospital-simualtor",
+      "name": "zorgbijjou-hospital-simulator",
       "version": "0.1.0",
       "dependencies": {
         "@emotion/cache": "11.11.0",

--- a/hospital_simulator/package.json
+++ b/hospital_simulator/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "zorgbijjou-hospital-simualtor",
+  "name": "zorgbijjou-hospital-simulator",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/viewer_simulator/next.config.js
+++ b/viewer_simulator/next.config.js
@@ -1,7 +1,16 @@
 /** @type {import('next').NextConfig} */
+let allowedOrigins = [];
+if (process.env.NEXT_ALLOWED_ORIGINS) {
+  allowedOrigins = process.env.NEXT_ALLOWED_ORIGINS.split(',');
+}
 const nextConfig = {
   reactStrictMode: true,
-  basePath: process.env.NEXT_PUBLIC_BASE_PATH || ""
+  basePath: process.env.NEXT_PUBLIC_BASE_PATH || "",
+  experimental: {
+    serverActions: {
+      allowedOrigins: allowedOrigins,
+    },
+  },
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
Attempt to fix:

```
`x-forwarded-host` header with value `(etc).westeurope.azurecontainerapps.io:443` does not match `origin` header with value `(etc).com` from a f...
```

Refer to https://github.com/vercel/next.js/issues/58295