### PR TITLE
[INT-370] Create logout endpoint

### DIFF
--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -134,7 +134,7 @@ func (s Service) RegisterHandlers(mux *http.ServeMux) {
 		s.SessionManager.Destroy(writer, request)
 		// If there is a 'Referrer' value in the header, redirect to that URL
 		if referrer := request.Header.Get("Referrer"); referrer != "" {
-			http.Redirect(writer, request, referrer, http.StatusOK)
+			http.Redirect(writer, request, referrer, http.Found)
 		} else {
 			// This redirection will be handled by middleware in the frontend
 			http.Redirect(writer, request, s.frontendUrl, http.StatusOK)

--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -132,9 +132,9 @@ func (s Service) RegisterHandlers(mux *http.ServeMux) {
 	// Logout endpoint
 	mux.HandleFunc(basePath+"/logout", s.withSession(func(writer http.ResponseWriter, request *http.Request, session *user.SessionData) {
 		s.SessionManager.Destroy(writer, request)
-		// If there is a 'Referrer' value in the header, redirect to that URL
-		if referrer := request.Header.Get("Referrer"); referrer != "" {
-			http.Redirect(writer, request, referrer, http.Found)
+		// If there is a 'Referer' value in the header, redirect to that URL
+		if referer := request.Header.Get("Referer"); referer != "" {
+			http.Redirect(writer, request, referer, http.StatusFound)
 		} else {
 			// This redirection will be handled by middleware in the frontend
 			http.Redirect(writer, request, s.frontendUrl, http.StatusOK)

--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -130,10 +130,16 @@ func (s Service) RegisterHandlers(mux *http.ServeMux) {
 	})
 
 	// Logout endpoint
-	mux.HandleFunc(basePath+"/zorgplatform/logout", func(response http.ResponseWriter, request *http.Request) {
-		s.SessionManager.Destroy(response, request)
-		http.Redirect(response, request, s.frontendUrl, http.StatusOK)
-	})
+	mux.HandleFunc(basePath+"/zorgplatform/logout", s.withSession(func(writer http.ResponseWriter, request *http.Request, session *user.SessionData) {
+		s.SessionManager.Destroy(writer, request)
+		// If there is a 'Referrer' value in the header, redirect to that URL
+		if referrer := request.Header.Get("Referrer"); referrer != "" {
+			http.Redirect(writer, request, referrer, http.StatusOK)
+		} else {
+			// TODO: Redirect to Logout screen
+			http.Redirect(writer, request, s.frontendUrl, http.StatusOK)
+		}
+	}))
 }
 
 // withSession is a middleware that retrieves the session for the given request.

--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -130,13 +130,13 @@ func (s Service) RegisterHandlers(mux *http.ServeMux) {
 	})
 
 	// Logout endpoint
-	mux.HandleFunc(basePath+"/zorgplatform/logout", s.withSession(func(writer http.ResponseWriter, request *http.Request, session *user.SessionData) {
+	mux.HandleFunc(basePath+"/logout", s.withSession(func(writer http.ResponseWriter, request *http.Request, session *user.SessionData) {
 		s.SessionManager.Destroy(writer, request)
 		// If there is a 'Referrer' value in the header, redirect to that URL
 		if referrer := request.Header.Get("Referrer"); referrer != "" {
 			http.Redirect(writer, request, referrer, http.StatusOK)
 		} else {
-			// TODO: Redirect to Logout screen
+			// This redirection will be handled by middleware in the frontend
 			http.Redirect(writer, request, s.frontendUrl, http.StatusOK)
 		}
 	}))

--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -128,6 +128,12 @@ func (s Service) RegisterHandlers(mux *http.ServeMux) {
 		log.Info().Msgf("Redirecting to %s", s.frontendUrl)
 		http.Redirect(response, request, s.frontendUrl, http.StatusFound)
 	})
+
+	// Logout endpoint
+	mux.HandleFunc(basePath+"/zorgplatform/logout", func(response http.ResponseWriter, request *http.Request) {
+		s.SessionManager.Destroy(response, request)
+		http.Redirect(response, request, s.frontendUrl, http.StatusOK)
+	})
 }
 
 // withSession is a middleware that retrieves the session for the given request.

--- a/orchestrator/careplancontributor/service_test.go
+++ b/orchestrator/careplancontributor/service_test.go
@@ -651,6 +651,17 @@ func TestService_ProxyToEHR(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, httpResponse.StatusCode)
 	require.Equal(t, fhirServerURL.Host, capturedHost)
+
+	// Logout and attempt to get the patient again
+	httpRequest, _ = http.NewRequest("POST", frontServer.URL+"/cpc/zorgplatform/logout", nil)
+	httpResponse, err = frontServer.Client().Do(httpRequest)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, httpResponse.StatusCode)
+
+	httpRequest, _ = http.NewRequest("GET", frontServer.URL+"/cpc/ehr/fhir/Patient", nil)
+	httpResponse, err = frontServer.Client().Do(httpRequest)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusUnauthorized, httpResponse.StatusCode)
 }
 
 func TestService_ProxyToCPS(t *testing.T) {
@@ -691,6 +702,17 @@ func TestService_ProxyToCPS(t *testing.T) {
 	require.Equal(t, http.StatusOK, httpResponse.StatusCode)
 	require.Equal(t, carePlanServiceURL.Host, capturedHost)
 	require.Equal(t, "foo:bar", capturedQueryParams.Get("_search"))
+
+	// Logout and attempt to get the patient again
+	httpRequest, _ = http.NewRequest("POST", frontServer.URL+"/cpc/zorgplatform/logout", nil)
+	httpResponse, err = frontServer.Client().Do(httpRequest)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, httpResponse.StatusCode)
+
+	httpRequest, _ = http.NewRequest("GET", frontServer.URL+"/cpc/cps/fhir/Patient?_search=foo:bar", nil)
+	httpResponse, err = frontServer.Client().Do(httpRequest)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusUnauthorized, httpResponse.StatusCode)
 }
 
 func TestService_handleGetContext(t *testing.T) {

--- a/orchestrator/careplancontributor/service_test.go
+++ b/orchestrator/careplancontributor/service_test.go
@@ -653,7 +653,7 @@ func TestService_ProxyToEHR(t *testing.T) {
 	require.Equal(t, fhirServerURL.Host, capturedHost)
 
 	// Logout and attempt to get the patient again
-	httpRequest, _ = http.NewRequest("POST", frontServer.URL+"/cpc/zorgplatform/logout", nil)
+	httpRequest, _ = http.NewRequest("POST", frontServer.URL+"/cpc/logout", nil)
 
 	// Trying to logout without a session cookie should return an error
 	httpResponse, err = frontServer.Client().Do(httpRequest)
@@ -718,7 +718,7 @@ func TestService_ProxyToCPS(t *testing.T) {
 	require.Equal(t, "foo:bar", capturedQueryParams.Get("_search"))
 
 	// Logout and attempt to get the patient again
-	httpRequest, _ = http.NewRequest("POST", frontServer.URL+"/cpc/zorgplatform/logout", nil)
+	httpRequest, _ = http.NewRequest("POST", frontServer.URL+"/cpc/logout", nil)
 	httpRequest.AddCookie(&http.Cookie{
 		Name:  "sid",
 		Value: sessionID,

--- a/orchestrator/careplancontributor/service_test.go
+++ b/orchestrator/careplancontributor/service_test.go
@@ -654,11 +654,25 @@ func TestService_ProxyToEHR(t *testing.T) {
 
 	// Logout and attempt to get the patient again
 	httpRequest, _ = http.NewRequest("POST", frontServer.URL+"/cpc/zorgplatform/logout", nil)
+
+	// Trying to logout without a session cookie should return an error
+	httpResponse, err = frontServer.Client().Do(httpRequest)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusUnauthorized, httpResponse.StatusCode)
+
+	httpRequest.AddCookie(&http.Cookie{
+		Name:  "sid",
+		Value: sessionID,
+	})
 	httpResponse, err = frontServer.Client().Do(httpRequest)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, httpResponse.StatusCode)
 
 	httpRequest, _ = http.NewRequest("GET", frontServer.URL+"/cpc/ehr/fhir/Patient", nil)
+	httpRequest.AddCookie(&http.Cookie{
+		Name:  "sid",
+		Value: sessionID,
+	})
 	httpResponse, err = frontServer.Client().Do(httpRequest)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusUnauthorized, httpResponse.StatusCode)
@@ -705,11 +719,19 @@ func TestService_ProxyToCPS(t *testing.T) {
 
 	// Logout and attempt to get the patient again
 	httpRequest, _ = http.NewRequest("POST", frontServer.URL+"/cpc/zorgplatform/logout", nil)
+	httpRequest.AddCookie(&http.Cookie{
+		Name:  "sid",
+		Value: sessionID,
+	})
 	httpResponse, err = frontServer.Client().Do(httpRequest)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusOK, httpResponse.StatusCode)
 
 	httpRequest, _ = http.NewRequest("GET", frontServer.URL+"/cpc/cps/fhir/Patient?_search=foo:bar", nil)
+	httpRequest.AddCookie(&http.Cookie{
+		Name:  "sid",
+		Value: sessionID,
+	})
 	httpResponse, err = frontServer.Client().Do(httpRequest)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusUnauthorized, httpResponse.StatusCode)

--- a/orchestrator/user/session.go
+++ b/orchestrator/user/session.go
@@ -62,6 +62,20 @@ func (m *SessionManager) Get(request *http.Request) *SessionData {
 	return &session.Data
 }
 
+func (m *SessionManager) Destroy(response http.ResponseWriter, request *http.Request) {
+	sessionID := getSessionCookie(request)
+	if sessionID != "" {
+		m.store.destroy(sessionID)
+	}
+	cookie := http.Cookie{
+		Name:     "sid",
+		Value:    "",
+		HttpOnly: true,
+		Expires:  time.Now().Add(-time.Minute),
+	}
+	http.SetCookie(response, &cookie)
+}
+
 func (s *sessionStore) create(values SessionData) (string, *Session) {
 	s.mux.Lock()
 	defer s.mux.Unlock()
@@ -95,6 +109,12 @@ func (s *sessionStore) prune() {
 			delete(s.sessions, id)
 		}
 	}
+}
+
+func (s *sessionStore) destroy(id string) {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+	delete(s.sessions, id)
 }
 
 func setSessionCookie(sessionID string, response http.ResponseWriter) {

--- a/orchestrator/user/session.go
+++ b/orchestrator/user/session.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
 	"net/http"
 	"sync"
 	"time"
@@ -66,6 +67,8 @@ func (m *SessionManager) Destroy(response http.ResponseWriter, request *http.Req
 	sessionID := getSessionCookie(request)
 	if sessionID != "" {
 		m.store.destroy(sessionID)
+	} else {
+		log.Warn().Msg("No session to destroy")
 	}
 	cookie := http.Cookie{
 		Name:     "sid",

--- a/orchestrator/user/session_test.go
+++ b/orchestrator/user/session_test.go
@@ -1,0 +1,73 @@
+package user
+
+import (
+	"github.com/stretchr/testify/require"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Test_SessionManager_SessionLifecycle tests the lifecycle of a session. It creates a session, retrieves it, deletes it and verifies that it is deleted.
+func Test_SessionManager_SessionLifecycle(t *testing.T) {
+	sessionManager := NewSessionManager()
+	response := httptest.NewRecorder()
+
+	// Create a session
+	sessionManager.Create(response, SessionData{
+		StringValues: map[string]string{
+			"key": "value",
+		},
+	})
+	require.Equal(t, 1, len(sessionManager.store.sessions))
+	require.Equal(t, http.StatusOK, response.Code)
+
+	request := httptest.NewRequest("GET", "/", nil)
+
+	// Get session without cookie returns nil data
+	sessionData := sessionManager.Get(request)
+	require.Nil(t, sessionData)
+
+	request.Header.Set("Cookie", response.Header().Get("Set-Cookie"))
+
+	// Get the session
+	sessionData = sessionManager.Get(request)
+	require.NotNil(t, sessionData)
+	// Check values in the request
+	require.Equal(t, "value", sessionData.StringValues["key"])
+
+	// Create new session to validate that delete only deletes the session in request
+	response = httptest.NewRecorder()
+	sessionManager.Create(response, SessionData{
+		StringValues: map[string]string{
+			"key2": "value2",
+		},
+	})
+	require.Equal(t, 2, len(sessionManager.store.sessions))
+	require.Equal(t, http.StatusOK, response.Code)
+
+	// store the cookie for later
+	cookie := response.Header().Get("Set-Cookie")
+
+	// Delete the first session, using the existing request
+	response = httptest.NewRecorder()
+	sessionManager.Destroy(response, request)
+
+	parts := strings.Split(response.Header().Get("Set-Cookie"), ";")
+	require.Equal(t, "sid=", parts[0])
+	// Verify the expiration date is in the past
+	expiration := strings.TrimPrefix(parts[1], " Expires=")
+	require.NotEmpty(t, expiration)
+	expirationTime, err := http.ParseTime(expiration)
+	require.NoError(t, err)
+	require.True(t, expirationTime.Before(time.Now()))
+
+	require.Equal(t, 1, len(sessionManager.store.sessions))
+
+	// Check that the second session is still there
+	request.Header.Set("Cookie", cookie)
+	sessionData = sessionManager.Get(request)
+	require.NotNil(t, sessionData)
+	require.Equal(t, "value2", sessionData.StringValues["key2"])
+}


### PR DESCRIPTION
Add endpoint for logout which destroys the current session and redirects the user back to the base frontend URL

Still TODO is to redirect to a real logout page, which has not been created yet 