### PR TITLE
Upgrade to Go 1.23

### DIFF
--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.23-alpine AS build
+FROM golang:1.23.2-alpine AS build
 
 LABEL maintainer="info@reinkrul.nl"
 

--- a/orchestrator/Dockerfile
+++ b/orchestrator/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.22.2-alpine AS build
+FROM golang:1.23-alpine AS build
 
 LABEL maintainer="info@reinkrul.nl"
 

--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -83,7 +83,7 @@ func (s Service) RegisterHandlers(mux *http.ServeMux) {
 		log.Info().Msg("TODO: Handle received notification")
 		writer.WriteHeader(http.StatusOK)
 	}))
-	mux.HandleFunc(fmt.Sprintf("GET %s/fhir/*", basePath), s.profile.Authenticator(baseURL, func(writer http.ResponseWriter, request *http.Request) {
+	mux.HandleFunc(fmt.Sprintf("GET %s/fhir/{rest...}", basePath), s.profile.Authenticator(baseURL, func(writer http.ResponseWriter, request *http.Request) {
 		err := s.handleProxyToFHIR(writer, request)
 		if err != nil {
 			coolfhir.WriteOperationOutcomeFromError(err, fmt.Sprintf("CarePlanContributer/%s %s", request.Method, request.URL.Path), writer)
@@ -94,9 +94,9 @@ func (s Service) RegisterHandlers(mux *http.ServeMux) {
 	// FE/Session Authorized Endpoints
 	//
 	mux.HandleFunc("GET "+basePath+"/context", s.withSession(s.handleGetContext))
-	mux.HandleFunc(basePath+"/ehr/fhir/*", s.withSession(s.handleProxyToEPD))
+	mux.HandleFunc(basePath+"/ehr/fhir/{rest...}", s.withSession(s.handleProxyToEPD))
 	carePlanServiceProxy := coolfhir.NewProxy(log.Logger, s.carePlanServiceURL, basePath+"/cps/fhir", s.scpHttpClient.Transport)
-	mux.HandleFunc(basePath+"/cps/fhir/*", s.withSessionOrBearerToken(func(writer http.ResponseWriter, request *http.Request) {
+	mux.HandleFunc(basePath+"/cps/fhir/{rest...}", s.withSessionOrBearerToken(func(writer http.ResponseWriter, request *http.Request) {
 		carePlanServiceProxy.ServeHTTP(writer, request)
 	}))
 	mux.HandleFunc(basePath+"/", func(response http.ResponseWriter, request *http.Request) {

--- a/orchestrator/careplancontributor/service_test.go
+++ b/orchestrator/careplancontributor/service_test.go
@@ -102,7 +102,7 @@ func TestService_Proxy_CarePlanNotFound_Fails(t *testing.T) {
 
 	capturedURL := ""
 	carePlanServiceMux := http.NewServeMux()
-	carePlanServiceMux.HandleFunc("GET /cps/*", func(writer http.ResponseWriter, request *http.Request) {
+	carePlanServiceMux.HandleFunc("GET /cps/{rest...}", func(writer http.ResponseWriter, request *http.Request) {
 		capturedURL = request.URL.String()
 		rawJson, _ := os.ReadFile("./testdata/careplan-bundle-not-found.json")
 		var data fhir.Bundle
@@ -152,7 +152,7 @@ func TestService_Proxy_CareTeamNotPresent_Fails(t *testing.T) {
 
 	capturedURL := ""
 	carePlanServiceMux := http.NewServeMux()
-	carePlanServiceMux.HandleFunc("GET /cps/*", func(writer http.ResponseWriter, request *http.Request) {
+	carePlanServiceMux.HandleFunc("GET /cps/{rest...}", func(writer http.ResponseWriter, request *http.Request) {
 		capturedURL = request.URL.String()
 		rawJson, _ := os.ReadFile("./testdata/careplan-bundle-careteam-missing.json")
 		var data fhir.Bundle
@@ -202,7 +202,7 @@ func TestService_Proxy_RequesterNotInCareTeam_Fails(t *testing.T) {
 
 	capturedURL := ""
 	carePlanServiceMux := http.NewServeMux()
-	carePlanServiceMux.HandleFunc("GET /cps/*", func(writer http.ResponseWriter, request *http.Request) {
+	carePlanServiceMux.HandleFunc("GET /cps/{rest...}", func(writer http.ResponseWriter, request *http.Request) {
 		capturedURL = request.URL.String()
 		rawJson, _ := os.ReadFile("./testdata/careplan-bundle-valid.json")
 		var data fhir.Bundle
@@ -254,7 +254,7 @@ func TestService_Proxy_Valid(t *testing.T) {
 
 	capturedURL := ""
 	carePlanServiceMux := http.NewServeMux()
-	carePlanServiceMux.HandleFunc("GET /cps/*", func(writer http.ResponseWriter, request *http.Request) {
+	carePlanServiceMux.HandleFunc("GET /cps/{rest...}", func(writer http.ResponseWriter, request *http.Request) {
 		capturedURL = request.URL.String()
 		rawJson, _ := os.ReadFile("./testdata/careplan-bundle-valid.json")
 		var data fhir.Bundle
@@ -307,7 +307,7 @@ func TestService_Proxy_ProxyReturnsError_Fails(t *testing.T) {
 
 	capturedURL := ""
 	carePlanServiceMux := http.NewServeMux()
-	carePlanServiceMux.HandleFunc("GET /cps/*", func(writer http.ResponseWriter, request *http.Request) {
+	carePlanServiceMux.HandleFunc("GET /cps/{rest...}", func(writer http.ResponseWriter, request *http.Request) {
 		capturedURL = request.URL.String()
 		rawJson, _ := os.ReadFile("./testdata/careplan-bundle-valid.json")
 		var data fhir.Bundle
@@ -357,7 +357,7 @@ func TestService_Proxy_CareTeamMemberInvalidPeriod_Fails(t *testing.T) {
 
 	capturedURL := ""
 	carePlanServiceMux := http.NewServeMux()
-	carePlanServiceMux.HandleFunc("GET /cps/*", func(writer http.ResponseWriter, request *http.Request) {
+	carePlanServiceMux.HandleFunc("GET /cps/{rest...}", func(writer http.ResponseWriter, request *http.Request) {
 		capturedURL = request.URL.String()
 		rawJson, _ := os.ReadFile("./testdata/careplan-bundle-valid.json")
 		var data fhir.Bundle

--- a/orchestrator/careplanservice/service.go
+++ b/orchestrator/careplanservice/service.go
@@ -90,7 +90,7 @@ func (s Service) RegisterHandlers(mux *http.ServeMux) {
 			return
 		}
 	}))
-	mux.HandleFunc(basePath+"/*", s.profile.Authenticator(baseURL, func(writer http.ResponseWriter, request *http.Request) {
+	mux.HandleFunc(basePath+"/{rest...}", s.profile.Authenticator(baseURL, func(writer http.ResponseWriter, request *http.Request) {
 
 		if request.Method == http.MethodPost && request.URL.Path == basePath+"/" {
 			err := s.handleBundle(writer, request)

--- a/orchestrator/go.mod
+++ b/orchestrator/go.mod
@@ -1,6 +1,6 @@
 module github.com/SanteonNL/orca/orchestrator
 
-go 1.22.2
+go 1.23
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.12.0

--- a/orchestrator/lib/coolfhir/proxy_test.go
+++ b/orchestrator/lib/coolfhir/proxy_test.go
@@ -41,7 +41,7 @@ func TestProxy(t *testing.T) {
 		},
 	})
 	proxyServer := httptest.NewServer(proxyServerMux)
-	proxyServerMux.HandleFunc("/localfhir/*", proxy.ServeHTTP)
+	proxyServerMux.HandleFunc("/localfhir/{rest...}", proxy.ServeHTTP)
 
 	t.Run("base request", func(t *testing.T) {
 		httpRequest, _ := http.NewRequest("GET", proxyServer.URL+"/localfhir/Patient", nil)


### PR DESCRIPTION
We need to stay cool.

Had to change URL routing wildcard paths, since it apparently changed in 1.23.