### PR TITLE
Fix questionnaire subtask filling

### DIFF
--- a/deployments/dev/start.sh
+++ b/deployments/dev/start.sh
@@ -119,7 +119,7 @@ echo "    Hospital DID: $HOSPITAL_DID"
 echo "  Self-issuing an NutsUraCredential"
 issueUraCredential "hospital" "${HOSPITAL_DID}" "4567" "Demo Hospital" "Amsterdam"
 echo "  Registering on Nuts Discovery Service"
-curl -X POST -H "Content-Type: application/json" -d "{\"registrationParameters\":{\"fhirNotificationURL\": \"${HOSPITAL_URL}/fhir/notify\"}}" http://localhost:9081/internal/discovery/v1/dev:HomeMonitoring2024/hospital
+curl -X POST -H "Content-Type: application/json" -d "{\"registrationParameters\":{\"fhirNotificationURL\": \"${HOSPITAL_URL}/orca/cpc/fhir/notify\"}}" http://localhost:9081/internal/discovery/v1/dev:HomeMonitoring2024/hospital
 # TODO: Remove this init when the Questionnaire is provided by the sub-Task.input
 echo "  Waiting for the FHIR server to be ready"
 ./config/init-fhir-resources.sh $HOSPITAL_URL
@@ -141,7 +141,7 @@ echo "    Clinic DID: $CLINIC_DID"
 echo "  Self-issuing an NutsUraCredential"
 issueUraCredential "clinic" "${CLINIC_DID}" "1234" "Demo Clinic" "Utrecht"
 echo "  Registering on Nuts Discovery Service"
-curl -X POST -H "Content-Type: application/json" -d "{\"registrationParameters\":{\"fhirNotificationURL\": \"${CLINIC_URL}/fhir/notify\"}}" http://localhost:8081/internal/discovery/v1/dev:HomeMonitoring2024/clinic
+curl -X POST -H "Content-Type: application/json" -d "{\"registrationParameters\":{\"fhirNotificationURL\": \"${CLINIC_URL}/orca/cpc/fhir/notify\"}}" http://localhost:8081/internal/discovery/v1/dev:HomeMonitoring2024/clinic
 popd
 
 # open orchestrator demo app

--- a/orchestrator/careplancontributor/handle_taskfiller.go
+++ b/orchestrator/careplancontributor/handle_taskfiller.go
@@ -40,7 +40,7 @@ func (s *Service) handleTaskFillerCreate(ctx context.Context, task *fhir.Task) e
 		if err != nil {
 			return err
 		}
