### PR TITLE
Support Type for Task Owner and Requester being optional

### DIFF
--- a/e2e-tests/main_test.go
+++ b/e2e-tests/main_test.go
@@ -67,14 +67,12 @@ func Test_Main(t *testing.T) {
 						System: to.Ptr(URANamingSystem),
 						Value:  to.Ptr(strconv.Itoa(hospitalURA)),
 					},
-					Type: to.Ptr("Organization"),
 				}
 				task.Owner = &fhir.Reference{
 					Identifier: &fhir.Identifier{
 						System: to.Ptr(URANamingSystem),
 						Value:  to.Ptr(strconv.Itoa(clinicURA)),
 					},
-					Type: to.Ptr("Organization"),
 				}
 				task.Focus = &fhir.Reference{
 					Identifier: &fhir.Identifier{
@@ -100,14 +98,12 @@ func Test_Main(t *testing.T) {
 						System: to.Ptr(URANamingSystem),
 						Value:  to.Ptr(strconv.Itoa(hospitalURA)),
 					},
-					Type: to.Ptr("Organization"),
 				}
 				task.Owner = &fhir.Reference{
 					Identifier: &fhir.Identifier{
 						System: to.Ptr(URANamingSystem),
 						Value:  to.Ptr(strconv.Itoa(clinicURA)),
 					},
-					Type: to.Ptr("Organization"),
 				}
 				task.Focus = &fhir.Reference{
 					Identifier: &fhir.Identifier{

--- a/orchestrator/careplanservice/subscriptions/manager.go
+++ b/orchestrator/careplanservice/subscriptions/manager.go
@@ -44,11 +44,10 @@ func (r DerivingManager) Notify(ctx context.Context, resource interface{}) error
 			Type:      to.Ptr("Task"),
 		}
 		log.Info().Msgf("Notifying subscribers for Task %s", *task.Id)
-		// Owner.Type is optional, if it is null set to empty string so the LogicalReference check doesn't fail
-		if task.Owner.Type == nil {
-			task.Owner.Type = to.Ptr("")
+		isOwnerValid := false
+		if task.Owner != nil {
+			isOwnerValid = coolfhir.IsLogicalIdentifier(task.Owner.Identifier)
 		}
-		isOwnerValid := coolfhir.IsLogicalReference(task.Owner)
 		if isOwnerValid {
 			subscribers = append(subscribers, *task.Owner.Identifier)
 		} else {
@@ -56,14 +55,13 @@ func (r DerivingManager) Notify(ctx context.Context, resource interface{}) error
 			if err != nil {
 				log.Error().Msgf("Failed to marshal owner to JSON: %s", err)
 			} else {
-				log.Warn().Msgf("Owner LogicalReference is invalid: %s", string(ownerJSON))
+				log.Warn().Msgf("Owner LogicalIdentifier is invalid: %s", string(ownerJSON))
 			}
 		}
-		// Requester.Type is optional, if it is null set to empty string so the LogicalReference check doesn't fail
-		if task.Requester.Type == nil {
-			task.Requester.Type = to.Ptr("")
+		isRequesterValid := false
+		if task.Requester != nil {
+			isRequesterValid = coolfhir.IsLogicalIdentifier(task.Requester.Identifier)
 		}
-		isRequesterValid := coolfhir.IsLogicalReference(task.Requester)
 		if isRequesterValid {
 			subscribers = append(subscribers, *task.Requester.Identifier)
 		} else {
@@ -71,7 +69,7 @@ func (r DerivingManager) Notify(ctx context.Context, resource interface{}) error
 			if err != nil {
 				log.Error().Msgf("Failed to marshal requester to JSON: %s", err)
 			} else {
-				log.Warn().Msgf("Requester LogicalReference is invalid: %s", string(requesterJSON))
+				log.Warn().Msgf("Requester LogicalIdentifier is invalid: %s", string(requesterJSON))
 			}
 		}
 	case "CareTeam":

--- a/orchestrator/careplanservice/subscriptions/manager.go
+++ b/orchestrator/careplanservice/subscriptions/manager.go
@@ -44,6 +44,10 @@ func (r DerivingManager) Notify(ctx context.Context, resource interface{}) error
 			Type:      to.Ptr("Task"),
 		}
 		log.Info().Msgf("Notifying subscribers for Task %s", *task.Id)
+		// Owner.Type is optional, if it is null set to empty string so the LogicalReference check doesn't fail
+		if task.Owner.Type == nil {
+			task.Owner.Type = to.Ptr("")
+		}
 		isOwnerValid := coolfhir.IsLogicalReference(task.Owner)
 		if isOwnerValid {
 			subscribers = append(subscribers, *task.Owner.Identifier)
@@ -54,6 +58,10 @@ func (r DerivingManager) Notify(ctx context.Context, resource interface{}) error
 			} else {
 				log.Warn().Msgf("Owner LogicalReference is invalid: %s", string(ownerJSON))
 			}
+		}
+		// Requester.Type is optional, if it is null set to empty string so the LogicalReference check doesn't fail
+		if task.Requester.Type == nil {
+			task.Requester.Type = to.Ptr("")
 		}
 		isRequesterValid := coolfhir.IsLogicalReference(task.Requester)
 		if isRequesterValid {


### PR DESCRIPTION
Check the Owner and Requester identifier directly rather than using the existing `IsLogicalReference` check which requires a type be set 