### PR TITLE
Update query parameter handling in care services

### DIFF
--- a/orchestrator/careplanservice/handle_getcareplan.go
+++ b/orchestrator/careplanservice/handle_getcareplan.go
@@ -39,8 +39,8 @@ func (s *Service) handleSearchCarePlan(ctx context.Context, queryParams url.Valu
 			if k == "_include" && value == "CarePlan:care-team" {
 				continue
 			}
+			params = append(params, fhirclient.QueryParam(k, value))
 		}
-		params = append(params, fhirclient.QueryParam(k, v[0]))
 	}
 	params = append(params, fhirclient.QueryParam("_include", "CarePlan:care-team"))
 	params = append(params, fhirclient.ResponseHeaders(headers))

--- a/orchestrator/careplanservice/handle_getcareplan.go
+++ b/orchestrator/careplanservice/handle_getcareplan.go
@@ -34,9 +34,11 @@ func (s *Service) handleGetCarePlan(ctx context.Context, id string, headers *fhi
 func (s *Service) handleSearchCarePlan(ctx context.Context, queryParams url.Values, headers *fhirclient.Headers) (*fhir.Bundle, error) {
 	params := []fhirclient.Option{}
 	for k, v := range queryParams {
-		// Skip param to include CareTeam since we need to add this for validation anyway
-		if k == "_include" && v[0] == "CarePlan:care-team" {
-			continue
+		for _, value := range v {
+			// Skip param to include CareTeam since we need to add this for validation anyway
+			if k == "_include" && value == "CarePlan:care-team" {
+				continue
+			}
 		}
 		params = append(params, fhirclient.QueryParam(k, v[0]))
 	}

--- a/orchestrator/careplanservice/handle_getcareteam.go
+++ b/orchestrator/careplanservice/handle_getcareteam.go
@@ -32,7 +32,9 @@ func (s *Service) handleGetCareTeam(ctx context.Context, id string, headers *fhi
 func (s *Service) handleSearchCareTeam(ctx context.Context, queryParams url.Values, headers *fhirclient.Headers) (*fhir.Bundle, error) {
 	params := []fhirclient.Option{}
 	for k, v := range queryParams {
-		params = append(params, fhirclient.QueryParam(k, v[0]))
+		for _, value := range v {
+			params = append(params, fhirclient.QueryParam(k, value))
+		}
 	}
 	params = append(params, fhirclient.ResponseHeaders(headers))
 	var bundle fhir.Bundle

--- a/orchestrator/careplanservice/handle_gettask.go
+++ b/orchestrator/careplanservice/handle_gettask.go
@@ -62,7 +62,9 @@ func (s *Service) handleGetTask(ctx context.Context, id string, headers *fhircli
 func (s *Service) handleSearchTask(ctx context.Context, queryParams url.Values, headers *fhirclient.Headers) (*fhir.Bundle, error) {
 	params := []fhirclient.Option{}
 	for k, v := range queryParams {
-		params = append(params, fhirclient.QueryParam(k, v[0]))
+		for _, value := range v {
+			params = append(params, fhirclient.QueryParam(k, value))
+		}
 	}
 
 	params = append(params, fhirclient.ResponseHeaders(headers))


### PR DESCRIPTION
Refactor query parameter loops to handle multiple values per key in the `handleSearchTask`, `handleSearchCareTeam`, and `handleSearchCarePlan` functions. This ensures that all values for a given query parameter key are included, improving the handling of multi-value parameters.