### PR TITLE
Ignore nil response.Location for unmanaged FHIR operations

### DIFF
--- a/orchestrator/careplanservice/handle_createtask.go
+++ b/orchestrator/careplanservice/handle_createtask.go
@@ -223,9 +223,7 @@ func (s *Service) handleCreateTask(ctx context.Context, request FHIRHandlerReque
 	}
 	return func(txResult *fhir.Bundle) (*fhir.BundleEntry, []any, error) {
 		var createdTask fhir.Task
-		result, err := coolfhir.FetchBundleEntry(s.fhirClient, s.fhirURL, &taskBundleEntry, txResult, func(idx int, entry fhir.BundleEntry) bool {
-			return idx == taskEntryIdx
-		}, &createdTask)
+		result, err := coolfhir.NormalizeTransactionBundleResponseEntry(s.fhirClient, s.fhirURL, &taskBundleEntry, &txResult.Entry[taskEntryIdx], &createdTask)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/orchestrator/careplanservice/handle_createtask.go
+++ b/orchestrator/careplanservice/handle_createtask.go
@@ -65,6 +65,8 @@ func (s *Service) handleCreateTask(ctx context.Context, request FHIRHandlerReque
 	}
 
 	// Resolve the CarePlan
+	var taskEntryIdx = -1
+	var taskBundleEntry fhir.BundleEntry
 	if task.BasedOn == nil || len(task.BasedOn) == 0 {
 		// The CarePlan does not exist, a CarePlan and CareTeam will be created and the requester will be added as a member
 
@@ -143,6 +145,8 @@ func (s *Service) handleCreateTask(ctx context.Context, request FHIRHandlerReque
 		tx.Create(carePlan, coolfhir.WithFullUrl(carePlanURL)).
 			Create(careTeam, coolfhir.WithFullUrl(careTeamURL)).
 			Create(task, coolfhir.WithFullUrl(taskURL))
+		taskEntryIdx = len(tx.Entry) - 1
+		taskBundleEntry = tx.Entry[taskEntryIdx]
 	} else {
 		// Adding a task to an existing CarePlan
 		carePlanRef, err = basedOn(task)
@@ -192,33 +196,35 @@ func (s *Service) handleCreateTask(ctx context.Context, request FHIRHandlerReque
 		}
 		// TODO: Manage time-outs properly
 		// Add Task to CarePlan.activities
-		taskBundleEntry := request.bundleEntryWithResource(task)
+		taskBundleEntry = request.bundleEntryWithResource(task)
 		if taskBundleEntry.FullUrl == nil {
 			taskBundleEntry.FullUrl = to.Ptr("urn:uuid:" + uuid.NewString())
 		}
-		err = s.newTaskInExistingCarePlan(tx, taskBundleEntry, task, &carePlan)
+
+		// TODO: Only if not updated
+		tx.AppendEntry(taskBundleEntry)
+		taskEntryIdx = len(tx.Entry) - 1
+		if len(task.PartOf) == 0 {
+			// Don't add subtasks to CarePlan.activity
+			carePlan.Activity = append(carePlan.Activity, fhir.CarePlanActivity{
+				Reference: &fhir.Reference{
+					Reference: taskBundleEntry.FullUrl,
+					Type:      to.Ptr("Task"),
+				},
+			})
+			tx.Update(carePlan, "CarePlan/"+*carePlan.Id)
+		}
+		if _, err := careteamservice.Update(s.fhirClient, *carePlan.Id, task, tx); err != nil {
+			return nil, fmt.Errorf("failed to update CarePlan: %w", err)
+		}
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to create Task: %w", err)
 	}
 	return func(txResult *fhir.Bundle) (*fhir.BundleEntry, []any, error) {
 		var createdTask fhir.Task
-		result, err := coolfhir.FetchBundleEntry(s.fhirClient, txResult, func(_ int, entry fhir.BundleEntry) bool {
-			if entry.Response.Location == nil {
-				return false
-			}
-			// HAPI uses relative Location URLs, Microsoft Azure FHIR uses absolute URLs.
-			createdResourceLocation := *entry.Response.Location
-			createdResourceLocation = strings.TrimPrefix(createdResourceLocation, s.fhirURL.String())
-			// depending on the base URL ending with slash or not, we might end up with a leading slash.
-			// Trim it for deterministic comparison.
-			createdResourceLocation = strings.TrimPrefix(createdResourceLocation, "/")
-			if strings.HasPrefix(createdResourceLocation, "Task/") {
-				// Consistent behavior for easier testing: always pass the relative resource URL to the FHIR client
-				entry.Response.Location = to.Ptr(createdResourceLocation)
-				return true
-			}
-			return false
+		result, err := coolfhir.FetchBundleEntry(s.fhirClient, s.fhirURL, &taskBundleEntry, txResult, func(idx int, entry fhir.BundleEntry) bool {
+			return idx == taskEntryIdx
 		}, &createdTask)
 		if err != nil {
 			return nil, nil, err
@@ -232,26 +238,6 @@ func (s *Service) handleCreateTask(ctx context.Context, request FHIRHandlerReque
 
 		return result, []any{&createdTask}, nil
 	}, nil
-}
-
-// newTaskInExistingCarePlan creates a new Task and references the Task from the CarePlan.activities.
-func (s *Service) newTaskInExistingCarePlan(tx *coolfhir.BundleBuilder, taskBundleEntry fhir.BundleEntry, task fhir.Task, carePlan *fhir.CarePlan) error {
-	// TODO: Only if not updated
-	tx.AppendEntry(taskBundleEntry)
-	if len(task.PartOf) == 0 {
-		// Don't add subtasks to CarePlan.activity
-		carePlan.Activity = append(carePlan.Activity, fhir.CarePlanActivity{
-			Reference: &fhir.Reference{
-				Reference: taskBundleEntry.FullUrl,
-				Type:      to.Ptr("Task"),
-			},
-		})
-		tx.Update(*carePlan, "CarePlan/"+*carePlan.Id)
-	}
-	if _, err := careteamservice.Update(s.fhirClient, *carePlan.Id, task, tx); err != nil {
-		return fmt.Errorf("failed to update CarePlan: %w", err)
-	}
-	return nil
 }
 
 // basedOn returns the CarePlan reference the Task is based on, e.g. CarePlan/123.

--- a/orchestrator/careplanservice/handle_updatetask.go
+++ b/orchestrator/careplanservice/handle_updatetask.go
@@ -113,7 +113,8 @@ func (s *Service) handleUpdateTask(ctx context.Context, request FHIRHandlerReque
 	}
 	carePlanId := strings.TrimPrefix(*carePlanRef, "CarePlan/")
 
-	tx = tx.AppendEntry(request.bundleEntryWithResource(task))
+	taskBundleEntry := request.bundleEntryWithResource(task)
+	tx = tx.AppendEntry(taskBundleEntry)
 	idx := len(tx.Entry) - 1
 	// Update care team
 	_, err = careteamservice.Update(s.fhirClient, carePlanId, task, tx)
@@ -123,7 +124,7 @@ func (s *Service) handleUpdateTask(ctx context.Context, request FHIRHandlerReque
 
 	return func(txResult *fhir.Bundle) (*fhir.BundleEntry, []any, error) {
 		var updatedTask fhir.Task
-		result, err := coolfhir.FetchBundleEntry(s.fhirClient, txResult, func(currIdx int, entry fhir.BundleEntry) bool {
+		result, err := coolfhir.FetchBundleEntry(s.fhirClient, s.fhirURL, &taskBundleEntry, txResult, func(currIdx int, entry fhir.BundleEntry) bool {
 			return currIdx == idx
 		}, &updatedTask)
 		if errors.Is(err, coolfhir.ErrEntryNotFound) {

--- a/orchestrator/careplanservice/handle_updatetask.go
+++ b/orchestrator/careplanservice/handle_updatetask.go
@@ -124,9 +124,7 @@ func (s *Service) handleUpdateTask(ctx context.Context, request FHIRHandlerReque
 
 	return func(txResult *fhir.Bundle) (*fhir.BundleEntry, []any, error) {
 		var updatedTask fhir.Task
-		result, err := coolfhir.FetchBundleEntry(s.fhirClient, s.fhirURL, &taskBundleEntry, txResult, func(currIdx int, entry fhir.BundleEntry) bool {
-			return currIdx == idx
-		}, &updatedTask)
+		result, err := coolfhir.NormalizeTransactionBundleResponseEntry(s.fhirClient, s.fhirURL, &taskBundleEntry, &txResult.Entry[idx], &updatedTask)
 		if errors.Is(err, coolfhir.ErrEntryNotFound) {
 			// Bundle execution succeeded, but could not read result entry.
 			// Just respond with the original Task that was sent.

--- a/orchestrator/careplanservice/integration_test.go
+++ b/orchestrator/careplanservice/integration_test.go
@@ -1,6 +1,7 @@
 package careplanservice
 
 import (
+	"encoding/json"
 	fhirclient "github.com/SanteonNL/go-fhir-client"
 	"github.com/SanteonNL/orca/orchestrator/cmd/profile"
 	"github.com/SanteonNL/orca/orchestrator/lib/auth"
@@ -13,6 +14,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -27,6 +29,16 @@ func Test_Integration_TaskLifecycle(t *testing.T) {
 	t.Log("This test requires creates a new CarePlan and Task, then runs the Task through requested->accepted->completed lifecycle.")
 	notificationEndpoint := setupNotificationEndpoint(t)
 	carePlanContributor1, carePlanContributor2, invalidCarePlanContributor := setupIntegrationTest(t, notificationEndpoint)
+
+	t.Run("Example bundle 1", func(t *testing.T) {
+		t.Skip("TODO")
+		bundleData, err := os.ReadFile("testdata/bundles/testbundle-1.json")
+		require.NoError(t, err)
+		testBundle(t, carePlanContributor1, bundleData)
+
+	})
+
+	notificationCounter.Store(0)
 
 	participant1 := fhir.CareTeamParticipant{
 		Member: coolfhir.LogicalReference("Organization", coolfhir.URANamingSystem, "1"),
@@ -596,6 +608,18 @@ func Test_Integration_TaskLifecycle(t *testing.T) {
 	}
 
 }
+
+func testBundle(t *testing.T, fhirClient *fhirclient.BaseClient, data []byte) {
+	var bundle fhir.Bundle
+	err := json.Unmarshal(data, &bundle)
+	require.NoError(t, err)
+
+	err = fhirClient.Create(bundle, &bundle, fhirclient.AtPath("/"))
+	require.NoError(t, err)
+	responseData, _ := json.MarshalIndent(bundle, "  ", "")
+	println(string(responseData))
+}
+
 func setupIntegrationTest(t *testing.T, notificationEndpoint *url.URL) (*fhirclient.BaseClient, *fhirclient.BaseClient, *fhirclient.BaseClient) {
 	fhirBaseURL := test.SetupHAPI(t)
 	activeProfile := profile.TestProfile{

--- a/orchestrator/careplanservice/integration_test.go
+++ b/orchestrator/careplanservice/integration_test.go
@@ -35,7 +35,6 @@ func Test_Integration_TaskLifecycle(t *testing.T) {
 		bundleData, err := os.ReadFile("testdata/bundles/testbundle-1.json")
 		require.NoError(t, err)
 		testBundle(t, carePlanContributor1, bundleData)
-
 	})
 
 	notificationCounter.Store(0)

--- a/orchestrator/careplanservice/service.go
+++ b/orchestrator/careplanservice/service.go
@@ -222,9 +222,13 @@ func (s *Service) handleUnmanagedOperation(request FHIRHandlerRequest, tx *coolf
 	idx := len(tx.Entry) - 1
 	return func(txResult *fhir.Bundle) (*fhir.BundleEntry, []any, error) {
 		var resultResource []byte
-		err := s.fhirClient.Read(*txResult.Entry[idx].Response.Location, &resultResource)
-		if err != nil {
-			return nil, nil, err
+		responseJson, _ := json.Marshal(txResult.Entry[idx].Response)
+		log.Info().Msgf("Unmanaged operation response JSON: %s", string(responseJson))
+		if txResult.Entry[idx].Response != nil && txResult.Entry[idx].Response.Location != nil {
+			err := s.fhirClient.Read(*txResult.Entry[idx].Response.Location, &resultResource)
+			if err != nil {
+				return nil, nil, err
+			}
 		}
 		return &fhir.BundleEntry{
 			Resource: resultResource,

--- a/orchestrator/careplanservice/service.go
+++ b/orchestrator/careplanservice/service.go
@@ -222,9 +222,7 @@ func (s *Service) handleUnmanagedOperation(request FHIRHandlerRequest, tx *coolf
 	tx.AppendEntry(requestBundleEntry)
 	idx := len(tx.Entry) - 1
 	return func(txResult *fhir.Bundle) (*fhir.BundleEntry, []any, error) {
-		result, err := coolfhir.FetchBundleEntry(s.fhirClient, s.fhirURL, &requestBundleEntry, txResult, func(i int, entry fhir.BundleEntry) bool {
-			return i == idx
-		}, nil)
+		result, err := coolfhir.NormalizeTransactionBundleResponseEntry(s.fhirClient, s.fhirURL, &requestBundleEntry, &txResult.Entry[idx], nil)
 		return result, nil, err
 	}, nil
 }

--- a/orchestrator/careplanservice/service_test.go
+++ b/orchestrator/careplanservice/service_test.go
@@ -177,9 +177,11 @@ func TestService_DefaultOperationHandler(t *testing.T) {
 				reflect.ValueOf(resultResource).Elem().Set(reflect.ValueOf(expectedServiceRequestJson))
 				return nil
 			})
+		fhirBaseUrl, _ := url.Parse("http://example.com")
 		service := Service{
 			fhirClient:                   fhirClient,
 			allowUnmanagedFHIROperations: true,
+			fhirURL:                      fhirBaseUrl,
 		}
 
 		resultHandler, err := service.handleUnmanagedOperation(request, tx)

--- a/orchestrator/lib/coolfhir/bundle.go
+++ b/orchestrator/lib/coolfhir/bundle.go
@@ -164,67 +164,66 @@ func ExecuteTransaction(fhirClient fhirclient.Client, bundle fhir.Bundle) (fhir.
 	return resultBundle, nil
 }
 
-func FetchBundleEntry(fhirClient fhirclient.Client, fhirBaseURL *url.URL, requestBundleEntry *fhir.BundleEntry, responseBundle *fhir.Bundle, filter func(i int, entry fhir.BundleEntry) bool, result interface{}) (*fhir.BundleEntry, error) {
-	for i, currentEntry := range responseBundle.Entry {
-		if currentEntry.Response == nil {
-			log.Error().Msg("entry.Response is nil")
-			continue
-		}
-		if !filter(i, currentEntry) {
-			continue
-		}
-		response := currentEntry
-		// Enrich result with resource from FHIR server
-		if response.Resource == nil {
-			// Microsoft Azure FHIR: when PUT-ing a resource, the response entry might not contain a location.
-			//                       in that case, the location is the same as the request URL.
-			var resourcePath string
-			var requestOptions []fhirclient.Option
-			if currentEntry.Response.Location != nil {
-				resourcePath = *currentEntry.Response.Location
-				// HAPI uses relative Location URLs, Microsoft Azure FHIR uses absolute URLs.
-				resourcePath = strings.TrimPrefix(resourcePath, fhirBaseURL.String())
-				// depending on the base URL ending with slash or not, we might end up with a leading slash.
-				// Trim it for deterministic comparison.
-				resourcePath = strings.TrimPrefix(resourcePath, "/")
-				// Consistent behavior for easier testing and integration: pass the relative resource URL to the FHIR client.
-				// (HAPI uses relative Location URLs, Microsoft Azure FHIR uses absolute URLs.)
-				response.Response.Location = to.Ptr(resourcePath)
-			} else if strings.Contains(requestBundleEntry.Request.Url, "/") {
-				// response.location is not set, might be an upsert with logical identifier.
-				// In this case, it's a literal reference
-				resourcePath = requestBundleEntry.Request.Url
-			} else if strings.Contains(requestBundleEntry.Request.Url, "?") {
-				// response.location is not set, might be an upsert with logical identifier.
-				// In this case, it's a reference with a logical identifier
-				entryRequestUrl, err := url.Parse(requestBundleEntry.Request.Url)
-				if err != nil {
-					return nil, err
-				}
-				resourcePath = entryRequestUrl.Path
-				for key, values := range entryRequestUrl.Query() {
-					for _, value := range values {
-						requestOptions = append(requestOptions, fhirclient.QueryParam(key, value))
-					}
-				}
-			}
-			if resourcePath == "" {
-				responseBundleEntryJson, _ := json.Marshal(currentEntry)
-				log.Error().Msgf("Failed to determine resource path from FHIR transaction response bundle: %s", string(responseBundleEntryJson))
-				return nil, fmt.Errorf("failed to determine resource path for entry %d, see log for more details", i)
-			}
-			var resourceData []byte
-			if err := fhirClient.Read(resourcePath, &resourceData, requestOptions...); err != nil {
-				return nil, errors.Join(ErrEntryNotFound, fmt.Errorf("failed to retrieve result Bundle entry (resource=%s): %w", resourcePath, err))
-			}
-			response.Resource = resourceData
-		}
-		if len(response.Resource) != 0 && result != nil {
-			if err := json.Unmarshal(response.Resource, result); err != nil {
-				return nil, fmt.Errorf("unmarshal Bundle entry (target=%T): %w", result, err)
-			}
-		}
-		return &response, nil
+// NormalizeTransactionBundleResponseEntry normalizes a transaction bundle response entry returned from an upstream FHIR server,
+// so it can be returned to a client, who is agnostic of the upstream FHIR server implementation.
+// It does the following:
+// - Change the response.location property to a relative URL if it was an absolute URL
+// - Read the resource being referenced and unmarshal it into the given result argument (so it can be used for notification).
+// - Set the response.resource property to the read resource
+func NormalizeTransactionBundleResponseEntry(fhirClient fhirclient.Client, fhirBaseURL *url.URL, requestEntry *fhir.BundleEntry, responseEntry *fhir.BundleEntry, result interface{}) (*fhir.BundleEntry, error) {
+	if responseEntry.Response == nil {
+		return nil, errors.New("entry.Response is nil")
 	}
-	return nil, ErrEntryNotFound
+	resultEntry := *responseEntry
+	// Enrich result with resource from FHIR server
+	if resultEntry.Resource == nil {
+		// Microsoft Azure FHIR: when PUT-ing a resource, the resultEntry entry might not contain a location.
+		//                       in that case, the location is the same as the request URL.
+		var resourcePath string
+		var requestOptions []fhirclient.Option
+		if resultEntry.Response.Location != nil {
+			resourcePath = *resultEntry.Response.Location
+			// HAPI uses relative Location URLs, Microsoft Azure FHIR uses absolute URLs.
+			resourcePath = strings.TrimPrefix(resourcePath, fhirBaseURL.String())
+			// depending on the base URL ending with slash or not, we might end up with a leading slash.
+			// Trim it for deterministic comparison.
+			resourcePath = strings.TrimPrefix(resourcePath, "/")
+			// Consistent behavior for easier testing and integration: pass the relative resource URL to the FHIR client.
+			// (HAPI uses relative Location URLs, Microsoft Azure FHIR uses absolute URLs.)
+			resultEntry.Response.Location = to.Ptr(resourcePath)
+		} else if strings.Contains(requestEntry.Request.Url, "/") {
+			// resultEntry.location is not set, might be an upsert with logical identifier.
+			// In this case, it's a literal reference
+			resourcePath = requestEntry.Request.Url
+		} else if strings.Contains(requestEntry.Request.Url, "?") {
+			// resultEntry.location is not set, might be an upsert with logical identifier.
+			// In this case, it's a reference with a logical identifier
+			entryRequestUrl, err := url.Parse(requestEntry.Request.Url)
+			if err != nil {
+				return nil, err
+			}
+			resourcePath = entryRequestUrl.Path
+			for key, values := range entryRequestUrl.Query() {
+				for _, value := range values {
+					requestOptions = append(requestOptions, fhirclient.QueryParam(key, value))
+				}
+			}
+		}
+		if resourcePath == "" {
+			responseBundleEntryJson, _ := json.Marshal(responseEntry)
+			log.Error().Msgf("Failed to determine resource path from FHIR transaction resultEntry bundle: %s", string(responseBundleEntryJson))
+			return nil, errors.New("failed to determine resource for transaction response bundle entry, see log for more details")
+		}
+		var resourceData []byte
+		if err := fhirClient.Read(resourcePath, &resourceData, requestOptions...); err != nil {
+			return nil, errors.Join(ErrEntryNotFound, fmt.Errorf("failed to retrieve result Bundle entry (resource=%s): %w", resourcePath, err))
+		}
+		resultEntry.Resource = resourceData
+	}
+	if len(resultEntry.Resource) != 0 && result != nil {
+		if err := json.Unmarshal(resultEntry.Resource, result); err != nil {
+			return nil, fmt.Errorf("unmarshal Bundle entry (target=%T): %w", result, err)
+		}
+	}
+	return &resultEntry, nil
 }

--- a/orchestrator/lib/coolfhir/bundle_test.go
+++ b/orchestrator/lib/coolfhir/bundle_test.go
@@ -2,6 +2,12 @@ package coolfhir
 
 import (
 	"encoding/json"
+	"errors"
+	fhirclient "github.com/SanteonNL/go-fhir-client"
+	"github.com/SanteonNL/orca/orchestrator/careplancontributor/mock"
+	"go.uber.org/mock/gomock"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/SanteonNL/orca/orchestrator/lib/to"
@@ -28,4 +34,158 @@ func TestTransactionBuilder(t *testing.T) {
 	var task2 map[string]interface{}
 	require.NoError(t, json.Unmarshal(tx.Entry[1].Resource, &task2))
 	require.Equal(t, "task2", task2["id"])
+}
+
+func TestFetchBundleEntry(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	fhirClient := mock.NewMockClient(ctrl)
+	fhirClient.EXPECT().Read("Task/123", gomock.Any(), gomock.Any()).DoAndReturn(func(resource string, data *[]byte, opts ...interface{}) error {
+		*data, _ = json.Marshal(fhir.Task{
+			Id: to.Ptr("123"),
+		})
+		return nil
+	}).AnyTimes()
+	fhirClient.EXPECT().Read("Task", gomock.Any(), gomock.Any()).DoAndReturn(func(resource string, data *[]byte, opts ...interface{}) error {
+		httpRequest := httptest.NewRequest("GET", "http://example.com/fhir/Task", nil)
+		opts[0].(fhirclient.PreRequestOption)(fhirClient, httpRequest)
+		if httpRequest.URL.Query()["_id"][0] == "123" {
+			*data, _ = json.Marshal(fhir.Task{
+				Id: to.Ptr("123"),
+			})
+			return nil
+		}
+		return errors.New("not found")
+	}).AnyTimes()
+	fhirBaseUrl, _ := url.Parse("http://example.com/fhir")
+
+	t.Run("resource read from response.location (relative URL)", func(t *testing.T) {
+		response := &fhir.Bundle{
+			Type: fhir.BundleTypeTransactionResponse,
+			Entry: []fhir.BundleEntry{
+				{
+					Response: &fhir.BundleEntryResponse{
+						Location: to.Ptr("Task/123"),
+						Status:   "200",
+					},
+				},
+			},
+		}
+		var actualResult fhir.Task
+		actualEntry, err := FetchBundleEntry(fhirClient, fhirBaseUrl, nil, response, func(_ int, _ fhir.BundleEntry) bool {
+			return true
+		}, &actualResult)
+		require.NoError(t, err)
+		require.Equal(t, "123", *actualResult.Id)
+		require.NotEmpty(t, actualEntry.Resource)
+		require.Equal(t, "Task/123", *actualEntry.Response.Location)
+		require.Equal(t, "200", actualEntry.Response.Status)
+	})
+	t.Run("resource read from response.location (absolute URL)", func(t *testing.T) {
+		response := &fhir.Bundle{
+			Type: fhir.BundleTypeTransactionResponse,
+			Entry: []fhir.BundleEntry{
+				{
+					Response: &fhir.BundleEntryResponse{
+						Location: to.Ptr("http://example.com/fhir/Task/123"),
+					},
+				},
+			},
+		}
+		var actualResult fhir.Task
+		actualEntry, err := FetchBundleEntry(fhirClient, fhirBaseUrl, nil, response, func(_ int, _ fhir.BundleEntry) bool {
+			return true
+		}, &actualResult)
+		require.NoError(t, err)
+		require.Equal(t, "123", *actualResult.Id)
+		require.NotEmpty(t, actualEntry.Resource)
+		require.Equal(t, "Task/123", *actualEntry.Response.Location)
+	})
+	t.Run("resource read from request BundleEntry.request.url, which contains a literal reference (response.location is nil, e.g. PUT in Azure FHIR)", func(t *testing.T) {
+		request := &fhir.BundleEntry{
+			Request: &fhir.BundleEntryRequest{
+				Url: "Task/123",
+			},
+		}
+		response := &fhir.Bundle{
+			Type: fhir.BundleTypeTransactionResponse,
+			Entry: []fhir.BundleEntry{
+				{
+					Response: &fhir.BundleEntryResponse{
+						Status: "200",
+					},
+				},
+			},
+		}
+		var actualResult fhir.Task
+		actualEntry, err := FetchBundleEntry(fhirClient, fhirBaseUrl, request, response, func(_ int, _ fhir.BundleEntry) bool {
+			return true
+		}, &actualResult)
+		require.NoError(t, err)
+		require.Equal(t, "123", *actualResult.Id)
+		require.NotEmpty(t, actualEntry.Resource)
+		require.Equal(t, "200", actualEntry.Response.Status)
+	})
+	t.Run("resource read from request BundleEntry.request.url, which contains a logical identifier (response.location is nil, e.g. PUT in Azure FHIR)", func(t *testing.T) {
+		request := &fhir.BundleEntry{
+			Request: &fhir.BundleEntryRequest{
+				Url: "Task?_id=123",
+			},
+		}
+		response := &fhir.Bundle{
+			Type: fhir.BundleTypeTransactionResponse,
+			Entry: []fhir.BundleEntry{
+				{
+					Response: &fhir.BundleEntryResponse{
+						Status: "200",
+					},
+				},
+			},
+		}
+		var actualResult fhir.Task
+		actualEntry, err := FetchBundleEntry(fhirClient, fhirBaseUrl, request, response, func(_ int, _ fhir.BundleEntry) bool {
+			return true
+		}, &actualResult)
+		require.NoError(t, err)
+		require.Equal(t, "123", *actualResult.Id)
+		require.NotEmpty(t, actualEntry.Resource)
+		require.Equal(t, "200", actualEntry.Response.Status)
+	})
+	t.Run("resource read from request BundleEntry.request.url, which doesn't contain a local reference nor logical identifier (not supported now)", func(t *testing.T) {
+		request := &fhir.BundleEntry{
+			Request: &fhir.BundleEntryRequest{
+				Url: "Task",
+			},
+		}
+		response := &fhir.Bundle{
+			Type: fhir.BundleTypeTransactionResponse,
+			Entry: []fhir.BundleEntry{
+				{
+					Response: &fhir.BundleEntryResponse{
+						Status: "200",
+					},
+				},
+			},
+		}
+		_, err := FetchBundleEntry(fhirClient, fhirBaseUrl, request, response, func(_ int, _ fhir.BundleEntry) bool {
+			return true
+		}, nil)
+		require.EqualError(t, err, "failed to determine resource path for entry 0, see log for more details")
+	})
+	t.Run("result to unmarshal into is nil", func(t *testing.T) {
+		response := &fhir.Bundle{
+			Type: fhir.BundleTypeTransactionResponse,
+			Entry: []fhir.BundleEntry{
+				{
+					Response: &fhir.BundleEntryResponse{
+						Location: to.Ptr("http://example.com/fhir/Task/123"),
+					},
+				},
+			},
+		}
+		actualEntry, err := FetchBundleEntry(fhirClient, fhirBaseUrl, nil, response, func(_ int, _ fhir.BundleEntry) bool {
+			return true
+		}, nil)
+		require.NoError(t, err)
+		require.NotNil(t, actualEntry)
+	})
 }

--- a/orchestrator/lib/test/hapi.go
+++ b/orchestrator/lib/test/hapi.go
@@ -3,7 +3,7 @@ package test
 import (
 	"context"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go"
+	tc "github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	"net/url"
 	"testing"
@@ -13,15 +13,16 @@ import (
 
 func SetupHAPI(t *testing.T) *url.URL {
 	ctx := context.Background()
-	req := testcontainers.ContainerRequest{
+	req := tc.ContainerRequest{
 		Image:        "hapiproject/hapi:v7.2.0",
 		ExposedPorts: []string{"8080/tcp"},
 		Env: map[string]string{
-			"hapi.fhir.fhir_version": "R4",
+			"hapi.fhir.fhir_version":              "R4",
+			"hapi.fhir.allow_external_references": "true",
 		},
 		WaitingFor: wait.ForHTTP("/fhir/Task"),
 	}
-	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
+	container, err := tc.GenericContainer(ctx, tc.GenericContainerRequest{
 		ContainerRequest: req,
 		Started:          true,
 	})


### PR DESCRIPTION
It failed because we need the resource being updated for sending notifications. But, sometimes Azure FHIR doesn't populate `Bundle.entry.response.location`. This caused nil derefs in multiple spots.

Made a more rigorous (and better tested) function, simplified the getting the right bundle entry to resepond with in the our FHIR operation handlers.