### PR TITLE
Persist Zorgplatform workflow-id

### DIFF
--- a/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
@@ -377,6 +377,12 @@ func (s *Service) getSessionData(ctx context.Context, accessToken string, launch
 
 	serviceRequest := &fhir.ServiceRequest{
 		Status: fhir.RequestStatusActive,
+		Identifier: []fhir.Identifier{
+			{
+				System: to.Ptr("https://api.zorgplatform.online/fhir/v1"),
+				Value:  to.Ptr(launchContext.WorkflowId),
+			},
+		},
 		Code: &fhir.CodeableConcept{
 			Coding: []fhir.Coding{
 				// Hardcoded, we only do Telemonitoring for now

--- a/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
@@ -379,8 +379,8 @@ func (s *Service) getSessionData(ctx context.Context, accessToken string, launch
 		Status: fhir.RequestStatusActive,
 		Identifier: []fhir.Identifier{
 			{
-				System: to.Ptr("https://api.zorgplatform.online/fhir/v1"),
-				Value:  to.Ptr("Task/" + launchContext.WorkflowId),
+				System: to.Ptr("https://api.zorgplatform.online/fhir/v1/Task"),
+				Value:  to.Ptr(launchContext.WorkflowId),
 			},
 		},
 		Code: &fhir.CodeableConcept{

--- a/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
@@ -380,7 +380,7 @@ func (s *Service) getSessionData(ctx context.Context, accessToken string, launch
 		Identifier: []fhir.Identifier{
 			{
 				System: to.Ptr("https://api.zorgplatform.online/fhir/v1"),
-				Value:  to.Ptr(launchContext.WorkflowId),
+				Value:  to.Ptr("Task/" + launchContext.WorkflowId),
 			},
 		},
 		Code: &fhir.CodeableConcept{

--- a/orchestrator/careplancontributor/applaunch/zorgplatform/service_test.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/service_test.go
@@ -10,8 +10,6 @@ import (
 	"encoding/binary"
 	"encoding/pem"
 	"fmt"
-	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
-	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
 	"hash"
 	"net/http"
 	"net/http/httptest"
@@ -19,6 +17,9 @@ import (
 	"os"
 	"testing"
 	"time"
+
+	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
+	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates"
 	"github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys"
@@ -227,6 +228,11 @@ func TestService(t *testing.T) {
 			serviceRequestRef := sessionData.StringValues["serviceRequest"]
 			require.NotEmpty(t, serviceRequestRef)
 			require.IsType(t, fhir.ServiceRequest{}, sessionData.OtherValues[serviceRequestRef])
+			t.Run("check Workflow-ID identifier is properly set on the ServiceRequest", func(t *testing.T) {
+				serviceRequest := sessionData.OtherValues[serviceRequestRef].(fhir.ServiceRequest)
+				require.Len(t, serviceRequest.Identifier, 1)
+				require.Equal(t, "b526e773-e1a6-4533-bd00-1360c97e745f", *serviceRequest.Identifier[0].Value)
+			})
 		})
 		t.Run("check Patient is in session", func(t *testing.T) {
 			patientRef := sessionData.StringValues["patient"]

--- a/orchestrator/careplancontributor/applaunch/zorgplatform/service_test.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/service_test.go
@@ -230,8 +230,15 @@ func TestService(t *testing.T) {
 			require.IsType(t, fhir.ServiceRequest{}, sessionData.OtherValues[serviceRequestRef])
 			t.Run("check Workflow-ID identifier is properly set on the ServiceRequest", func(t *testing.T) {
 				serviceRequest := sessionData.OtherValues[serviceRequestRef].(fhir.ServiceRequest)
-				require.Len(t, serviceRequest.Identifier, 1)
-				require.Equal(t, "Task/b526e773-e1a6-4533-bd00-1360c97e745f", *serviceRequest.Identifier[0].Value)
+				var workflowIDIdentifier *fhir.Identifier
+				for _, identifier := range serviceRequest.Identifier {
+					if *identifier.System == "https://api.zorgplatform.online/fhir/v1/Task" {
+						workflowIDIdentifier = &identifier
+						break
+					}
+				}
+				require.NotNil(t, workflowIDIdentifier)
+				require.Equal(t, "b526e773-e1a6-4533-bd00-1360c97e745f", *workflowIDIdentifier.Value)
 			})
 		})
 		t.Run("check Patient is in session", func(t *testing.T) {

--- a/orchestrator/careplancontributor/applaunch/zorgplatform/service_test.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/service_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/binary"
 	"encoding/pem"
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"hash"
 	"net/http"
 	"net/http/httptest"
@@ -230,15 +231,10 @@ func TestService(t *testing.T) {
 			require.IsType(t, fhir.ServiceRequest{}, sessionData.OtherValues[serviceRequestRef])
 			t.Run("check Workflow-ID identifier is properly set on the ServiceRequest", func(t *testing.T) {
 				serviceRequest := sessionData.OtherValues[serviceRequestRef].(fhir.ServiceRequest)
-				var workflowIDIdentifier *fhir.Identifier
-				for _, identifier := range serviceRequest.Identifier {
-					if *identifier.System == "https://api.zorgplatform.online/fhir/v1/Task" {
-						workflowIDIdentifier = &identifier
-						break
-					}
-				}
-				require.NotNil(t, workflowIDIdentifier)
-				require.Equal(t, "b526e773-e1a6-4533-bd00-1360c97e745f", *workflowIDIdentifier.Value)
+				assert.Contains(t, serviceRequest.Identifier, fhir.Identifier{
+					System: to.Ptr("https://api.zorgplatform.online/fhir/v1/Task"),
+					Value:  to.Ptr("b526e773-e1a6-4533-bd00-1360c97e745f"),
+				})
 			})
 		})
 		t.Run("check Patient is in session", func(t *testing.T) {

--- a/orchestrator/careplancontributor/applaunch/zorgplatform/service_test.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/service_test.go
@@ -231,7 +231,7 @@ func TestService(t *testing.T) {
 			t.Run("check Workflow-ID identifier is properly set on the ServiceRequest", func(t *testing.T) {
 				serviceRequest := sessionData.OtherValues[serviceRequestRef].(fhir.ServiceRequest)
 				require.Len(t, serviceRequest.Identifier, 1)
-				require.Equal(t, "b526e773-e1a6-4533-bd00-1360c97e745f", *serviceRequest.Identifier[0].Value)
+				require.Equal(t, "Task/b526e773-e1a6-4533-bd00-1360c97e745f", *serviceRequest.Identifier[0].Value)
 			})
 		})
 		t.Run("check Patient is in session", func(t *testing.T) {


### PR DESCRIPTION
Mapping the `ServiceRequest` to the Zorgplatform `workflow-id`. Zorgplatform does not work with a `ServiceRequest`, but a `Task` for orders. They serve the same purpose, so they are mapped. This allows for querying the Zorgplatform data later on.