### PR TITLE
Changed the taskfiller logic to only handle primary Tasks when its st…

### DIFF
--- a/frontend/lib/store/enrollment-store.ts
+++ b/frontend/lib/store/enrollment-store.ts
@@ -118,7 +118,7 @@ const fetchEhrResources = async (get: () => StoreState, set: (partial: StoreStat
         patient: patient as Patient,
         practitioner: practitioner as Practitioner,
         serviceRequest: serviceRequest as ServiceRequest,
-        patientConditions: allConditions
+        patientConditions: allConditions.filter(condition => condition.resourceType === "Condition")
     });
 
     return patient;

--- a/orchestrator/careplancontributor/testdata/task-1.json
+++ b/orchestrator/careplancontributor/testdata/task-1.json
@@ -1,24 +1,26 @@
 {
-  "id" : "1",
-  "basedOn" : [ {
-    "reference" : "CarePlan/1",
-    "type" : "CarePlan"
-  } ],
-  "status" : "accepted",
-  "intent" : "order",
-  "requester" : {
-    "type" : "Organization",
-    "identifier" : {
-      "system" : "http://fhir.nl/fhir/NamingSystem/ura",
-      "value" : "1"
+  "id": "1",
+  "basedOn": [
+    {
+      "reference": "CarePlan/1",
+      "type": "CarePlan"
+    }
+  ],
+  "status": "requested",
+  "intent": "order",
+  "requester": {
+    "type": "Organization",
+    "identifier": {
+      "system": "http://fhir.nl/fhir/NamingSystem/ura",
+      "value": "1"
     }
   },
-  "owner" : {
-    "type" : "Organization",
-    "identifier" : {
-      "system" : "http://fhir.nl/fhir/NamingSystem/ura",
-      "value" : "2"
+  "owner": {
+    "type": "Organization",
+    "identifier": {
+      "system": "http://fhir.nl/fhir/NamingSystem/ura",
+      "value": "2"
     }
   },
-  "resourceType" : "Task"
+  "resourceType": "Task"
 }

--- a/orchestrator/careplancontributor/testdata/task-2.json
+++ b/orchestrator/careplancontributor/testdata/task-2.json
@@ -1,27 +1,31 @@
 {
-  "id" : "2",
-  "basedOn" : [ {
-    "reference" : "CarePlan/1",
-    "type" : "CarePlan"
-  } ],
-  "status" : "accepted",
-  "intent" : "order",
-  "requester" : {
-    "type" : "Organization",
-    "identifier" : {
-      "system" : "http://fhir.nl/fhir/NamingSystem/ura",
-      "value" : "2"
+  "id": "2",
+  "basedOn": [
+    {
+      "reference": "CarePlan/1",
+      "type": "CarePlan"
+    }
+  ],
+  "status": "requested",
+  "intent": "order",
+  "requester": {
+    "type": "Organization",
+    "identifier": {
+      "system": "http://fhir.nl/fhir/NamingSystem/ura",
+      "value": "2"
     }
   },
-  "owner" : {
-    "type" : "Organization",
-    "identifier" : {
-      "system" : "http://fhir.nl/fhir/NamingSystem/ura",
-      "value" : "1"
+  "owner": {
+    "type": "Organization",
+    "identifier": {
+      "system": "http://fhir.nl/fhir/NamingSystem/ura",
+      "value": "1"
     }
   },
-  "resourceType" : "Task",
-  "meta":  {
-    "profile": ["http://santeonnl.github.io/shared-care-planning/StructureDefinition/SCPTask"]
+  "resourceType": "Task",
+  "meta": {
+    "profile": [
+      "http://santeonnl.github.io/shared-care-planning/StructureDefinition/SCPTask"
+    ]
   }
 }

--- a/orchestrator/careplancontributor/testdata/task-3.json
+++ b/orchestrator/careplancontributor/testdata/task-3.json
@@ -1,33 +1,37 @@
 {
-  "id" : "3",
-  "basedOn" : [ {
-    "reference" : "CarePlan/1",
-    "type" : "CarePlan"
-  } ],
-  "status" : "accepted",
-  "intent" : "order",
-  "requester" : {
-    "type" : "Organization",
-    "identifier" : {
-      "system" : "http://fhir.nl/fhir/NamingSystem/ura",
-      "value" : "1"
+  "id": "3",
+  "basedOn": [
+    {
+      "reference": "CarePlan/1",
+      "type": "CarePlan"
+    }
+  ],
+  "status": "requested",
+  "intent": "order",
+  "requester": {
+    "type": "Organization",
+    "identifier": {
+      "system": "http://fhir.nl/fhir/NamingSystem/ura",
+      "value": "1"
     }
   },
-  "owner" : {
-    "type" : "Organization",
-    "identifier" : {
-      "system" : "http://fhir.nl/fhir/NamingSystem/ura",
-      "value" : "2"
+  "owner": {
+    "type": "Organization",
+    "identifier": {
+      "system": "http://fhir.nl/fhir/NamingSystem/ura",
+      "value": "2"
     }
   },
-  "resourceType" : "Task",
-  "meta":  {
-    "profile": ["http://santeonnl.github.io/shared-care-planning/StructureDefinition/SCPTask"]
+  "resourceType": "Task",
+  "meta": {
+    "profile": [
+      "http://santeonnl.github.io/shared-care-planning/StructureDefinition/SCPTask"
+    ]
   },
   "focus": {
     "identifier": {
       "system": "2.16.528.1.1007.3.3.21514.ehr.orders",
-      "value":  "99534756439"
+      "value": "99534756439"
     }
   },
   "for": {


### PR DESCRIPTION
…atus is `requested`. The taskfiller will create subtasks from the WorkFlow, so it should never do so on updates. The status of the primary task will be updated via completing the final subTask.

I've only updated the `status` in the task files, as SCP tasks are sent to us with the status `requested` according to the SCP spec.