### PR TITLE
[INT-398] If bundle in CarePlan search is empty, return early

### DIFF
--- a/deployments/dev/start.sh
+++ b/deployments/dev/start.sh
@@ -141,7 +141,6 @@ issueUraCredential "clinic" "${CLINIC_DID}" "1234" "Demo Clinic" "Utrecht"
 echo "  Registering on Nuts Discovery Service"
 curl -X POST -H "Content-Type: application/json" -d "{\"registrationParameters\":{\"fhirNotificationURL\": \"${CLINIC_URL}/fhir/notify\"}}" http://localhost:8081/internal/discovery/v1/dev:HomeMonitoring2024/clinic
 echo "  Waiting for the FHIR server to be ready"
-./config/init-fhir-resources.sh $HOSPITAL_URL
 popd
 
 echo "Creating stack for Clinic..."

--- a/orchestrator/careplanservice/handle_getcareplan.go
+++ b/orchestrator/careplanservice/handle_getcareplan.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	fhirclient "github.com/SanteonNL/go-fhir-client"
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
+	"github.com/rs/zerolog/log"
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
 	"net/http"
 	"net/url"
@@ -47,6 +48,12 @@ func (s *Service) handleSearchCarePlan(ctx context.Context, queryParams url.Valu
 	if err != nil {
 		return nil, err
 	}
+
+	if len(bundle.Entry) == 0 {
+		log.Info().Msg("CarePlan search returned empty bundle")
+		return &bundle, nil
+	}
+
 	var careTeams []fhir.CareTeam
 	err = coolfhir.ResourcesInBundle(&bundle, coolfhir.EntryIsOfType("CareTeam"), &careTeams)
 	if err != nil {

--- a/orchestrator/careplanservice/handle_getcareplan.go
+++ b/orchestrator/careplanservice/handle_getcareplan.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	fhirclient "github.com/SanteonNL/go-fhir-client"
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
-	"github.com/rs/zerolog/log"
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
 	"net/http"
 	"net/url"
@@ -50,7 +49,6 @@ func (s *Service) handleSearchCarePlan(ctx context.Context, queryParams url.Valu
 	}
 
 	if len(bundle.Entry) == 0 {
-		log.Info().Msg("CarePlan search returned empty bundle")
 		return &bundle, nil
 	}
 

--- a/orchestrator/careplanservice/handle_gettask_test.go
+++ b/orchestrator/careplanservice/handle_gettask_test.go
@@ -99,10 +99,24 @@ func TestService_handleSearchTask(t *testing.T) {
 	}{
 		{
 			ctx:         context.Background(),
-			name:        "No CareTeam in bundle",
+			name:        "Empty bundle",
 			queryParams: url.Values{},
 			returnedBundle: &fhir.Bundle{
 				Entry: []fhir.BundleEntry{},
+			},
+			errorFromRead: nil,
+			expectError:   false,
+		},
+		{
+			ctx:         context.Background(),
+			name:        "No CareTeam in bundle",
+			queryParams: url.Values{},
+			returnedBundle: &fhir.Bundle{
+				Entry: []fhir.BundleEntry{
+					{
+						Resource: rawCarePlan,
+					},
+				},
 			},
 			errorFromRead: nil,
 			expectError:   true,


### PR DESCRIPTION
We were searching for a CareTeam in an empty bundle, causing failures