### PR TITLE
INT-419: Microsoft Azure FHIR compatiblity

### DIFF
--- a/orchestrator/README.md
+++ b/orchestrator/README.md
@@ -1,9 +1,10 @@
 ## Configuration
 Use the following environment variables to configure the orchestrator:
 
-Required configuration:
-- `ORCA_PUBLIC_BASEURL`: base URL of the public endpoints.
-- `ORCA_PUBLIC_ADDRESS`: address the public endpoints bind to (default: `:8080`).
+General configuration:
+- `ORCA_PUBLIC_BASEURL` (required): base URL of the public endpoints.
+- `ORCA_PUBLIC_ADDRESS` (required): address the public endpoints bind to (default: `:8080`).
+- `ORCA_LOGLEVEL`: log level, can be `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `panic`, or `disabled` (default: `info`).
 
 Required configuration for Nuts:
 - `ORCA_NUTS_PUBLIC_URL`: public URL of the Nuts, used for informing OAuth2 clients of the URL of the OAuth2 Authorization Server, e.g. `http://example.com/nuts`.

--- a/orchestrator/careplanservice/handle_createtask_test.go
+++ b/orchestrator/careplanservice/handle_createtask_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/SanteonNL/orca/orchestrator/lib/deep"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
+	"net/url"
 	"reflect"
 	"testing"
 
@@ -115,12 +116,14 @@ func Test_handleCreateTask_NoExistingCarePlan(t *testing.T) {
 	mockFHIRClient := mock.NewMockClient(ctrl)
 
 	// Create the service with the mock FHIR client
+	fhirBaseUrl, _ := url.Parse("http://example.com/fhir")
 	service := &Service{
 		profile: profile.TestProfile{
 			Principal:        auth.TestPrincipal1,
 			TestCsdDirectory: profile.TestCsdDirectory{},
 		},
 		fhirClient: mockFHIRClient,
+		fhirURL:    fhirBaseUrl,
 	}
 
 	scpMeta := &fhir.Meta{
@@ -242,6 +245,13 @@ func Test_handleCreateTask_NoExistingCarePlan(t *testing.T) {
 				}
 			}),
 		},
