### PR TITLE
CPS: return original bundle stripped from unauthorized resources

### DIFF
--- a/orchestrator/careplanservice/handle_getpatient_test.go
+++ b/orchestrator/careplanservice/handle_getpatient_test.go
@@ -7,6 +7,7 @@ import (
 	fhirclient "github.com/SanteonNL/go-fhir-client"
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor/mock"
 	"github.com/SanteonNL/orca/orchestrator/lib/auth"
+	"github.com/SanteonNL/orca/orchestrator/lib/to"
 	"github.com/stretchr/testify/require"
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
 	"go.uber.org/mock/gomock"
@@ -261,6 +262,13 @@ func TestService_handleSearchPatient(t *testing.T) {
 			name:        "Patient returned, careplan and careteam returned, correct principal",
 			queryParams: url.Values{},
 			returnedBundle: &fhir.Bundle{
+				Link: []fhir.BundleLink{
+					{
+						Relation: "self",
+						Url:      "http://example.com/fhir/Patient?some-query-params",
+					},
+				},
+				Timestamp: to.Ptr("2021-09-01T12:00:00Z"),
 				Entry: []fhir.BundleEntry{
 					{
 						Resource: patient1,
@@ -278,6 +286,13 @@ func TestService_handleSearchPatient(t *testing.T) {
 				},
 			},
 			expectedBundle: &fhir.Bundle{
+				Link: []fhir.BundleLink{
+					{
+						Relation: "self",
+						Url:      "http://example.com/fhir/Patient?some-query-params",
+					},
+				},
+				Timestamp: to.Ptr("2021-09-01T12:00:00Z"),
 				Entry: []fhir.BundleEntry{
 					{
 						Resource: patient1,

--- a/orchestrator/careplanservice/integration_test.go
+++ b/orchestrator/careplanservice/integration_test.go
@@ -14,7 +14,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -29,13 +28,6 @@ func Test_Integration_TaskLifecycle(t *testing.T) {
 	t.Log("This test requires creates a new CarePlan and Task, then runs the Task through requested->accepted->completed lifecycle.")
 	notificationEndpoint := setupNotificationEndpoint(t)
 	carePlanContributor1, carePlanContributor2, invalidCarePlanContributor := setupIntegrationTest(t, notificationEndpoint)
-
-	t.Run("Example bundle 1", func(t *testing.T) {
-		t.Skip("TODO")
-		bundleData, err := os.ReadFile("testdata/bundles/testbundle-1.json")
-		require.NoError(t, err)
-		testBundle(t, carePlanContributor1, bundleData)
-	})
 
 	notificationCounter.Store(0)
 
@@ -603,7 +595,7 @@ func Test_Integration_TaskLifecycle(t *testing.T) {
 		err = carePlanContributor1.Read("Patient", &searchResult, fhirclient.QueryParam("identifier", "http://fhir.nl/fhir/NamingSystem/bsn|1333333337,http://fhir.nl/fhir/NamingSystem/bsn|12345"))
 		require.NoError(t, err)
 		require.Len(t, searchResult.Entry, 1)
-		require.True(t, strings.HasSuffix(*searchResult.Entry[0].FullUrl, "Patient/"+*patient.Id))
+		require.Truef(t, strings.HasSuffix(*searchResult.Entry[0].FullUrl, "Patient/"+*patient.Id), "Expected %s to end with %s", *searchResult.Entry[0].FullUrl, "Patient/"+*patient.Id)
 	}
 
 }

--- a/orchestrator/careplanservice/util.go
+++ b/orchestrator/careplanservice/util.go
@@ -148,24 +148,19 @@ func matchResourceIDs(request *FHIRHandlerRequest, idFromResource *string) error
 }
 
 // filterMatchingResourcesInBundle will find all resources in the bundle of the given type with a matching ID and return a new bundle with only those resources
+// To populate the 'total' field, the function will count the number of matching resources that
 func filterMatchingResourcesInBundle(bundle *fhir.Bundle, resourceTypes []string, references []string) fhir.Bundle {
-	newBundle := fhir.Bundle{
-		Entry: []fhir.BundleEntry{},
-	}
-
-	operationOutcomeErrors := []fhir.BundleEntry{}
-	for i, entry := range bundle.Entry {
+	newBundle := *bundle
+	j := 0
+	for _, entry := range newBundle.Entry {
 		var resourceInBundle coolfhir.Resource
 		err := json.Unmarshal(entry.Resource, &resourceInBundle)
 		if err != nil {
-			// We don't want to fail the whole operation if one resource fails to unmarshal
+			// We don't want to fail the whole operation if one resource fails to unmarshal.
+			// Replace result bundle entry with an OperationOutcome to inform the client something went wrong.
 			log.Error().Msgf("filterMatchingResourcesInBundle: Failed to unmarshal resource: %v", err)
-			operationOutcomeEntry, err := coolfhir.CreateOperationOutcomeBundleEntryFromError(err, "Failed to unmarshal resource")
-			if err != nil {
-				log.Error().Msgf("filterMatchingResourcesInBundle: Failed to marshal operation outcome: %v", err)
-				continue
-			}
-			operationOutcomeErrors = append(operationOutcomeErrors, *operationOutcomeEntry)
+			newBundle.Entry[j] = coolfhir.CreateOperationOutcomeBundleEntryFromError(err, "Failed to unmarshal resource")
+			j++
 			continue
 		}
 
@@ -173,23 +168,20 @@ func filterMatchingResourcesInBundle(bundle *fhir.Bundle, resourceTypes []string
 			for _, ref := range references {
 				parts := strings.Split(ref, "/")
 				if len(parts) != 2 {
+					// Replace result bundle entry with an OperationOutcome, since we couldn't resolve it
 					log.Error().Msgf("filterMatchingResourcesInBundle: Invalid reference format: %s", ref)
-					operationOutcomeEntry, err := coolfhir.CreateOperationOutcomeBundleEntryFromError(fmt.Errorf("Invalid reference format: %s", ref), "Invalid reference format")
-					if err != nil {
-						log.Error().Msgf("filterMatchingResourcesInBundle: Failed to marshal operation outcome: %v", err)
-						continue
-					}
-					operationOutcomeErrors = append(operationOutcomeErrors, *operationOutcomeEntry)
+					newBundle.Entry[j] = coolfhir.CreateOperationOutcomeBundleEntryFromError(fmt.Errorf("Invalid reference format: %s", ref), "Invalid reference format")
+					j++
 					continue
 				}
 				if parts[0] == resourceInBundle.Type && parts[1] == resourceInBundle.ID {
-					newBundle.Entry = append(newBundle.Entry, bundle.Entry[i])
+					newBundle.Entry[j] = entry
+					j++
 					break
 				}
 			}
 		}
 	}
-	newBundle.Entry = append(newBundle.Entry, operationOutcomeErrors...)
-
+	newBundle.Entry = newBundle.Entry[:j]
 	return newBundle
 }

--- a/orchestrator/lib/coolfhir/error.go
+++ b/orchestrator/lib/coolfhir/error.go
@@ -74,8 +74,8 @@ func BadRequest(msg string, args ...any) error {
 }
 
 // CreateOperationOutcomeBundleEntryFromError creates a BundleEntry with an OperationOutcome based on the given error
-func CreateOperationOutcomeBundleEntryFromError(err error, desc string) (*fhir.BundleEntry, error) {
-	rawOperationOutcome, err := json.Marshal(fhir.OperationOutcome{
+func CreateOperationOutcomeBundleEntryFromError(err error, desc string) fhir.BundleEntry {
+	rawOperationOutcome, _ := json.Marshal(fhir.OperationOutcome{
 		Issue: []fhir.OperationOutcomeIssue{
 			{
 				Severity:    fhir.IssueSeverityError,
@@ -83,13 +83,9 @@ func CreateOperationOutcomeBundleEntryFromError(err error, desc string) (*fhir.B
 			},
 		},
 	})
-	if err != nil {
-		log.Error().Msgf("Failed to marshal operation outcome: %v", err)
-		return nil, err
-	}
-	return &fhir.BundleEntry{
+	return fhir.BundleEntry{
 		Resource: rawOperationOutcome,
-	}, nil
+	}
 }
 
 // WriteOperationOutcomeFromError writes an OperationOutcome based on the given error as HTTP response.


### PR DESCRIPTION
To prevent accidentally omitting fields.

The problem was we created a new Bundle, now we simply take a copy instead.