### PR TITLE
Zorgplatform: read Task performer name from CSD

### DIFF
--- a/orchestrator/careplancontributor/applaunch/zorgplatform/handle_create_hcp_rst.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/handle_create_hcp_rst.go
@@ -20,6 +20,12 @@ import (
 	dsig "github.com/russellhaering/goxmldsig"
 )
 
+type SecureTokenService interface {
+	RequestHcpRst(launchContext LaunchContext) (string, error)
+}
+
+var _ SecureTokenService = &Service{}
+
 // RequestHcpRst generates the SAML assertion, signs it, and sends the SOAP request to the Zorgplatform STS
 func (s *Service) RequestHcpRst(launchContext LaunchContext) (string, error) {
 	// Create the SAML assertion

--- a/orchestrator/careplancontributor/applaunch/zorgplatform/service_integration_test.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/service_integration_test.go
@@ -41,7 +41,8 @@ func TestService_FetchContext_IntegrationTest(t *testing.T) {
 		signingCertificateKey: signCert.PrivateKey.(*rsa.PrivateKey),
 		signingCertificate:    signCert.Certificate,
 		profile: profile.TestProfile{
-			Principal: auth.TestPrincipal1,
+			Principal:        auth.TestPrincipal1,
+			TestCsdDirectory: profile.TestCsdDirectory{},
 		},
 		zorgplatformHttpClient: &http.Client{
 			Transport: &http.Transport{

--- a/orchestrator/careplancontributor/applaunch/zorgplatform/service_test.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/service_test.go
@@ -1,7 +1,6 @@
 package zorgplatform
 
 import (
-	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/sha1"
@@ -11,6 +10,8 @@ import (
 	"encoding/binary"
 	"encoding/pem"
 	"fmt"
+	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
+	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
 	"hash"
 	"net/http"
 	"net/http/httptest"
@@ -34,7 +35,6 @@ import (
 )
 
 func TestService(t *testing.T) {
-
 	httpServerMux := http.NewServeMux()
 	httpServer := httptest.NewServer(httpServerMux)
 
@@ -106,29 +106,55 @@ func TestService(t *testing.T) {
 				Key: publicKeyToJWK(signingKeyPair.PublicKey, signKeyName, "0"),
 			},
 		}, nil)
-	keysClient.EXPECT().Sign(gomock.Any(), signKeyName, "0", gomock.Any(), nil).
-		DoAndReturn(func(ctx interface{}, keyName string, keyVersion string, parameters azkeys.SignParameters, options *azkeys.SignOptions) (azkeys.SignResponse, error) {
-			hashed := sha256.Sum256(parameters.Value)
-			signature, err := rsa.SignPKCS1v15(rand.Reader, signingKeyPair, crypto.SHA256, hashed[:])
-			if err != nil {
-				return azkeys.SignResponse{}, err
-			}
-			return azkeys.SignResponse{
-				KeyOperationResult: azkeys.KeyOperationResult{
-					Result: signature,
-				},
-			}, nil
-		})
 
 	zorgplatformHttpServerMux := http.NewServeMux()
 	zorgplatformHttpServer := httptest.NewServer(zorgplatformHttpServerMux)
-	zorgplatformHttpServerMux.Handle("POST /sts", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// TODO: Handle
-		w.WriteHeader(http.StatusOK)
+	zorgplatformHttpServerMux.Handle("GET /api/Task/b526e773-e1a6-4533-bd00-1360c97e745f", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Get Zorgplatform Workflow Task
+		coolfhir.SendResponse(w, http.StatusOK, map[string]interface{}{
+			"context": map[string]interface{}{
+				"reference": "Encounter/enc-123",
+			},
+		})
 	}))
-	zorgplatformHttpServerMux.Handle("POST /api", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		// TODO: Handle
-		w.WriteHeader(http.StatusOK)
+	zorgplatformHttpServerMux.Handle("GET /api/Patient", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		coolfhir.SendResponse(w, http.StatusOK, coolfhir.SearchSet().
+			Append(
+				fhir.Patient{
+					Id: to.Ptr("pat-123"),
+				}, nil, nil).
+			Append(
+				fhir.PractitionerRole{
+					Practitioner: &fhir.Reference{
+						Reference: to.Ptr("Practitioner/prac-123"),
+					},
+				}, nil, nil).
+			Append(
+				fhir.Practitioner{
+					Id: to.Ptr("prac-123"),
+				}, nil, nil),
+		)
+	}))
+	zorgplatformHttpServerMux.Handle("GET /api/Encounter", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("_id") == "enc-123" {
+			enc := fhir.Encounter{
+				Subject: &fhir.Reference{
+					Reference: to.Ptr("Patient/pat-123"),
+				},
+				ServiceProvider: &fhir.Reference{
+					Reference: to.Ptr("Organization/org-123"),
+				},
+			}
+			org := fhir.Organization{
+				Id: to.Ptr("org-123"),
+			}
+			coolfhir.SendResponse(w, http.StatusOK, coolfhir.SearchSet().
+				Append(enc, nil, nil).
+				Append(org, nil, nil),
+			)
+			return
+		}
+		coolfhir.SendResponse(w, http.StatusNotFound, nil)
 	}))
 
 	certDER := certificate.Certificate[0]
@@ -142,7 +168,6 @@ func TestService(t *testing.T) {
 	cfg := Config{
 		Enabled:            true,
 		ApiUrl:             zorgplatformHttpServer.URL + "/api",
-		StsUrl:             zorgplatformHttpServer.URL + "/sts",
 		SAMLRequestTimeout: 10 * time.Second,
 		SigningConfig: SigningConfig{
 			Issuer:   "https://partner-application.nl",
@@ -166,8 +191,10 @@ func TestService(t *testing.T) {
 
 	sessionManager := user.NewSessionManager()
 	service, err := newWithClients(sessionManager, cfg, httpServer.URL, "/", keysClient, certsClient, profile.TestProfile{
-		Principal: auth.TestPrincipal1,
+		Principal:        auth.TestPrincipal1,
+		TestCsdDirectory: profile.TestCsdDirectory{},
 	})
+	service.secureTokenService = &stubSecureTokenService{}
 	require.NoError(t, err)
 	service.RegisterHandlers(httpServerMux)
 
@@ -182,46 +209,43 @@ func TestService(t *testing.T) {
 	})
 
 	require.NoError(t, err)
-	//TODO: Below needs to be fixed, the service executes the RequestHcpRst logic, which SHOULD be mocked as it has its own tests
-	// require.Equal(t, http.StatusFound, launchHttpResponse.StatusCode)
-	require.Equal(t, http.StatusBadRequest, launchHttpResponse.StatusCode)
+	require.Equal(t, http.StatusFound, launchHttpResponse.StatusCode)
 
-	//TODO: Uncomment when actually fetching this data
-	// t.Run("assert user session is created", func(t *testing.T) {
-	// 	sessionData := user.SessionFromHttpResponse(sessionManager, launchHttpResponse)
-	// 	require.NotNil(t, sessionData)
-	// })
-	// 	t.Run("check Practitioner is in session", func(t *testing.T) {
-	// 		practitionerRef := sessionData.StringValues["practitioner"]
-	// 		require.NotEmpty(t, practitionerRef)
-	// 		require.IsType(t, fhir.Practitioner{}, sessionData.OtherValues[practitionerRef])
-	// 	})
-	// 	t.Run("check ServiceRequest is in session", func(t *testing.T) {
-	// 		serviceRequestRef := sessionData.StringValues["serviceRequest"]
-	// 		require.NotEmpty(t, serviceRequestRef)
-	// 		require.IsType(t, fhir.ServiceRequest{}, sessionData.OtherValues[serviceRequestRef])
-	// 	})
-	// 	t.Run("check Patient is in session", func(t *testing.T) {
-	// 		patientRef := sessionData.StringValues["patient"]
-	// 		require.NotEmpty(t, patientRef)
-	// 		require.IsType(t, fhir.Patient{}, sessionData.OtherValues[patientRef])
-	// 	})
-	// })
+	t.Run("assert user session", func(t *testing.T) {
+		sessionData := user.SessionFromHttpResponse(sessionManager, launchHttpResponse)
+		require.NotNil(t, sessionData)
 
-	// t.Run("test invalid SAML response", func(t *testing.T) {
-	// 	invalidSAMLResponse := "invalidSAMLResponse"
-	// 	launchHttpResponse, err := client.PostForm(httpServer.URL+"/zorgplatform-app-launch", url.Values{
-	// 		"SAMLResponse": {invalidSAMLResponse},
-	// 	})
-	// 	require.NoError(t, err)
-	// 	require.Equal(t, http.StatusBadRequest, launchHttpResponse.StatusCode)
-	// })
+		t.Run("check Practitioner is in session", func(t *testing.T) {
+			practitionerRef := sessionData.StringValues["practitioner"]
+			require.NotEmpty(t, practitionerRef)
+			require.IsType(t, fhir.Practitioner{}, sessionData.OtherValues[practitionerRef])
+		})
+		t.Run("check ServiceRequest is in session", func(t *testing.T) {
+			serviceRequestRef := sessionData.StringValues["serviceRequest"]
+			require.NotEmpty(t, serviceRequestRef)
+			require.IsType(t, fhir.ServiceRequest{}, sessionData.OtherValues[serviceRequestRef])
+		})
+		t.Run("check Patient is in session", func(t *testing.T) {
+			patientRef := sessionData.StringValues["patient"]
+			require.NotEmpty(t, patientRef)
+			require.IsType(t, fhir.Patient{}, sessionData.OtherValues[patientRef])
+		})
+	})
 
-	// t.Run("test missing SAML response", func(t *testing.T) {
-	// 	launchHttpResponse, err := client.PostForm(httpServer.URL+"/zorgplatform-app-launch", url.Values{})
-	// 	require.NoError(t, err)
-	// 	require.Equal(t, http.StatusBadRequest, launchHttpResponse.StatusCode)
-	// })
+	t.Run("test invalid SAML response", func(t *testing.T) {
+		invalidSAMLResponse := "invalidSAMLResponse"
+		launchHttpResponse, err := client.PostForm(httpServer.URL+"/zorgplatform-app-launch", url.Values{
+			"SAMLResponse": {invalidSAMLResponse},
+		})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, launchHttpResponse.StatusCode)
+	})
+
+	t.Run("test missing SAML response", func(t *testing.T) {
+		launchHttpResponse, err := client.PostForm(httpServer.URL+"/zorgplatform-app-launch", url.Values{})
+		require.NoError(t, err)
+		require.Equal(t, http.StatusBadRequest, launchHttpResponse.StatusCode)
+	})
 }
 
 func createSAMLResponse(t *testing.T, encryptionKey *x509.Certificate) string {
@@ -258,4 +282,13 @@ func publicKeyToJWK(key rsa.PublicKey, id string, version string) *azkeys.JSONWe
 		E:   e,
 		KID: (*azkeys.ID)(to.Ptr("https://myvaultname.vault.azure.net/keys/" + id + "/" + version)),
 	}
+}
+
+var _ SecureTokenService = &stubSecureTokenService{}
+
+type stubSecureTokenService struct {
+}
+
+func (s stubSecureTokenService) RequestHcpRst(launchContext LaunchContext) (string, error) {
+	return "stub-at", nil
 }

--- a/orchestrator/careplanservice/careteamservice/careteam.go
+++ b/orchestrator/careplanservice/careteamservice/careteam.go
@@ -19,7 +19,7 @@ var nowFunc = time.Now
 // updateTrigger is the Task that triggered the update, which is used to determine the CareTeam membership.
 // It's passed to the function, as the new Task is not yet stored in the FHIR server, since the update is to be done in a single transaction.
 // When the CareTeam is updated, it adds the update(s) to the given transaction and returns true. If no changes are made, it returns false.
-func Update(client fhirclient.Client, carePlanId string, updateTriggerTask fhir.Task, tx *coolfhir.TransactionBuilder) (bool, error) {
+func Update(client fhirclient.Client, carePlanId string, updateTriggerTask fhir.Task, tx *coolfhir.BundleBuilder) (bool, error) {
 	bundle := new(fhir.Bundle)
 	if err := client.Read("CarePlan",
 		bundle,

--- a/orchestrator/careplanservice/handle_createtask.go
+++ b/orchestrator/careplanservice/handle_createtask.go
@@ -18,7 +18,7 @@ import (
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
 )
 
-func (s *Service) handleCreateTask(ctx context.Context, request FHIRHandlerRequest, tx *coolfhir.TransactionBuilder) (FHIRHandlerResult, error) {
+func (s *Service) handleCreateTask(ctx context.Context, request FHIRHandlerRequest, tx *coolfhir.BundleBuilder) (FHIRHandlerResult, error) {
 	log.Info().Msg("Creating Task")
 	var task fhir.Task
 	if err := json.Unmarshal(request.ResourceData, &task); err != nil {
@@ -197,7 +197,7 @@ func (s *Service) handleCreateTask(ctx context.Context, request FHIRHandlerReque
 }
 
 // newTaskInExistingCarePlan creates a new Task and references the Task from the CarePlan.activities.
-func (s *Service) newTaskInExistingCarePlan(tx *coolfhir.TransactionBuilder, taskBundleEntry fhir.BundleEntry, task fhir.Task, carePlan *fhir.CarePlan) error {
+func (s *Service) newTaskInExistingCarePlan(tx *coolfhir.BundleBuilder, taskBundleEntry fhir.BundleEntry, task fhir.Task, carePlan *fhir.CarePlan) error {
 	carePlan.Activity = append(carePlan.Activity, fhir.CarePlanActivity{
 		Reference: &fhir.Reference{
 			Reference: taskBundleEntry.FullUrl,
@@ -206,7 +206,7 @@ func (s *Service) newTaskInExistingCarePlan(tx *coolfhir.TransactionBuilder, tas
 	})
 
 	// TODO: Only if not updated
-	tx.Append(taskBundleEntry).
+	tx.AppendEntry(taskBundleEntry).
 		Update(*carePlan, "CarePlan/"+*carePlan.Id)
 
 	if _, err := careteamservice.Update(s.fhirClient, *carePlan.Id, task, tx); err != nil {

--- a/orchestrator/careplanservice/handle_updatetask.go
+++ b/orchestrator/careplanservice/handle_updatetask.go
@@ -14,7 +14,7 @@ import (
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
 )
 
-func (s *Service) handleUpdateTask(ctx context.Context, request FHIRHandlerRequest, tx *coolfhir.TransactionBuilder) (FHIRHandlerResult, error) {
+func (s *Service) handleUpdateTask(ctx context.Context, request FHIRHandlerRequest, tx *coolfhir.BundleBuilder) (FHIRHandlerResult, error) {
 	log.Info().Msgf("Updating Task: %s", request.RequestUrl)
 	var task fhir.Task
 	if err := json.Unmarshal(request.ResourceData, &task); err != nil {
@@ -111,7 +111,7 @@ func (s *Service) handleUpdateTask(ctx context.Context, request FHIRHandlerReque
 		return nil, fmt.Errorf("invalid Task.basedOn: %w", err)
 	}
 
-	tx = tx.Append(request.bundleEntryWithResource(task))
+	tx = tx.AppendEntry(request.bundleEntryWithResource(task))
 	idx := len(tx.Entry) - 1
 	// Update care team
 	_, err = careteamservice.Update(s.fhirClient, *carePlanRef, task, tx)

--- a/orchestrator/careplanservice/handle_updatetask_test.go
+++ b/orchestrator/careplanservice/handle_updatetask_test.go
@@ -735,7 +735,7 @@ func Test_handleUpdateTask_Validation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tx := &coolfhir.TransactionBuilder{}
+			tx := &coolfhir.BundleBuilder{}
 
 			if tt.existingTask != nil {
 				mockFHIRClient.EXPECT().Read("Task/1", gomock.Any(), gomock.Any()).DoAndReturn(func(path string, result interface{}, option ...fhirclient.Option) error {

--- a/orchestrator/careplanservice/service.go
+++ b/orchestrator/careplanservice/service.go
@@ -67,14 +67,14 @@ type Service struct {
 	maxReadBodySize              int
 	proxy                        *httputil.ReverseProxy
 	allowUnmanagedFHIROperations bool
-	handlerProvider              func(method string, resourceType string) func(context.Context, FHIRHandlerRequest, *coolfhir.TransactionBuilder) (FHIRHandlerResult, error)
+	handlerProvider              func(method string, resourceType string) func(context.Context, FHIRHandlerRequest, *coolfhir.BundleBuilder) (FHIRHandlerResult, error)
 }
 
 // FHIRHandler defines a function that handles a FHIR request and returns a function to write the response.
 // It may be executed singular, or be part of a Bundle that causes multiple handlers to be executed.
-// It is provided with a TransactionBuilder to add FHIR resource operations that must be executed on the backing FHIR server.
+// It is provided with a BundleBuilder to add FHIR resource operations that must be executed on the backing FHIR server.
 // The handler itself must not cause side-effects in the FHIR server: those MUST be effectuated through the transaction.
-type FHIRHandler func(http.ResponseWriter, *http.Request, *coolfhir.TransactionBuilder) (FHIRHandlerResult, error)
+type FHIRHandler func(http.ResponseWriter, *http.Request, *coolfhir.BundleBuilder) (FHIRHandlerResult, error)
 
 type FHIRHandlerRequest struct {
 	ResourceId   string
@@ -157,7 +157,7 @@ func (s *Service) RegisterHandlers(mux *http.ServeMux) {
 
 // commitTransaction sends the given transaction Bundle to the FHIR server, and processes the result with the given resultHandlers.
 // It returns the result Bundle that should be returned to the client, or an error if the transaction failed.
-func (s *Service) commitTransaction(request *http.Request, tx *coolfhir.TransactionBuilder, resultHandlers []FHIRHandlerResult) (*fhir.Bundle, error) {
+func (s *Service) commitTransaction(request *http.Request, tx *coolfhir.BundleBuilder, resultHandlers []FHIRHandlerResult) (*fhir.Bundle, error) {
 	var txResult fhir.Bundle
 	if err := s.fhirClient.Create(tx.Bundle(), &txResult, fhirclient.AtPath("/")); err != nil {
 		log.Error().Err(err).Msgf("Failed to execute transaction (url=%s)", request.URL.String())
@@ -188,7 +188,7 @@ func (s *Service) commitTransaction(request *http.Request, tx *coolfhir.Transact
 
 // handleTransactionEntry executes the FHIR operation in the HTTP request. It adds the FHIR operations to be executed to the given transaction Bundle,
 // and returns the function that must be executed after the transaction is committed.
-func (s *Service) handleTransactionEntry(ctx context.Context, request FHIRHandlerRequest, tx *coolfhir.TransactionBuilder) (FHIRHandlerResult, error) {
+func (s *Service) handleTransactionEntry(ctx context.Context, request FHIRHandlerRequest, tx *coolfhir.BundleBuilder) (FHIRHandlerResult, error) {
 	if request.HttpMethod == http.MethodPost {
 		// We don't allow creation of resources with a specific ID
 		if request.ResourceId != "" {
@@ -202,7 +202,7 @@ func (s *Service) handleTransactionEntry(ctx context.Context, request FHIRHandle
 	return handler(ctx, request, tx)
 }
 
-func (s *Service) handleUnmanagedOperation(request FHIRHandlerRequest, tx *coolfhir.TransactionBuilder) (FHIRHandlerResult, error) {
+func (s *Service) handleUnmanagedOperation(request FHIRHandlerRequest, tx *coolfhir.BundleBuilder) (FHIRHandlerResult, error) {
 	log.Warn().Msgf("Unmanaged FHIR operation at CarePlanService: %s %s", request.HttpMethod, request.RequestUrl)
 
 	err := s.checkAllowUnmanagedOperations()
@@ -210,7 +210,7 @@ func (s *Service) handleUnmanagedOperation(request FHIRHandlerRequest, tx *coolf
 		return nil, err
 	}
 
-	tx.Append(request.bundleEntry())
+	tx.AppendEntry(request.bundleEntry())
 	idx := len(tx.Entry) - 1
 	return func(txResult *fhir.Bundle) (*fhir.BundleEntry, []any, error) {
 		var resultResource []byte
@@ -409,7 +409,7 @@ func (s *Service) handleBundle(httpRequest *http.Request, httpResponse http.Resp
 	coolfhir.SendResponse(httpResponse, http.StatusOK, resultBundle)
 }
 
-func (s *Service) defaultHandlerProvider(method string, resourcePath string) func(context.Context, FHIRHandlerRequest, *coolfhir.TransactionBuilder) (FHIRHandlerResult, error) {
+func (s *Service) defaultHandlerProvider(method string, resourcePath string) func(context.Context, FHIRHandlerRequest, *coolfhir.BundleBuilder) (FHIRHandlerResult, error) {
 	switch method {
 	case http.MethodPost:
 		switch getResourceType(resourcePath) {
@@ -422,7 +422,7 @@ func (s *Service) defaultHandlerProvider(method string, resourcePath string) fun
 			return s.handleUpdateTask
 		}
 	}
-	return func(ctx context.Context, request FHIRHandlerRequest, tx *coolfhir.TransactionBuilder) (FHIRHandlerResult, error) {
+	return func(ctx context.Context, request FHIRHandlerRequest, tx *coolfhir.BundleBuilder) (FHIRHandlerResult, error) {
 		return s.handleUnmanagedOperation(request, tx)
 	}
 }

--- a/orchestrator/careplanservice/service_test.go
+++ b/orchestrator/careplanservice/service_test.go
@@ -263,13 +263,13 @@ func TestService_Handle(t *testing.T) {
 		},
 	}, profile.TestProfile{}, orcaPublicURL)
 
-	service.handlerProvider = func(method string, resourceType string) func(context.Context, FHIRHandlerRequest, *coolfhir.TransactionBuilder) (FHIRHandlerResult, error) {
+	service.handlerProvider = func(method string, resourceType string) func(context.Context, FHIRHandlerRequest, *coolfhir.BundleBuilder) (FHIRHandlerResult, error) {
 		switch method {
 		case http.MethodPost:
 			switch resourceType {
 			case "CarePlan":
-				return func(ctx context.Context, request FHIRHandlerRequest, tx *coolfhir.TransactionBuilder) (FHIRHandlerResult, error) {
-					tx.Append(request.bundleEntry())
+				return func(ctx context.Context, request FHIRHandlerRequest, tx *coolfhir.BundleBuilder) (FHIRHandlerResult, error) {
+					tx.AppendEntry(request.bundleEntry())
 					return func(txResult *fhir.Bundle) (*fhir.BundleEntry, []any, error) {
 						result := coolfhir.FirstBundleEntry(txResult, coolfhir.EntryIsOfType("CarePlan"))
 						carePlan := fhir.CarePlan{
@@ -280,8 +280,8 @@ func TestService_Handle(t *testing.T) {
 					}, nil
 				}
 			case "Task":
-				return func(ctx context.Context, request FHIRHandlerRequest, tx *coolfhir.TransactionBuilder) (FHIRHandlerResult, error) {
-					tx.Append(request.bundleEntry())
+				return func(ctx context.Context, request FHIRHandlerRequest, tx *coolfhir.BundleBuilder) (FHIRHandlerResult, error) {
+					tx.AppendEntry(request.bundleEntry())
 					return func(txResult *fhir.Bundle) (*fhir.BundleEntry, []any, error) {
 						result := coolfhir.FirstBundleEntry(txResult, coolfhir.EntryIsOfType("Task"))
 						task := fhir.Task{
@@ -295,8 +295,8 @@ func TestService_Handle(t *testing.T) {
 		case http.MethodPut:
 			switch resourceType {
 			case "Task":
-				return func(ctx context.Context, request FHIRHandlerRequest, tx *coolfhir.TransactionBuilder) (FHIRHandlerResult, error) {
-					tx.Append(request.bundleEntry())
+				return func(ctx context.Context, request FHIRHandlerRequest, tx *coolfhir.BundleBuilder) (FHIRHandlerResult, error) {
+					tx.AppendEntry(request.bundleEntry())
 					return func(txResult *fhir.Bundle) (*fhir.BundleEntry, []any, error) {
 						result := coolfhir.FirstBundleEntry(txResult, coolfhir.EntryIsOfType("Task"))
 						task := fhir.Task{
@@ -307,7 +307,7 @@ func TestService_Handle(t *testing.T) {
 					}, nil
 				}
 			case "Organization":
-				return func(ctx context.Context, request FHIRHandlerRequest, tx *coolfhir.TransactionBuilder) (FHIRHandlerResult, error) {
+				return func(ctx context.Context, request FHIRHandlerRequest, tx *coolfhir.BundleBuilder) (FHIRHandlerResult, error) {
 					return nil, errors.New("this fails on purpose")
 				}
 			}

--- a/orchestrator/lib/coolfhir/bundle.go
+++ b/orchestrator/lib/coolfhir/bundle.go
@@ -36,7 +36,7 @@ func (t *BundleBuilder) Create(resource interface{}, opts ...BundleEntryOption) 
 func (t *BundleBuilder) Update(resource interface{}, path string, opts ...BundleEntryOption) *BundleBuilder {
 	return t.Append(resource, &fhir.BundleEntryRequest{
 		Method: fhir.HTTPVerbPUT,
-		Url:    ResourceType(resource),
+		Url:    path,
 	}, nil, opts...)
 }
 


### PR DESCRIPTION
Otherwise, we're going to have to hardcode it. Zorgplatform app launch already has the URA, so we can just read it from CSD.

Improve unit test coverage in the meantime (and fix a bug)