### PR TITLE
[INT-405] Disallow unmanaged FHIR operations in CPS

### DIFF
--- a/e2e-tests/main_test.go
+++ b/e2e-tests/main_test.go
@@ -42,7 +42,7 @@ func Test_Main(t *testing.T) {
 	// Setup Clinic
 	err = createTenant(nutsInternalURL, hapiFhirClient, "clinic", clinicURA, "Clinic", "Bug City", clinicBaseUrl+"/cpc/fhir/notify", false)
 	require.NoError(t, err)
-	clinicOrcaURL := setupOrchestrator(t, dockerNetwork.Name, "clinic-orchestrator", "clinic", false, carePlanServiceBaseURL, clinicFHIRStoreURL)
+	clinicOrcaURL := setupOrchestrator(t, dockerNetwork.Name, "clinic-orchestrator", "clinic", false, carePlanServiceBaseURL, clinicFHIRStoreURL, true)
 	clinicOrcaFHIRClient := fhirclient.New(clinicOrcaURL.JoinPath("/cpc/cps/fhir"), orcaHttpClient, nil)
 
 	// Setup Hospital
@@ -51,7 +51,7 @@ func Test_Main(t *testing.T) {
 	// This is why the hospital, running the CPS, stores its data in the default partition.
 	err = createTenant(nutsInternalURL, hapiFhirClient, "hospital", hospitalURA, "Hospital", "Fix City", hospitalBaseUrl+"/cpc/fhir/notify", true)
 	require.NoError(t, err)
-	hospitalOrcaURL := setupOrchestrator(t, dockerNetwork.Name, "hospital-orchestrator", "hospital", true, carePlanServiceBaseURL, hospitalFHIRStoreURL)
+	hospitalOrcaURL := setupOrchestrator(t, dockerNetwork.Name, "hospital-orchestrator", "hospital", true, carePlanServiceBaseURL, hospitalFHIRStoreURL, true)
 	// hospitalOrcaFHIRClient is the FHIR client the hospital uses to interact with the CarePlanService
 	hospitalOrcaFHIRClient := fhirclient.New(hospitalOrcaURL.JoinPath("/cpc/cps/fhir"), orcaHttpClient, nil)
 

--- a/e2e-tests/orca.go
+++ b/e2e-tests/orca.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 )
 
-func setupOrchestrator(t *testing.T, dockerNetworkName string, containerName string, nutsSubject string, cpsEnabled bool, cpsFhirBaseUrl string, fhirStoreURL string) *url.URL {
+func setupOrchestrator(t *testing.T, dockerNetworkName string, containerName string, nutsSubject string, cpsEnabled bool, cpsFhirBaseUrl string, fhirStoreURL string, allowUnmanagedFHIROperations bool) *url.URL {
 	image := os.Getenv("ORCHESTRATOR_IMAGE")
 	pullImage := false
 	if image == "" {
@@ -30,17 +30,18 @@ func setupOrchestrator(t *testing.T, dockerNetworkName string, containerName str
 			Consumers: []testcontainers.LogConsumer{&testcontainers.StdoutLogConsumer{}},
 		},
 		Env: map[string]string{
-			"ORCA_PUBLIC_URL":                              "http://" + containerName + ":8080",
-			"ORCA_NUTS_API_URL":                            "http://nutsnode:8081",
-			"ORCA_NUTS_PUBLIC_URL":                         "http://nutsnode:8080",
-			"ORCA_NUTS_SUBJECT":                            nutsSubject,
-			"ORCA_NUTS_DISCOVERYSERVICE":                   "dev:HomeMonitoring2024",
-			"ORCA_CAREPLANSERVICE_ENABLED":                 strconv.FormatBool(cpsEnabled),
-			"ORCA_CAREPLANSERVICE_FHIR_URL":                fhirStoreURL,
-			"ORCA_CAREPLANCONTRIBUTOR_CAREPLANSERVICE_URL": cpsFhirBaseUrl,
-			"ORCA_CAREPLANCONTRIBUTOR_FHIR_URL":            fhirStoreURL,
-			"ORCA_CAREPLANCONTRIBUTOR_ENABLED":             "true",
-			"ORCA_CAREPLANCONTRIBUTOR_STATICBEARERTOKEN":   "valid",
+			"ORCA_PUBLIC_URL":                                       "http://" + containerName + ":8080",
+			"ORCA_NUTS_API_URL":                                     "http://nutsnode:8081",
+			"ORCA_NUTS_PUBLIC_URL":                                  "http://nutsnode:8080",
+			"ORCA_NUTS_SUBJECT":                                     nutsSubject,
+			"ORCA_NUTS_DISCOVERYSERVICE":                            "dev:HomeMonitoring2024",
+			"ORCA_CAREPLANSERVICE_ENABLED":                          strconv.FormatBool(cpsEnabled),
+			"ORCA_CAREPLANSERVICE_FHIR_URL":                         fhirStoreURL,
+			"ORCA_CAREPLANCONTRIBUTOR_CAREPLANSERVICE_URL":          cpsFhirBaseUrl,
+			"ORCA_CAREPLANCONTRIBUTOR_FHIR_URL":                     fhirStoreURL,
+			"ORCA_CAREPLANCONTRIBUTOR_ENABLED":                      "true",
+			"ORCA_CAREPLANCONTRIBUTOR_STATICBEARERTOKEN":            "valid",
+			"ORCA_CAREPLANCONTRIBUTOR_ALLOWUNMANAGEDFHIROPERATIONS": strconv.FormatBool(allowUnmanagedFHIROperations),
 		},
 		Files: []testcontainers.ContainerFile{
 			{

--- a/orchestrator/careplanservice/config.go
+++ b/orchestrator/careplanservice/config.go
@@ -13,7 +13,7 @@ type Config struct {
 	FHIR    coolfhir.ClientConfig `koanf:"fhir"`
 	Enabled bool                  `koanf:"enabled"`
 	// Defaults to false, should not be set true in Test or Prod
-	AllowUnmanagedFHIROperations bool `koanf:"allow_unmanaged_fhir_operations"`
+	AllowUnmanagedFHIROperations bool `koanf:"allowunmanagedfhiroperations"`
 }
 
 func (c Config) Validate() error {

--- a/orchestrator/careplanservice/config.go
+++ b/orchestrator/careplanservice/config.go
@@ -12,6 +12,8 @@ func DefaultConfig() Config {
 type Config struct {
 	FHIR    coolfhir.ClientConfig `koanf:"fhir"`
 	Enabled bool                  `koanf:"enabled"`
+	// Defaults to false, should not be set true in Test or Prod
+	AllowUnmanagedFHIROperations bool `koanf:"allow_unmanaged_fhir_operations"`
 }
 
 func (c Config) Validate() error {

--- a/orchestrator/careplanservice/service_test.go
+++ b/orchestrator/careplanservice/service_test.go
@@ -30,6 +30,31 @@ func TestService_Proxy(t *testing.T) {
 	// Test that the service registers the /cps URL that proxies to the backing FHIR server
 	// Setup: configure backing FHIR server to which the service proxies
 	fhirServerMux := http.NewServeMux()
+	fhirServer := httptest.NewServer(fhirServerMux)
+	// Setup: create the service
+	service, err := New(Config{
+		FHIR: coolfhir.ClientConfig{
+			BaseURL: fhirServer.URL + "/fhir",
+		},
+	}, profile.TestProfile{}, orcaPublicURL)
+	require.NoError(t, err)
+	// Setup: configure the service to proxy to the backing FHIR server
+	frontServerMux := http.NewServeMux()
+	service.RegisterHandlers(frontServerMux)
+	frontServer := httptest.NewServer(frontServerMux)
+
+	httpClient := frontServer.Client()
+	httpClient.Transport = auth.AuthenticatedTestRoundTripper(frontServer.Client().Transport, auth.TestPrincipal1, "")
+
+	httpResponse, err := httpClient.Get(frontServer.URL + "/cps/Patient")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusMethodNotAllowed, httpResponse.StatusCode)
+}
+
+func TestService_Proxy_AllowUnmanagedOperations(t *testing.T) {
+	// Test that the service registers the /cps URL that proxies to the backing FHIR server
+	// Setup: configure backing FHIR server to which the service proxies
+	fhirServerMux := http.NewServeMux()
 	capturedHost := ""
 	fhirServerMux.HandleFunc("GET /fhir/Patient", func(writer http.ResponseWriter, request *http.Request) {
 		writer.WriteHeader(http.StatusOK)
@@ -42,6 +67,7 @@ func TestService_Proxy(t *testing.T) {
 		FHIR: coolfhir.ClientConfig{
 			BaseURL: fhirServer.URL + "/fhir",
 		},
+		AllowUnmanagedFHIROperations: true,
 	}, profile.TestProfile{}, orcaPublicURL)
 	require.NoError(t, err)
 	// Setup: configure the service to proxy to the backing FHIR server
@@ -106,10 +132,8 @@ func TestService_ErrorHandling(t *testing.T) {
 }
 
 func TestService_DefaultOperationHandler(t *testing.T) {
-	t.Run("handles unmanaged FHIR operations", func(t *testing.T) {
-		// For now, we allow unmanaged FHIR operations. Unmanaged operations are operations (e.g. POST ServiceRequest)
-		// which aren't explicitly implemented in the CarePlanService API. We currently allow these, as we know
-		// some operations are required, but not implemented yet.
+	t.Run("handles unmanaged FHIR operations - allow unmanaged operations", func(t *testing.T) {
+		// For now, we have a flag that can be enabled in config that will allow unmanaged FHIR operations. This defaults to false and should not be enabled in test or prod environments
 		tx := coolfhir.Transaction()
 		// The unmanaged operation handler reads the resource to return from the result Bundle,
 		// from the same index as the resource it added to the transaction Bundle. To test this,
@@ -154,7 +178,8 @@ func TestService_DefaultOperationHandler(t *testing.T) {
 				return nil
 			})
 		service := Service{
-			fhirClient: fhirClient,
+			fhirClient:                   fhirClient,
+			allowUnmanagedFHIROperations: true,
 		}
 
 		resultHandler, err := service.handleUnmanagedOperation(request, tx)
@@ -165,6 +190,27 @@ func TestService_DefaultOperationHandler(t *testing.T) {
 		require.Empty(t, notifications)
 		assert.JSONEq(t, string(expectedServiceRequestJson), string(resultBundleEntry.Resource))
 		assert.Equal(t, "ServiceRequest/123", *resultBundleEntry.Response.Location)
+	})
+	t.Run("handles unmanaged FHIR operations - fail for unmanaged operations", func(t *testing.T) {
+		// Default behaviour is that we fail when a user tries to perform an unmanaged operation
+		tx := coolfhir.Transaction()
+		// The unmanaged operation handler reads the resource to return from the result Bundle,
+		// from the same index as the resource it added to the transaction Bundle. To test this,
+		// we make sure there's 2 other resources in the Bundle.
+		tx.Create(fhir.Task{})
+		ctrl := gomock.NewController(t)
+		fhirClient := mock.NewMockClient(ctrl)
+		service := Service{
+			fhirClient: fhirClient,
+		}
+		request := FHIRHandlerRequest{
+			ResourcePath: "ServiceRequest",
+			HttpMethod:   http.MethodPost,
+		}
+
+		resultHandler, err := service.handleUnmanagedOperation(request, tx)
+		require.Error(t, err)
+		require.Nil(t, resultHandler)
 	})
 }
 


### PR DESCRIPTION
Add a flag that allows unmanaged FHIR operations, default behaviour is that they are not allowed