### PR TITLE
Align FHIR notification URL Discovery Service parameter 

### DIFF
--- a/e2e-tests/config/nuts/discovery/homemonitoring.json
+++ b/e2e-tests/config/nuts/discovery/homemonitoring.json
@@ -71,6 +71,34 @@
             }
           ]
         }
+      },
+      {
+        "id": "id_registration_parameters_credential",
+        "name": "Registration parameters",
+        "purpose": "Finding endpoints registered by the care organization.",
+        "constraints": {
+          "fields": [
+            {
+              "path": [
+                "$.type"
+              ],
+              "filter": {
+                "type": "string",
+                "const": "DiscoveryRegistrationCredential"
+              }
+            },
+            {
+              "id": "fhir_notification_url",
+              "purpose": "FHIR subscription REST channel endpoint, issued by SCP-nodes notify about FHIR resources.",
+              "path": [
+                "$.credentialSubject.fhirNotificationURL"
+              ],
+              "filter": {
+                "type": "string"
+              }
+            }
+          ]
+        }
       }
     ]
   }

--- a/e2e-tests/nuts.go
+++ b/e2e-tests/nuts.go
@@ -22,7 +22,7 @@ func setupNutsNode(t *testing.T, dockerNetworkName string) (string, string) {
 	println("Starting Nuts node...")
 	ctx := context.Background()
 	req := testcontainers.ContainerRequest{
-		Image:        "nutsfoundation/nuts-node:6.0.0-rc.9",
+		Image:        "nutsfoundation/nuts-node:6.0.0-rc.10",
 		Name:         "nutsnode",
 		ExposedPorts: []string{"8080/tcp", "8081/tcp"},
 		Networks:     []string{dockerNetworkName},
@@ -83,8 +83,8 @@ func createNutsIdentity(internalAPI string, subject string, ura int, name string
 func nutsActivateDiscoveryService(internalAPI string, subject string, notificationEndpointURL string) {
 	requestBody, _ := json.Marshal(map[string]interface{}{
 		"registrationParameters": map[string]string{
-			// fhir-notify should be defined by the use case
-			"fhir-notify": notificationEndpointURL,
+			// fhirNotificationURL should be defined by the use case
+			"fhirNotificationURL": notificationEndpointURL,
 		},
 	})
 	httpResponse, err := http.Post(internalAPI+"/internal/discovery/v1/dev:HomeMonitoring2024/"+subject, jsonType, bytes.NewReader(requestBody))

--- a/orchestrator/careplanservice/subscriptions/channels.go
+++ b/orchestrator/careplanservice/subscriptions/channels.go
@@ -57,7 +57,7 @@ type CsdChannelFactory struct {
 }
 
 func (c CsdChannelFactory) Create(ctx context.Context, subscriber fhir.Identifier) (Channel, error) {
-	endpoint, err := c.Directory.LookupEndpoint(ctx, subscriber, "fhir-notify")
+	endpoint, err := c.Directory.LookupEndpoint(ctx, subscriber, "fhirNotificationURL") // fhirNotificationURL
 	if err != nil {
 		return nil, fmt.Errorf("lookup notification endpoint in CSD: %w", err)
 	}


### PR DESCRIPTION
With Service Discovery definition as determined by the use case.

Also requires upgrading Nuts node to rc.10