### PR TITLE
Fix integration of Zorgplatform

### DIFF
--- a/frontend/lib/fhirUtils.ts
+++ b/frontend/lib/fhirUtils.ts
@@ -106,9 +106,9 @@ export const getTask = (serviceRequest: ServiceRequest, primaryCondition: Condit
             identifier: serviceRequest.performer?.[0]?.identifier,
         },
         focus: {
-            identifier: serviceRequest.identifier?.[0],
             display: serviceRequest.code?.coding?.[0].display,
-            type: 'ServiceRequest'
+            type: 'ServiceRequest',
+            reference: "ServiceRequest/" + serviceRequest.id
         },
     }
 }

--- a/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
@@ -366,12 +366,6 @@ func (s *Service) getSessionData(ctx context.Context, accessToken string, launch
 				},
 			},
 		},
-		Identifier: []fhir.Identifier{
-			{
-				System: to.Ptr("http://snomed.info/sct"), //TODO: Hard coded to Hartfalen for demo purposes. Should be based on the Task
-				Value:  to.Ptr("84114007"),
-			},
-		},
 		ReasonReference: []fhir.Reference{reasonReference},
 		Subject: fhir.Reference{
 			Identifier: &fhir.Identifier{

--- a/orchestrator/careplancontributor/handle_taskfiller_test.go
+++ b/orchestrator/careplancontributor/handle_taskfiller_test.go
@@ -509,6 +509,8 @@ var primaryTask = fhir.Task{
 
 var subTask = deep.AlterCopy(primaryTask, func(subTask *fhir.Task) {
 	swap := subTask.Owner
+	subTask.ReasonCode = nil
+	subTask.ReasonReference = nil
 	subTask.Owner = subTask.Requester
 	subTask.Requester = swap
 	subTask.PartOf = []fhir.Reference{


### PR DESCRIPTION
Fixes:
- Always use primary Task's reason to resolve the service (telemonitoring), as the subtask might not have it
- Zorgplatform's Task must refer to the ServiceRequest by ID (fixes error: `failed to process new primary Task: task.Focus or task.Focus.Reference is nil`)
- Zorgplatform's ServiceRequest should not have a logical identifier denoting the condition code