### PR TITLE
Pass context to loggers to prepare for contextual logging

### DIFF
--- a/orchestrator/careplancontributor/applaunch/demo/service.go
+++ b/orchestrator/careplancontributor/applaunch/demo/service.go
@@ -86,7 +86,7 @@ func (s *Service) handle(response http.ResponseWriter, request *http.Request) {
 	//Destroy the previous session if found
 	session := s.sessionManager.Get(request)
 	if session != nil {
-		log.Debug().Msg("Demo launch performed and previous session found - Destroying previous session")
+		log.Debug().Ctx(request.Context()).Msg("Demo launch performed and previous session found - Destroying previous session")
 		s.sessionManager.Destroy(response, request)
 	}
 

--- a/orchestrator/careplancontributor/applaunch/smartonfhir/service.go
+++ b/orchestrator/careplancontributor/applaunch/smartonfhir/service.go
@@ -1,6 +1,7 @@
 package smartonfhir
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor/applaunch/clients"
@@ -104,14 +105,14 @@ func (s *Service) handleSmartAppLaunchRedirect(response http.ResponseWriter, req
 	state := request.URL.Query().Get("state")
 	code := request.URL.Query().Get("code")
 
-	tokenResponse, err := s.appLaunchRedirectLogic(state, code)
+	tokenResponse, err := s.appLaunchRedirectLogic(request.Context(), state, code)
 	if err != nil {
 		return
 	}
 
 	// accessToken := tokenResponse["access_token"]
 
-	log.Info().Msgf("SMART App Launch succeeded, got the following response\n%v", tokenResponse)
+	log.Info().Ctx(request.Context()).Msgf("SMART App Launch succeeded, got the following response\n%v", tokenResponse)
 
 	// 1) Extract the type of launch that is being performed, for example an enrollment, or a data view
 	// 2) switch type - call the apropriate service to handle the request
@@ -125,7 +126,7 @@ func (s *Service) handleSmartAppLaunchRedirect(response http.ResponseWriter, req
 	http.Redirect(response, request, s.landingUrlPath, http.StatusFound)
 }
 
-func (s *Service) appLaunchRedirectLogic(state string, code string) (map[string]interface{}, error) {
+func (s *Service) appLaunchRedirectLogic(ctx context.Context, state string, code string) (map[string]interface{}, error) {
 	s.mu.Lock()
 	tokenEndpoint, ok := s.stateToTokenUrlMap[state]
 	s.mu.Unlock()
@@ -142,7 +143,7 @@ func (s *Service) appLaunchRedirectLogic(state string, code string) (map[string]
 
 	resp, err := http.PostForm(tokenEndpoint, data)
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to exchange authorization code for access token")
+		log.Error().Ctx(ctx).Err(err).Msg("Failed to exchange authorization code for access token")
 		return nil, err
 	}
 	defer resp.Body.Close()
@@ -153,7 +154,7 @@ func (s *Service) appLaunchRedirectLogic(state string, code string) (map[string]
 
 	var tokenResponse map[string]interface{}
 	if err := json.NewDecoder(resp.Body).Decode(&tokenResponse); err != nil {
-		log.Error().Err(err).Msg("Failed to decode token response")
+		log.Error().Ctx(ctx).Err(err).Msg("Failed to decode token response")
 		return nil, err
 	}
 

--- a/orchestrator/careplancontributor/applaunch/zorgplatform/handle_create_access_token.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/handle_create_access_token.go
@@ -384,8 +384,8 @@ func (s *Service) submitSAMLRequest(envelope string) (string, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		log.Debug().Msgf("Zorgplatform STS SOAP request: %s", envelope)
-		log.Debug().Msgf("Zorgplatform STS SOAP response: %s", string(responseBody))
+		log.Debug().Ctx(ctx).Msgf("Zorgplatform STS SOAP request: %s", envelope)
+		log.Debug().Ctx(ctx).Msgf("Zorgplatform STS SOAP response: %s", string(responseBody))
 		return "", fmt.Errorf("unexpected response status: %d", resp.StatusCode)
 	}
 

--- a/orchestrator/careplancontributor/applaunch/zorgplatform/handle_validation_test.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/handle_validation_test.go
@@ -1,6 +1,7 @@
 package zorgplatform
 
 import (
+	"context"
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
@@ -25,6 +26,7 @@ func TestValidateAudienceIssuerAndExtractSubjectAndExtractResourceID(t *testing.
 		sessionManager: sessionManager,
 	}
 
+	ctx := context.Background()
 	assertionXML, err := os.ReadFile("assertion_example.xml")
 	require.NoError(t, err)
 	decryptedDocument := etree.NewDocument()
@@ -94,7 +96,7 @@ func TestValidateAudienceIssuerAndExtractSubjectAndExtractResourceID(t *testing.
 			}
 
 			// Extract Practitioner
-			practitioner, err := s.extractPractitioner(decryptedAssertion)
+			practitioner, err := s.extractPractitioner(ctx, decryptedAssertion)
 			if tt.expectedError != nil && err != nil {
 				assert.EqualError(t, err, tt.expectedError.Error())
 			} else {
@@ -113,7 +115,7 @@ func TestValidateAudienceIssuerAndExtractSubjectAndExtractResourceID(t *testing.
 			}
 
 			// Extract Workflow ID
-			workflowID, err := s.extractWorkflowID(decryptedAssertion)
+			workflowID, err := s.extractWorkflowID(ctx, decryptedAssertion)
 			if tt.expectedError != nil && err != nil {
 				assert.EqualError(t, err, tt.expectedError.Error())
 			} else {
@@ -174,6 +176,7 @@ func TestValidateTokenExpiry(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			doc := etree.NewDocument()
+			ctx := context.Background()
 			root := doc.CreateElement("Assertion")
 			timestamp := root.CreateElement("u:Timestamp")
 			created := timestamp.CreateElement("u:Created")
@@ -181,7 +184,7 @@ func TestValidateTokenExpiry(t *testing.T) {
 			expires := timestamp.CreateElement("u:Expires")
 			expires.SetText(tt.expires)
 
-			err := s.validateAssertionExpiry(doc)
+			err := s.validateAssertionExpiry(ctx, doc)
 			if tt.expectedError != nil {
 				assert.EqualError(t, err, tt.expectedError.Error())
 			} else {

--- a/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
@@ -172,7 +172,7 @@ func (s *Service) RegisterHandlers(mux *http.ServeMux) {
 }
 
 func (s *Service) handleLaunch(response http.ResponseWriter, request *http.Request) {
-	log.Debug().Msg("Handling ChipSoft HiX app launch")
+	log.Debug().Ctx(request.Context()).Msg("Handling ChipSoft HiX app launch")
 	if err := request.ParseForm(); err != nil {
 		http.Error(response, fmt.Errorf("unable to parse form: %w", err).Error(), http.StatusBadRequest)
 		return
@@ -183,17 +183,17 @@ func (s *Service) handleLaunch(response http.ResponseWriter, request *http.Reque
 		return
 	}
 
-	launchContext, err := s.parseSamlResponse(samlResponse)
+	launchContext, err := s.parseSamlResponse(request.Context(), samlResponse)
 
 	if err != nil {
 		// Only log sensitive information, the response just sends out 400
-		log.Error().Err(err).Msg("unable to validate SAML token")
+		log.Err(err).Ctx(request.Context()).Msg("unable to validate SAML token")
 		http.Error(response, "Application launch failed.", http.StatusBadRequest)
 		return
 	}
 
 	// TODO: Remove this debug logging later
-	log.Info().Msgf("SAML token validated, bsn=%s, workflowId=%s", launchContext.Bsn, launchContext.WorkflowId)
+	log.Info().Ctx(request.Context()).Msgf("SAML token validated, bsn=%s, workflowId=%s", launchContext.Bsn, launchContext.WorkflowId)
 
 	//TODO: launchContext.Practitioner needs to be converted to Patient ref (after the HCP ProfessionalService access tokens can be requested)
 	// Cache FHIR resources that don't exist in the EHR in the session,
@@ -203,16 +203,16 @@ func (s *Service) handleLaunch(response http.ResponseWriter, request *http.Reque
 	accessToken, err := s.secureTokenService.RequestAccessToken(launchContext, hcpTokenType)
 
 	if err != nil {
-		log.Error().Err(err).Msg("unable to request access token for HCP ProfessionalService")
+		log.Err(err).Ctx(request.Context()).Msg("unable to request access token for HCP ProfessionalService")
 		http.Error(response, "Application launch failed.", http.StatusBadRequest)
 		return
 	}
 
-	log.Info().Msgf("Successfully requested access token for HCP ProfessionalService, access_token=%s...", accessToken[:min(len(accessToken), 16)])
+	log.Info().Ctx(request.Context()).Msgf("Successfully requested access token for HCP ProfessionalService, access_token=%s...", accessToken[:min(len(accessToken), 16)])
 
 	sessionData, err := s.getSessionData(request.Context(), accessToken, launchContext)
 	if err != nil {
-		log.Error().Err(err).Msg("unable to create session data")
+		log.Err(err).Ctx(request.Context()).Msg("unable to create session data")
 		http.Error(response, "Application launch failed.", http.StatusInternalServerError)
 		return
 	}
@@ -222,7 +222,7 @@ func (s *Service) handleLaunch(response http.ResponseWriter, request *http.Reque
 	// Redirect to landing page
 	targetURL, _ := url.Parse(s.baseURL)
 	targetURL = targetURL.JoinPath(s.landingUrlPath)
-	log.Info().Msg("Successfully launched through ChipSoft HiX app launch")
+	log.Info().Ctx(request.Context()).Msg("Successfully launched through ChipSoft HiX app launch")
 	http.Redirect(response, request, targetURL.String(), http.StatusFound)
 }
 
@@ -345,7 +345,7 @@ func (s *Service) getSessionData(ctx context.Context, accessToken string, launch
 	if len(identities) == 0 {
 		return nil, fmt.Errorf("no identities found")
 	} else if len(identities) > 1 {
-		log.Warn().Msgf("More than one identity found, using the first one: %v", identities[0])
+		log.Warn().Ctx(ctx).Msgf("More than one identity found, using the first one: %v", identities[0])
 	}
 	localOrgIdentifier := identities[0]
 
@@ -366,7 +366,7 @@ func (s *Service) getSessionData(ctx context.Context, accessToken string, launch
 	}
 	// Enrich performer URA with registered name
 	if result, err := s.profile.CsdDirectory().LookupEntity(ctx, *taskPerformer.Identifier); err != nil {
-		log.Warn().Err(err).Msgf("Couldn't resolve performer name (ura: %s)", s.config.TaskPerformerUra)
+		log.Warn().Ctx(ctx).Err(err).Msgf("Couldn't resolve performer name (ura: %s)", s.config.TaskPerformerUra)
 	} else {
 		taskPerformer = *result
 	}

--- a/orchestrator/careplancontributor/handle_taskfiller_test.go
+++ b/orchestrator/careplancontributor/handle_taskfiller_test.go
@@ -394,12 +394,12 @@ func TestService_createSubTaskEnrollmentCriteria(t *testing.T) {
 	var task fhir.Task
 	json.Unmarshal(taskBytes, &task)
 	workflow := service.workflows["http://snomed.info/sct|719858009"]["http://snomed.info/sct|13645005"].Start()
-	questionnaire, err := service.questionnaireLoader.Load(workflow.QuestionnaireUrl)
+	questionnaire, err := service.questionnaireLoader.Load(context.Background(), workflow.QuestionnaireUrl)
 	require.NoError(t, err)
 	require.NotNil(t, questionnaire)
 
 	questionnaireRef := "urn:uuid:" + *questionnaire.Id
-	log.Info().Msgf("Creating a new Enrollment Criteria subtask - questionnaireRef: %s", questionnaireRef)
+	log.Info().Ctx(context.Background()).Msgf("Creating a new Enrollment Criteria subtask - questionnaireRef: %s", questionnaireRef)
 	subtask := service.getSubTask(&primaryTask, questionnaireRef, true)
 
 	expectedSubTaskInput := []fhir.TaskInput{

--- a/orchestrator/careplanservice/handle_createtask.go
+++ b/orchestrator/careplanservice/handle_createtask.go
@@ -20,7 +20,7 @@ import (
 )
 
 func (s *Service) handleCreateTask(ctx context.Context, request FHIRHandlerRequest, tx *coolfhir.BundleBuilder) (FHIRHandlerResult, error) {
-	log.Info().Msg("Creating Task")
+	log.Info().Ctx(ctx).Msg("Creating Task")
 	var task fhir.Task
 	if err := json.Unmarshal(request.ResourceData, &task); err != nil {
 		return nil, fmt.Errorf("invalid %T: %w", task, coolfhir.BadRequestError(err))
@@ -55,12 +55,12 @@ func (s *Service) handleCreateTask(ctx context.Context, request FHIRHandlerReque
 	// Enrich Task.Requester and Task.Owner with info from CSD (if available), typically to add the organization name
 	// TODO: CSD is queried again later, to get the notification endpoint. We should optimize/cache this. Maybe in the context.Context?
 	if entity, err := s.profile.CsdDirectory().LookupEntity(ctx, *task.Requester.Identifier); err != nil {
-		log.Info().Err(err).Msgf("Unable to lookup Task.requester in CSD, won't be enriched.")
+		log.Info().Ctx(ctx).Err(err).Msgf("Unable to lookup Task.requester in CSD, won't be enriched.")
 	} else {
 		task.Requester = entity
 	}
 	if entity, err := s.profile.CsdDirectory().LookupEntity(ctx, *task.Owner.Identifier); err != nil {
-		log.Info().Err(err).Msgf("Unable to lookup Task.owner in CSD, won't be enriched.")
+		log.Info().Ctx(ctx).Err(err).Msgf("Unable to lookup Task.owner in CSD, won't be enriched.")
 	} else {
 		task.Owner = entity
 	}

--- a/orchestrator/careplanservice/handle_getcareplan.go
+++ b/orchestrator/careplanservice/handle_getcareplan.go
@@ -89,7 +89,7 @@ func (s *Service) handleSearchCarePlan(ctx context.Context, queryParams url.Valu
 			}
 		}
 	}
-	retBundle := filterMatchingResourcesInBundle(bundle, []string{"CarePlan", "CareTeam"}, filterRefs)
+	retBundle := filterMatchingResourcesInBundle(ctx, bundle, []string{"CarePlan", "CareTeam"}, filterRefs)
 
 	return &retBundle, nil
 }

--- a/orchestrator/careplanservice/handle_getcareteam.go
+++ b/orchestrator/careplanservice/handle_getcareteam.go
@@ -60,7 +60,7 @@ func (s *Service) handleSearchCareTeam(ctx context.Context, queryParams url.Valu
 		}
 		careTeamRefs = append(careTeamRefs, "CareTeam/"+*ct.Id)
 	}
-	retBundle := filterMatchingResourcesInBundle(bundle, []string{"CareTeam"}, careTeamRefs)
+	retBundle := filterMatchingResourcesInBundle(ctx, bundle, []string{"CareTeam"}, careTeamRefs)
 
 	return &retBundle, nil
 }

--- a/orchestrator/careplanservice/handle_getcondition.go
+++ b/orchestrator/careplanservice/handle_getcondition.go
@@ -30,7 +30,7 @@ func (s *Service) handleGetCondition(ctx context.Context, id string, headers *fh
 			}
 		}
 	} else {
-		log.Warn().Msg("Condition does not have Patient as subject, can't verify access")
+		log.Warn().Ctx(ctx).Msg("Condition does not have Patient as subject, can't verify access")
 		return nil, &coolfhir.ErrorWithCode{
 			Message:    "Participant does not have access to Condition",
 			StatusCode: http.StatusForbidden,

--- a/orchestrator/careplanservice/handle_getpatient.go
+++ b/orchestrator/careplanservice/handle_getpatient.go
@@ -100,7 +100,7 @@ func (s *Service) handleSearchPatient(ctx context.Context, queryParams url.Value
 		}
 	}
 
-	retBundle := filterMatchingResourcesInBundle(bundle, []string{"Patient"}, patientRefs)
+	retBundle := filterMatchingResourcesInBundle(ctx, bundle, []string{"Patient"}, patientRefs)
 
 	return &retBundle, nil
 }

--- a/orchestrator/careplanservice/handle_gettask.go
+++ b/orchestrator/careplanservice/handle_gettask.go
@@ -103,7 +103,7 @@ func (s *Service) handleSearchTask(ctx context.Context, queryParams url.Values, 
 			taskRefs = append(taskRefs, "Task/"+*task.Id)
 		}
 	}
-	retBundle := filterMatchingResourcesInBundle(bundle, []string{"Task"}, taskRefs)
+	retBundle := filterMatchingResourcesInBundle(ctx, bundle, []string{"Task"}, taskRefs)
 
 	return &retBundle, nil
 }

--- a/orchestrator/careplanservice/handle_updatetask.go
+++ b/orchestrator/careplanservice/handle_updatetask.go
@@ -16,7 +16,7 @@ import (
 )
 
 func (s *Service) handleUpdateTask(ctx context.Context, request FHIRHandlerRequest, tx *coolfhir.BundleBuilder) (FHIRHandlerResult, error) {
-	log.Info().Msgf("Updating Task: %s", request.RequestUrl)
+	log.Info().Ctx(ctx).Msgf("Updating Task: %s", request.RequestUrl)
 	var task fhir.Task
 	if err := json.Unmarshal(request.ResourceData, &task); err != nil {
 		return nil, fmt.Errorf("invalid %T: %w", task, coolfhir.BadRequestError(err))

--- a/orchestrator/careplanservice/subscriptions/manager.go
+++ b/orchestrator/careplanservice/subscriptions/manager.go
@@ -43,7 +43,7 @@ func (r DerivingManager) Notify(ctx context.Context, resource interface{}) error
 			Reference: to.Ptr("Task/" + *task.Id),
 			Type:      to.Ptr("Task"),
 		}
-		log.Info().Msgf("Notifying subscribers for Task %s", *task.Id)
+		log.Info().Ctx(ctx).Msgf("Notifying subscribers for Task %s", *task.Id)
 		isOwnerValid := false
 		if task.Owner != nil {
 			isOwnerValid = coolfhir.IsLogicalIdentifier(task.Owner.Identifier)
@@ -53,9 +53,9 @@ func (r DerivingManager) Notify(ctx context.Context, resource interface{}) error
 		} else {
 			ownerJSON, err := json.Marshal(task.Owner)
 			if err != nil {
-				log.Error().Msgf("Failed to marshal owner to JSON: %s", err)
+				log.Error().Ctx(ctx).Msgf("Failed to marshal owner to JSON: %s", err)
 			} else {
-				log.Warn().Msgf("Owner LogicalIdentifier is invalid: %s", string(ownerJSON))
+				log.Warn().Ctx(ctx).Msgf("Owner LogicalIdentifier is invalid: %s", string(ownerJSON))
 			}
 		}
 		isRequesterValid := false
@@ -67,9 +67,9 @@ func (r DerivingManager) Notify(ctx context.Context, resource interface{}) error
 		} else {
 			requesterJSON, err := json.Marshal(task.Requester)
 			if err != nil {
-				log.Error().Msgf("Failed to marshal requester to JSON: %s", err)
+				log.Error().Ctx(ctx).Msgf("Failed to marshal requester to JSON: %s", err)
 			} else {
-				log.Warn().Msgf("Requester LogicalIdentifier is invalid: %s", string(requesterJSON))
+				log.Warn().Ctx(ctx).Msgf("Requester LogicalIdentifier is invalid: %s", string(requesterJSON))
 			}
 		}
 	case "CareTeam":
@@ -84,9 +84,9 @@ func (r DerivingManager) Notify(ctx context.Context, resource interface{}) error
 			} else {
 				memberJSON, err := json.Marshal(participant.Member)
 				if err != nil {
-					log.Error().Msgf("Failed to marshal member to JSON: %s", err)
+					log.Error().Ctx(ctx).Msgf("Failed to marshal member to JSON: %s", err)
 				} else {
-					log.Warn().Msgf("Member LogicalReference is invalid: %s", string(memberJSON))
+					log.Warn().Ctx(ctx).Msgf("Member LogicalReference is invalid: %s", string(memberJSON))
 				}
 			}
 		}
@@ -94,7 +94,7 @@ func (r DerivingManager) Notify(ctx context.Context, resource interface{}) error
 		return fmt.Errorf("subscription manager does not support notifying for resource type: %T", resource)
 	}
 
-	log.Info().Msgf("Notifying %d subscriber(s) for update on resource: %s", len(subscribers), *focus.Reference)
+	log.Info().Ctx(ctx).Msgf("Notifying %d subscriber(s) for update on resource: %s", len(subscribers), *focus.Reference)
 
 	return r.notifyAll(ctx, timeFunc(), focus, subscribers)
 }

--- a/orchestrator/cmd/profile/nuts/auth.go
+++ b/orchestrator/cmd/profile/nuts/auth.go
@@ -34,7 +34,7 @@ func (d DutchNutsProfile) Authenticator(resourceServerURL *url.URL, fn func(writ
 
 		organization, err := claimsToOrganization(userInfo)
 		if err != nil {
-			log.Error().Err(err).Msg("Invalid user info in context")
+			log.Err(err).Msg("Invalid user info in context")
 			http.Error(response, "Unauthorized", http.StatusUnauthorized)
 			return
 		}

--- a/orchestrator/lib/az/azkeyvault/test.go
+++ b/orchestrator/lib/az/azkeyvault/test.go
@@ -43,7 +43,7 @@ func NewTestServer() *TestAzureKeyVault {
 		if key, ok := result.keys[name]; ok {
 			plainText, err := rsa.DecryptOAEP(sha1.New(), rand.Reader, key, []byte("test"), nil)
 			if err != nil {
-				log.Logger.Error().Err(err).Msg("failed to decrypt")
+				log.Logger.Err(err).Msg("failed to decrypt")
 				w.WriteHeader(http.StatusInternalServerError)
 				return
 			}

--- a/orchestrator/lib/coolfhir/util.go
+++ b/orchestrator/lib/coolfhir/util.go
@@ -285,7 +285,7 @@ func IsScpTask(task *fhir.Task) bool {
 func SendResponse(httpResponse http.ResponseWriter, httpStatus int, resource interface{}, additionalHeaders ...map[string]string) {
 	data, err := json.MarshalIndent(resource, "", "  ")
 	if err != nil {
-		log.Error().Err(err).Msg("Failed to marshal response")
+		log.Err(err).Msg("Failed to marshal response")
 		httpStatus = http.StatusInternalServerError
 		data = []byte(`{"resourceType":"OperationOutcome","issue":[{"severity":"error","code":"processing","diagnostics":"Failed to marshal response"}]}`)
 	}
@@ -299,6 +299,6 @@ func SendResponse(httpResponse http.ResponseWriter, httpStatus int, resource int
 	httpResponse.WriteHeader(httpStatus)
 	_, err = httpResponse.Write(data)
 	if err != nil {
-		log.Error().Err(err).Msgf("Failed to write response: %s", string(data))
+		log.Err(err).Msgf("Failed to write response: %s", string(data))
 	}
 }


### PR DESCRIPTION
Then we can start including fields such as authorized user and trace/span IDs in all log messages.