-		isOwner, _ := coolfhir.ValidateTaskOwnerAndRequester(task, ids)
+		isOwner, _ := coolfhir.IsIdentifierTaskOwnerAndRequester(task, ids)
 		if !isOwner {
 			log.Info().Msg("Current CPC node is not the task Owner - skipping")
 			return nil
@@ -85,7 +85,7 @@ func (s *Service) handleTaskFillerUpdate(ctx context.Context, task *fhir.Task) e
 	if err != nil {
 		return err
 	}
-	isOwner, _ := coolfhir.ValidateTaskOwnerAndRequester(task, ids)
+	isOwner, _ := coolfhir.IsIdentifierTaskOwnerAndRequester(task, ids)
 
 	return s.createSubTaskOrFinishPrimaryTask(task, false, isOwner)
 

--- a/orchestrator/careplancontributor/handle_taskfiller.go
+++ b/orchestrator/careplancontributor/handle_taskfiller.go
@@ -17,7 +17,7 @@ import (
 func (s *Service) handleTaskFillerCreate(ctx context.Context, task *fhir.Task) error {
 	log.Info().Msgf("Running handleTaskFillerCreate for Task %s", *task.Id)
 
-	if !s.isScpTask(task) {
+	if !coolfhir.IsScpTask(task) {
 		log.Info().Msg("Task is not an SCP Task - skipping")
 		return nil
 	}
@@ -60,7 +60,7 @@ func (s *Service) handleTaskFillerUpdate(ctx context.Context, task *fhir.Task) e
 
 	log.Info().Msg("Running handleTaskFillerUpdate")
 
-	if !s.isScpTask(task) {
+	if !coolfhir.IsScpTask(task) {
 		log.Debug().Msg("Task is not an SCP Task - skipping")
 		return nil
 	}

--- a/orchestrator/careplancontributor/integration_test.go
+++ b/orchestrator/careplancontributor/integration_test.go
@@ -41,6 +41,9 @@ func Test_Integration_CPCFHIRProxy(t *testing.T) {
 			Intent:    "order",
 			Requester: coolfhir.LogicalReference("Organization", coolfhir.URANamingSystem, "1"),
 			Owner:     coolfhir.LogicalReference("Organization", coolfhir.URANamingSystem, "2"),
+			Meta: &fhir.Meta{
+				Profile: []string{coolfhir.SCPTaskProfile},
+			},
 		}
 
 		err := cpsDataHolder.Create(task, &task)

--- a/orchestrator/careplanservice/handle_createtask.go
+++ b/orchestrator/careplanservice/handle_createtask.go
@@ -108,7 +108,7 @@ func (s *Service) handleCreateTask(ctx context.Context, request FHIRHandlerReque
 		}
 
 		// Different validation logic for an SCP subtask
-		if coolfhir.IsScpTask(&task) && len(task.PartOf) > 0 {
+		if len(task.PartOf) > 0 {
 			if len(task.PartOf) != 1 {
 				return nil, coolfhir.NewErrorWithCode("SCP subtask must have exactly one parent task", http.StatusBadRequest)
 			}

--- a/orchestrator/careplanservice/handle_createtask_test.go
+++ b/orchestrator/careplanservice/handle_createtask_test.go
@@ -408,3 +408,5 @@ func Test_handleCreateTask_ExistingCarePlan(t *testing.T) {
 		})
 	}
 }
+
+// TODO: Unit test for creating an SCP subtask, to be done when refactoring the tests to use HTTP client mocking (too complex to test positive cases with reflection)

--- a/orchestrator/careplanservice/handle_createtask_test.go
+++ b/orchestrator/careplanservice/handle_createtask_test.go
@@ -158,12 +158,41 @@ func Test_handleCreateTask_NoExistingCarePlan(t *testing.T) {
 		},
 		{
 			ctx:  auth.WithPrincipal(context.Background(), *auth.TestPrincipal1),
+			name: "CreateTask - Not SCP Task",
+			taskToCreate: fhir.Task{
+				Intent:    "order",
+				Status:    fhir.TaskStatusRequested,
+				Requester: coolfhir.LogicalReference("Organization", coolfhir.URANamingSystem, "1"),
+				Owner:     coolfhir.LogicalReference("Organization", coolfhir.URANamingSystem, "2"),
+			},
+			createdTask: fhir.Task{
+				Id: to.Ptr("123"),
+				BasedOn: []fhir.Reference{
+					{
+						Type:      to.Ptr("CarePlan"),
+						Reference: to.Ptr("CarePlan/1"),
+					},
+				},
+				Intent:    "order",
+				Status:    fhir.TaskStatusRequested,
+				Requester: coolfhir.LogicalReference("Organization", coolfhir.URANamingSystem, "1"),
+				Owner:     coolfhir.LogicalReference("Organization", coolfhir.URANamingSystem, "2"),
+			},
+			returnedBundle: nil,
+			errorFromRead:  nil,
+			expectError:    true,
+		},
+		{
+			ctx:  auth.WithPrincipal(context.Background(), *auth.TestPrincipal1),
 			name: "CreateTask",
 			taskToCreate: fhir.Task{
 				Intent:    "order",
 				Status:    fhir.TaskStatusRequested,
 				Requester: coolfhir.LogicalReference("Organization", coolfhir.URANamingSystem, "1"),
 				Owner:     coolfhir.LogicalReference("Organization", coolfhir.URANamingSystem, "2"),
+				Meta: &fhir.Meta{
+					Profile: []string{coolfhir.SCPTaskProfile},
+				},
 			},
 			createdTask: fhir.Task{
 				Id: to.Ptr("123"),
@@ -307,6 +336,25 @@ func Test_handleCreateTask_ExistingCarePlan(t *testing.T) {
 		},
 		{
 			ctx:  auth.WithPrincipal(context.Background(), *auth.TestPrincipal1),
+			name: "CreateTask - Not SCP Task",
+			taskToCreate: fhir.Task{
+				BasedOn: []fhir.Reference{
+					{
+						Type:      to.Ptr("CarePlan"),
+						Reference: to.Ptr("CarePlan/999"),
+					},
+				},
+				Intent:    "order",
+				Status:    fhir.TaskStatusRequested,
+				Requester: coolfhir.LogicalReference("Organization", coolfhir.URANamingSystem, "1"),
+				Owner:     coolfhir.LogicalReference("Organization", coolfhir.URANamingSystem, "2"),
+			},
+			returnedBundle: &fhir.Bundle{},
+			errorFromRead:  nil,
+			expectError:    true,
+		},
+		{
+			ctx:  auth.WithPrincipal(context.Background(), *auth.TestPrincipal1),
 			name: "CreateTask - CarePlan not found",
 			taskToCreate: fhir.Task{
 				BasedOn: []fhir.Reference{
@@ -319,6 +367,9 @@ func Test_handleCreateTask_ExistingCarePlan(t *testing.T) {
 				Status:    fhir.TaskStatusRequested,
 				Requester: coolfhir.LogicalReference("Organization", coolfhir.URANamingSystem, "1"),
 				Owner:     coolfhir.LogicalReference("Organization", coolfhir.URANamingSystem, "2"),
+				Meta: &fhir.Meta{
+					Profile: []string{coolfhir.SCPTaskProfile},
+				},
 			},
 			returnedCarePlan:      nil,
 			returnedCarePlanError: errors.New("not found"),
@@ -340,6 +391,9 @@ func Test_handleCreateTask_ExistingCarePlan(t *testing.T) {
 				Status:    fhir.TaskStatusRequested,
 				Requester: coolfhir.LogicalReference("Organization", coolfhir.URANamingSystem, "1"),
 				Owner:     coolfhir.LogicalReference("Organization", coolfhir.URANamingSystem, "2"),
+				Meta: &fhir.Meta{
+					Profile: []string{coolfhir.SCPTaskProfile},
+				},
 			},
 			returnedCarePlan: &fhir.CarePlan{
 				Id: to.Ptr("1"),

--- a/orchestrator/careplanservice/handle_gettask.go
+++ b/orchestrator/careplanservice/handle_gettask.go
@@ -40,7 +40,7 @@ func (s *Service) handleGetTask(ctx context.Context, id string, headers *fhircli
 	}
 
 	// Check if the requester is either the task Owner or Requester, if not, they must be a member of the CareTeam
-	isOwner, isRequester := coolfhir.ValidateTaskOwnerAndRequester(&task, principal.Organization.Identifier)
+	isOwner, isRequester := coolfhir.IsIdentifierTaskOwnerAndRequester(&task, principal.Organization.Identifier)
 	if !(isOwner || isRequester) {
 		_, careTeams, _, err := s.getCarePlanAndCareTeams(*task.BasedOn[0].Reference)
 		if err != nil {
@@ -100,7 +100,7 @@ func (s *Service) handleSearchTask(ctx context.Context, queryParams url.Values, 
 
 	for ref, _ := range refs {
 		for _, task := range tasks {
-			isOwner, isRequester := coolfhir.ValidateTaskOwnerAndRequester(&task, principal.Organization.Identifier)
+			isOwner, isRequester := coolfhir.IsIdentifierTaskOwnerAndRequester(&task, principal.Organization.Identifier)
 			if !(isOwner || isRequester) {
 				_, careTeams, _, err := s.getCarePlanAndCareTeams(ref)
 				if err != nil {

--- a/orchestrator/careplanservice/handle_updatetask.go
+++ b/orchestrator/careplanservice/handle_updatetask.go
@@ -38,7 +38,7 @@ func (s *Service) handleUpdateTask(ctx context.Context, request FHIRHandlerReque
 	if err != nil {
 		return nil, err
 	}
-	isOwner, isRequester := coolfhir.ValidateTaskOwnerAndRequester(&task, principal.Organization.Identifier)
+	isOwner, isRequester := coolfhir.IsIdentifierTaskOwnerAndRequester(&task, principal.Organization.Identifier)
 	if !isValidTransition(taskExisting.Status, task.Status, isOwner, isRequester) {
 		return nil, errors.New(
 			fmt.Sprintf(

--- a/orchestrator/careplanservice/integration_test.go
+++ b/orchestrator/careplanservice/integration_test.go
@@ -266,6 +266,9 @@ func Test_Integration_TaskLifecycle(t *testing.T) {
 			Status:    fhir.TaskStatusRequested,
 			Requester: coolfhir.LogicalReference("Organization", coolfhir.URANamingSystem, "1"),
 			Owner:     coolfhir.LogicalReference("Organization", coolfhir.URANamingSystem, "2"),
+			Meta: &fhir.Meta{
+				Profile: []string{coolfhir.SCPTaskProfile},
+			},
 		}
 
 		err := carePlanContributor1.Create(task, &task)

--- a/orchestrator/lib/coolfhir/util.go
+++ b/orchestrator/lib/coolfhir/util.go
@@ -123,9 +123,9 @@ func ValidateTaskRequiredFields(task fhir.Task) error {
 	return nil
 }
 
-// ValidateTaskOwnerAndRequester checks the owner and requester of a task against the supplied principal
+// IsIdentifierTaskOwnerAndRequester checks the owner and requester of a task against the supplied principal
 // returns 2 booleans, isOwner, and isRequester
-func ValidateTaskOwnerAndRequester(task *fhir.Task, principalOrganizationIdentifier []fhir.Identifier) (bool, bool) {
+func IsIdentifierTaskOwnerAndRequester(task *fhir.Task, principalOrganizationIdentifier []fhir.Identifier) (bool, bool) {
 	isOwner := false
 	if task.Owner != nil {
 		for _, identifier := range principalOrganizationIdentifier {

--- a/orchestrator/lib/coolfhir/util.go
+++ b/orchestrator/lib/coolfhir/util.go
@@ -255,3 +255,17 @@ func HttpMethodToVerb(method string) fhir.HTTPVerb {
 		return 0
 	}
 }
+
+func IsScpTask(task *fhir.Task) bool {
+	if task.Meta == nil {
+		return false
+	}
+
+	for _, profile := range task.Meta.Profile {
+		if profile == SCPTaskProfile {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
Dev testing was broken as we could create tasks but would not see the questionnaire, this was due to the task filler not being notified due to an incorrect endpoint and validation logic that would reject it.

Endpoint has been updated to the correct one, and new validation logic for SCP subtasks has been implemented 