### PR TITLE
INT-436: Destroying the previous session on demo launch (if found). 

### DIFF
--- a/hospital_simulator/app/(DashboardLayout)/components/service-requests/service-request-overview.tsx
+++ b/hospital_simulator/app/(DashboardLayout)/components/service-requests/service-request-overview.tsx
@@ -69,6 +69,7 @@ export default async function ServiceRequestOverview() {
                 const patient = serviceRequest.subject ? idToPatientMap[serviceRequest.subject.identifier.value] : undefined;
                 const patientIdentifier = serviceRequest.subject ? serviceRequest.subject.identifier.value : ""
                 const patientName = patient?.name && patient.name[0] ? patient.name[0].text : patientIdentifier;
+                const reasonRef = serviceRequest.reasonReference?.[0].display || "unknown";
 
                 return {
                     id: serviceRequest.id,
@@ -76,7 +77,8 @@ export default async function ServiceRequestOverview() {
                     title: serviceRequest.code.coding[0].display,
                     patient: patientName,
                     status: serviceRequest.status,
-                    patientId: patient ? `Patient/${patient.id}` : patientIdentifier
+                    patientId: patient ? `Patient/${patient.id}` : patientIdentifier,
+                    reasonReference: reasonRef,
                 }
             });
         }

--- a/hospital_simulator/app/(DashboardLayout)/components/service-requests/service-request-table.tsx
+++ b/hospital_simulator/app/(DashboardLayout)/components/service-requests/service-request-table.tsx
@@ -38,6 +38,7 @@ const ServiceRequestTable: React.FC<Props> = ({ rows }) => {
         { field: 'lastUpdated', headerName: 'Last Updated', type: 'dateTime', flex: 2 },
         { field: 'title', headerName: 'Title', flex: 3 },
         { field: 'patient', headerName: 'Patient', flex: 2 },
+        { field: 'reasonReference', headerName: 'Reason', flex: 2 },
         {
             field: 'status',
             headerName: 'Status',

--- a/orchestrator/careplancontributor/applaunch/demo/service.go
+++ b/orchestrator/careplancontributor/applaunch/demo/service.go
@@ -1,12 +1,13 @@
 package demo
 
 import (
-	"github.com/SanteonNL/orca/orchestrator/careplancontributor/applaunch/clients"
-	"github.com/SanteonNL/orca/orchestrator/user"
-	"github.com/rs/zerolog/log"
 	"net/http"
 	"net/url"
 	"strings"
+
+	"github.com/SanteonNL/orca/orchestrator/careplancontributor/applaunch/clients"
+	"github.com/SanteonNL/orca/orchestrator/user"
+	"github.com/rs/zerolog/log"
 )
 
 const fhirLauncherKey = "demo"
@@ -81,6 +82,14 @@ func (s *Service) handle(response http.ResponseWriter, request *http.Request) {
 	if !ok {
 		return
 	}
+
+	//Destroy the previous session if found
+	session := s.sessionManager.Get(request)
+	if session != nil {
+		log.Debug().Msg("Demo launch performed and previous session found - Destroying previous session")
+		s.sessionManager.Destroy(response, request)
+	}
+
 	s.sessionManager.Create(response, user.SessionData{
 		FHIRLauncher: fhirLauncherKey,
 		StringValues: values,

--- a/orchestrator/careplancontributor/applaunch/demo/service_test.go
+++ b/orchestrator/careplancontributor/applaunch/demo/service_test.go
@@ -1,11 +1,12 @@
 package demo
 
 import (
-	"github.com/SanteonNL/orca/orchestrator/user"
-	"github.com/stretchr/testify/require"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/SanteonNL/orca/orchestrator/user"
+	"github.com/stretchr/testify/require"
 )
 
 func TestService_handle(t *testing.T) {
@@ -30,5 +31,25 @@ func TestService_handle(t *testing.T) {
 
 		require.Equal(t, http.StatusFound, response.Code)
 		require.Equal(t, "/orca/cpc/", response.Header().Get("Location"))
+	})
+	t.Run("should destroy previous session", func(t *testing.T) {
+		sessionManager := user.NewSessionManager()
+		service := Service{sessionManager: sessionManager, baseURL: "/orca", landingUrlPath: "/cpc/"}
+		response := httptest.NewRecorder()
+		request := httptest.NewRequest("GET", "/demo-app-launch?patient=a&serviceRequest=b&practitioner=c&iss=https://example.com/fhir", nil)
+
+		service.handle(response, request)
+		require.Equal(t, 1, sessionManager.SessionCount())
+
+		// Now launch the second session - copy the cookies so the session is retained
+		cookies := response.Result().Cookies()
+		response = httptest.NewRecorder()
+		request = httptest.NewRequest("GET", "/demo-app-launch?patient=a&serviceRequest=b&practitioner=c&iss=https://example.com/fhir", nil)
+		for _, cookie := range cookies {
+			request.AddCookie(cookie)
+		}
+		service.handle(response, request)
+		require.Equal(t, 1, sessionManager.SessionCount())
+
 	})
 }

--- a/orchestrator/user/session.go
+++ b/orchestrator/user/session.go
@@ -1,11 +1,12 @@
 package user
 
 import (
-	"github.com/google/uuid"
-	"github.com/rs/zerolog/log"
 	"net/http"
 	"sync"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
 )
 
 const sessionLifetime = 15 * time.Minute
@@ -145,4 +146,8 @@ func getSessionCookie(request *http.Request) string {
 		return ""
 	}
 	return cookie.Value
+}
+
+func (m *SessionManager) SessionCount() int {
+	return len(m.store.sessions)
 }


### PR DESCRIPTION
Also showing the `ServiceRequest.reasonReference` in the EHR mock.

I've create a [separate issue](https://linear.app/zorg-bij-jou/issue/INT-446/orca-or-support-multiple-launches-in-one-browser) on how to support multiple launches in one browser.