+		{
+			name: "Task location in transaction response bundle contains an absolute URL (Microsoft Azure FHIR behavior)",
+			returnedBundle: deep.AlterCopy(defaultReturnedBundle, func(bundle **fhir.Bundle) {
+				b := *bundle
+				b.Entry[2].Response.Location = to.Ptr(fhirBaseUrl.JoinPath("Task/3").String())
+			}),
+		},
 	}
 
 	for _, tt := range tests {
@@ -305,11 +315,13 @@ func Test_handleCreateTask_ExistingCarePlan(t *testing.T) {
 	mockFHIRClient := mock.NewMockClient(ctrl)
 
 	// Create the service with the mock FHIR client
+	fhirBaseUrl, _ := url.Parse("http://example.com/fhir")
 	service := &Service{
 		fhirClient: mockFHIRClient,
 		profile: profile.TestProfile{
 			TestCsdDirectory: profile.TestCsdDirectory{},
 		},
+		fhirURL: fhirBaseUrl,
 	}
 
 	tests := []struct {

--- a/orchestrator/careplanservice/service.go
+++ b/orchestrator/careplanservice/service.go
@@ -158,9 +158,9 @@ func (s *Service) RegisterHandlers(mux *http.ServeMux) {
 // commitTransaction sends the given transaction Bundle to the FHIR server, and processes the result with the given resultHandlers.
 // It returns the result Bundle that should be returned to the client, or an error if the transaction failed.
 func (s *Service) commitTransaction(request *http.Request, tx *coolfhir.BundleBuilder, resultHandlers []FHIRHandlerResult) (*fhir.Bundle, error) {
-	if log.Debug().Enabled() {
+	if log.Trace().Enabled() {
 		txJson, _ := json.MarshalIndent(tx, "", "  ")
-		log.Debug().Msgf("Transaction bundle request: %s", txJson)
+		log.Trace().Msgf("FHIR Transaction request: %s", txJson)
 	}
 	var txResult fhir.Bundle
 	if err := s.fhirClient.Create(tx.Bundle(), &txResult, fhirclient.AtPath("/")); err != nil {
@@ -171,9 +171,9 @@ func (s *Service) commitTransaction(request *http.Request, tx *coolfhir.BundleBu
 	resultBundle := fhir.Bundle{
 		Type: fhir.BundleTypeTransactionResponse,
 	}
-	if log.Debug().Enabled() {
+	if log.Trace().Enabled() {
 		txJson, _ := json.MarshalIndent(txResult, "", "  ")
-		log.Debug().Msgf("Transaction bundle response: %s", txJson)
+		log.Trace().Msgf("FHIR Transaction response: %s", txJson)
 	}
 	var notificationResources []any
 	for entryIdx, resultHandler := range resultHandlers {

--- a/orchestrator/careplanservice/service.go
+++ b/orchestrator/careplanservice/service.go
@@ -158,6 +158,10 @@ func (s *Service) RegisterHandlers(mux *http.ServeMux) {
 // commitTransaction sends the given transaction Bundle to the FHIR server, and processes the result with the given resultHandlers.
 // It returns the result Bundle that should be returned to the client, or an error if the transaction failed.
 func (s *Service) commitTransaction(request *http.Request, tx *coolfhir.BundleBuilder, resultHandlers []FHIRHandlerResult) (*fhir.Bundle, error) {
+	if log.Debug().Enabled() {
+		txJson, _ := json.MarshalIndent(tx, "", "  ")
+		log.Debug().Msgf("Transaction bundle request: %s", txJson)
+	}
 	var txResult fhir.Bundle
 	if err := s.fhirClient.Create(tx.Bundle(), &txResult, fhirclient.AtPath("/")); err != nil {
 		log.Error().Err(err).Msgf("Failed to execute transaction (url=%s)", request.URL.String())
@@ -166,6 +170,10 @@ func (s *Service) commitTransaction(request *http.Request, tx *coolfhir.BundleBu
 	}
 	resultBundle := fhir.Bundle{
 		Type: fhir.BundleTypeTransactionResponse,
+	}
+	if log.Debug().Enabled() {
+		txJson, _ := json.MarshalIndent(txResult, "", "  ")
+		log.Debug().Msgf("Transaction bundle response: %s", txJson)
 	}
 	var notificationResources []any
 	for entryIdx, resultHandler := range resultHandlers {

--- a/orchestrator/cmd/config.go
+++ b/orchestrator/cmd/config.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"github.com/rs/zerolog"
 
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor"
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor/applaunch"
@@ -24,6 +25,7 @@ type Config struct {
 	CarePlanContributor careplancontributor.Config `koanf:"careplancontributor"`
 	// CarePlanService holds the configuration for the CarePlanService.
 	CarePlanService careplanservice.Config `koanf:"careplanservice"`
+	LogLevel        zerolog.Level          `koanf:"loglevel"`
 }
 
 func (c Config) Validate() error {
@@ -80,6 +82,7 @@ func LoadConfig() (*Config, error) {
 // DefaultConfig returns sensible, but not complete, default configuration values.
 func DefaultConfig() Config {
 	return Config{
+		LogLevel: zerolog.InfoLevel,
 		Public: InterfaceConfig{
 			Address: ":8080",
 			URL:     "/",

--- a/orchestrator/cmd/config_test.go
+++ b/orchestrator/cmd/config_test.go
@@ -4,7 +4,9 @@ import (
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor"
 	"github.com/SanteonNL/orca/orchestrator/careplanservice"
 	"github.com/SanteonNL/orca/orchestrator/cmd/profile/nuts"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
+	"os"
 	"testing"
 )
 
@@ -27,5 +29,20 @@ func TestConfig_Validate(t *testing.T) {
 		}
 		err := c.Validate()
 		require.EqualError(t, err, "public base URL is not configured")
+	})
+}
+
+func TestLoadConfig(t *testing.T) {
+	t.Run("default log level", func(t *testing.T) {
+		c, err := LoadConfig()
+		require.NoError(t, err)
+		require.Equal(t, zerolog.InfoLevel, c.LogLevel)
+	})
+	t.Run("log level is parsed", func(t *testing.T) {
+		os.Setenv("ORCA_LOGLEVEL", "trace")
+		defer os.Unsetenv("ORCA_LOGLEVEL")
+		c, err := LoadConfig()
+		require.NoError(t, err)
+		require.Equal(t, zerolog.TraceLevel, c.LogLevel)
 	})
 }

--- a/orchestrator/main.go
+++ b/orchestrator/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/SanteonNL/orca/orchestrator/cmd"
+	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 )
 
@@ -10,6 +11,7 @@ func main() {
 	if err != nil {
 		log.Fatal().Err(err).Msg("Failed to load configuration")
 	}
+	zerolog.SetGlobalLevel(config.LogLevel)
 	log.Info().Msgf("Public interface listens on %s", config.Public.Address)
 	log.Info().Msgf("Using Nuts API on %s", config.Nuts.API.URL)
 	if err := cmd.Start(*config); err != nil {


### PR DESCRIPTION
Note: ongoing tests, more might be added.

We found issues with the processing of `POST Task` transaction result processing on Azure FHIR.

Changes:
- Log transaction request and result bundle
- Introduce ORCA_LOGLEVEL config parameter (default: info)
- Support Azure FHIR's absolute URL (HAPI provides relative URLs) in bundle response `Location` header, which is used to select the right resource to return from a TX bundle

TODO:
- [x] Set tx logging to TRACE
- [x] Check what log level is enabled by default