### PR TITLE
Troubleshoot Bad Request response without response body

### DIFF
--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -138,7 +138,7 @@ func (s Service) RegisterHandlers(mux *http.ServeMux) {
 	mux.HandleFunc("GET "+basePath+"/context", s.withSession(s.handleGetContext))
 	mux.HandleFunc(basePath+"/ehr/fhir/{rest...}", s.withSession(s.handleProxyAppRequestToEHR))
 	proxyBasePath := basePath + "/cps/fhir"
-	carePlanServiceProxy := coolfhir.NewProxy("App->CPS", log.Logger, s.localCarePlanServiceUrl, proxyBasePath, s.orcaPublicURL.JoinPath(proxyBasePath), s.scpHttpClient.Transport)
+	carePlanServiceProxy := coolfhir.NewProxy("App->CPS FHIR proxy", log.Logger, s.localCarePlanServiceUrl, proxyBasePath, s.orcaPublicURL.JoinPath(proxyBasePath), s.scpHttpClient.Transport)
 	mux.HandleFunc(basePath+"/cps/fhir/{rest...}", s.withSessionOrBearerToken(func(writer http.ResponseWriter, request *http.Request) {
 		carePlanServiceProxy.ServeHTTP(writer, request)
 	}))
@@ -178,7 +178,7 @@ func (s Service) withSession(next func(response http.ResponseWriter, request *ht
 func (s Service) handleProxyAppRequestToEHR(writer http.ResponseWriter, request *http.Request, session *user.SessionData) {
 	clientFactory := clients.Factories[session.FHIRLauncher](session.StringValues)
 	proxyBasePath := basePath + "/ehr/fhir"
-	proxy := coolfhir.NewProxy("App->EHR", log.Logger, clientFactory.BaseURL, proxyBasePath, s.orcaPublicURL.JoinPath(proxyBasePath), clientFactory.Client)
+	proxy := coolfhir.NewProxy("App->EHR FHIR proxy", log.Logger, clientFactory.BaseURL, proxyBasePath, s.orcaPublicURL.JoinPath(proxyBasePath), clientFactory.Client)
 
 	resourcePath := request.PathValue("rest")
 	// If the requested resource is cached in the session, directly return it. This is used to support resources that are required (e.g. by Frontend), but not provided by the EHR.
@@ -259,7 +259,7 @@ func (s Service) handleProxyExternalRequestToEHR(writer http.ResponseWriter, req
 		return coolfhir.NewErrorWithCode("requester does not have access to resource", http.StatusForbidden)
 	}
 	proxyBasePath := basePath + "/fhir"
-	fhirProxy := coolfhir.NewProxy("External CPC->EHR", log.Logger, s.fhirURL, proxyBasePath, s.orcaPublicURL.JoinPath(proxyBasePath), s.transport)
+	fhirProxy := coolfhir.NewProxy("External CPC->EHR FHIR proxy", log.Logger, s.fhirURL, proxyBasePath, s.orcaPublicURL.JoinPath(proxyBasePath), s.transport)
 	fhirProxy.ServeHTTP(writer, request)
 	return nil
 }

--- a/orchestrator/careplancontributor/service_test.go
+++ b/orchestrator/careplancontributor/service_test.go
@@ -328,8 +328,6 @@ func TestService_Proxy_Valid(t *testing.T) {
 	httpResponse, err := httpClient.Do(httpRequest)
 	require.NoError(t, err)
 	require.Equal(t, httpResponse.StatusCode, http.StatusOK)
-	body, _ := io.ReadAll(httpResponse.Body)
-	require.Equal(t, "", string(body))
 	require.Equal(t, "/cps/CarePlan?_id=cps-careplan-01&_include=CarePlan%3Acare-team", capturedURL)
 }
 
@@ -382,8 +380,6 @@ func TestService_Proxy_ProxyReturnsError_Fails(t *testing.T) {
 	httpResponse, err := httpClient.Do(httpRequest)
 	require.NoError(t, err)
 	require.Equal(t, httpResponse.StatusCode, http.StatusNotFound)
-	body, _ := io.ReadAll(httpResponse.Body)
-	require.Equal(t, "", string(body))
 	require.Equal(t, "/cps/CarePlan?_id=cps-careplan-01&_include=CarePlan%3Acare-team", capturedURL)
 }
 

--- a/orchestrator/careplanservice/service.go
+++ b/orchestrator/careplanservice/service.go
@@ -353,8 +353,6 @@ func (s *Service) handleSearch(httpRequest *http.Request, httpResponse http.Resp
 		bundle, err = s.handleSearchTask(httpRequest.Context(), httpRequest.URL.Query(), headers)
 	case "Patient":
 		bundle, err = s.handleSearchPatient(httpRequest.Context(), httpRequest.URL.Query(), headers)
-	//case "ServiceRequest":
-	//	_, bundle, err = handleSearchResource[fhir.Patient](s, "ServiceRequest", httpRequest.URL.Query(), headers)
 	default:
 		log.Warn().Ctx(httpRequest.Context()).
 			Msgf("Unmanaged FHIR operation at CarePlanService: %s %s", httpRequest.Method, httpRequest.URL.String())

--- a/orchestrator/careplanservice/service.go
+++ b/orchestrator/careplanservice/service.go
@@ -136,7 +136,7 @@ func (r FHIRHandlerRequest) bundleEntry() fhir.BundleEntry {
 type FHIRHandlerResult func(txResult *fhir.Bundle) (*fhir.BundleEntry, []any, error)
 
 func (s *Service) RegisterHandlers(mux *http.ServeMux) {
-	s.proxy = coolfhir.NewProxy(log.Logger, s.fhirURL, basePath, s.orcaPublicURL.JoinPath(basePath), s.transport)
+	s.proxy = coolfhir.NewProxy("CPS->FHIR", log.Logger, s.fhirURL, basePath, s.orcaPublicURL.JoinPath(basePath), s.transport)
 	baseUrl := s.baseUrl()
 	s.profile.RegisterHTTPHandlers(basePath, baseUrl, mux)
 

--- a/orchestrator/careplanservice/service.go
+++ b/orchestrator/careplanservice/service.go
@@ -354,6 +354,8 @@ func (s *Service) handleSearch(httpRequest *http.Request, httpResponse http.Resp
 		bundle, err = s.handleSearchTask(httpRequest.Context(), httpRequest.URL.Query(), headers)
 	case "Patient":
 		bundle, err = s.handleSearchPatient(httpRequest.Context(), httpRequest.URL.Query(), headers)
+	case "ServiceRequest":
+		_, bundle, err = handleSearchResource[fhir.Patient](s, "ServiceRequest", httpRequest.URL.Query(), headers)
 	default:
 		log.Warn().Ctx(httpRequest.Context()).
 			Msgf("Unmanaged FHIR operation at CarePlanService: %s %s", httpRequest.Method, httpRequest.URL.String())

--- a/orchestrator/careplanservice/service.go
+++ b/orchestrator/careplanservice/service.go
@@ -8,7 +8,6 @@ import (
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir/pipeline"
 	"io"
 	"net/http"
-	"net/http/httputil"
 	"net/url"
 	"strconv"
 	"strings"
@@ -81,7 +80,7 @@ type Service struct {
 	profile                      profile.Provider
 	subscriptionManager          subscriptions.Manager
 	maxReadBodySize              int
-	proxy                        *httputil.ReverseProxy
+	proxy                        coolfhir.HttpProxy
 	allowUnmanagedFHIROperations bool
 	handlerProvider              func(method string, resourceType string) func(context.Context, FHIRHandlerRequest, *coolfhir.BundleBuilder) (FHIRHandlerResult, error)
 	pipeline                     pipeline.Instance

--- a/orchestrator/careplanservice/service.go
+++ b/orchestrator/careplanservice/service.go
@@ -136,7 +136,7 @@ func (r FHIRHandlerRequest) bundleEntry() fhir.BundleEntry {
 type FHIRHandlerResult func(txResult *fhir.Bundle) (*fhir.BundleEntry, []any, error)
 
 func (s *Service) RegisterHandlers(mux *http.ServeMux) {
-	s.proxy = coolfhir.NewProxy("CPS->FHIR", log.Logger, s.fhirURL, basePath, s.orcaPublicURL.JoinPath(basePath), s.transport)
+	s.proxy = coolfhir.NewProxy("CPS->FHIR proxy", log.Logger, s.fhirURL, basePath, s.orcaPublicURL.JoinPath(basePath), s.transport)
 	baseUrl := s.baseUrl()
 	s.profile.RegisterHTTPHandlers(basePath, baseUrl, mux)
 
@@ -354,8 +354,8 @@ func (s *Service) handleSearch(httpRequest *http.Request, httpResponse http.Resp
 		bundle, err = s.handleSearchTask(httpRequest.Context(), httpRequest.URL.Query(), headers)
 	case "Patient":
 		bundle, err = s.handleSearchPatient(httpRequest.Context(), httpRequest.URL.Query(), headers)
-	case "ServiceRequest":
-		_, bundle, err = handleSearchResource[fhir.Patient](s, "ServiceRequest", httpRequest.URL.Query(), headers)
+	//case "ServiceRequest":
+	//	_, bundle, err = handleSearchResource[fhir.Patient](s, "ServiceRequest", httpRequest.URL.Query(), headers)
 	default:
 		log.Warn().Ctx(httpRequest.Context()).
 			Msgf("Unmanaged FHIR operation at CarePlanService: %s %s", httpRequest.Method, httpRequest.URL.String())

--- a/orchestrator/careplanservice/service_test.go
+++ b/orchestrator/careplanservice/service_test.go
@@ -544,7 +544,7 @@ func TestService_Handle(t *testing.T) {
 			hdrs := new(fhirclient.Headers)
 			err = fhirClient.Create(requestBundle, &resultBundle, fhirclient.AtPath("/"), fhirclient.ResponseHeaders(hdrs))
 
-			require.EqualError(t, err, "OperationOutcome, issues: [processing error] Bundle failed: OperationOutcome, issues: [processing error] Transaction failed on 'PUT' for the requested url '/ServiceRequest'.; [invalid error] Found result with Id '4eaffb23-02ab-452c-8ef1-b4c9be7b2425', which did not match the provided Id 'e669F4l0Bk3NJpQzoTzVE0opsQR2iWXR41M6FXkeguZo3'.")
+			require.EqualError(t, err, "OperationOutcome, issues: [processing error] Transaction failed on 'PUT' for the requested url '/ServiceRequest'.; [invalid error] Found result with Id '4eaffb23-02ab-452c-8ef1-b4c9be7b2425', which did not match the provided Id 'e669F4l0Bk3NJpQzoTzVE0opsQR2iWXR41M6FXkeguZo3'.")
 			assert.Equal(t, "application/fhir+json", hdrs.Get("Content-Type"))
 		})
 		t.Run("commit fails, FHIR server returns OperationOutcome with security issue, which is sanitized", func(t *testing.T) {
@@ -565,7 +565,7 @@ func TestService_Handle(t *testing.T) {
 			hdrs := new(fhirclient.Headers)
 			err = fhirClient.Create(requestBundle, &resultBundle, fhirclient.AtPath("/"), fhirclient.ResponseHeaders(hdrs))
 
-			require.EqualError(t, err, "OperationOutcome, issues: [processing error] Bundle failed: OperationOutcome, issues: [processing error] upstream FHIR server error")
+			require.EqualError(t, err, "OperationOutcome, issues: [processing error] upstream FHIR server error")
 			assert.Equal(t, "application/fhir+json", hdrs.Get("Content-Type"))
 		})
 		t.Run("GET is disallowed", func(t *testing.T) {

--- a/orchestrator/careplanservice/service_test.go
+++ b/orchestrator/careplanservice/service_test.go
@@ -116,6 +116,7 @@ func TestService_Proxy_AllowUnmanagedOperations(t *testing.T) {
 	capturedHost := ""
 	fhirServerMux.HandleFunc("GET /fhir/SomeResource", func(writer http.ResponseWriter, request *http.Request) {
 		writer.WriteHeader(http.StatusOK)
+		_, _ = writer.Write([]byte(`{"resourceType":"Task"}`))
 		capturedHost = request.Host
 	})
 	fhirServer := httptest.NewServer(fhirServerMux)

--- a/orchestrator/go.mod
+++ b/orchestrator/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.12.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.6.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates v1.1.0
-	github.com/SanteonNL/go-fhir-client v0.2.11
+	github.com/SanteonNL/go-fhir-client v0.2.12
 	github.com/SanteonNL/nuts-policy-enforcement-point v0.0.0-20240805130644-8b92f1cbf865
 	github.com/beevik/etree v1.2.0
 	github.com/braineet/saml v0.4.15

--- a/orchestrator/go.mod
+++ b/orchestrator/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.12.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.6.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates v1.1.0
-	github.com/SanteonNL/go-fhir-client v0.2.10
+	github.com/SanteonNL/go-fhir-client v0.2.11
 	github.com/SanteonNL/nuts-policy-enforcement-point v0.0.0-20240805130644-8b92f1cbf865
 	github.com/beevik/etree v1.2.0
 	github.com/braineet/saml v0.4.15

--- a/orchestrator/go.sum
+++ b/orchestrator/go.sum
@@ -29,6 +29,8 @@ github.com/SanteonNL/go-fhir-client v0.2.9 h1:eqnyB16ww0UX5O9Z3StMJd/7QnBl6qzMM/
 github.com/SanteonNL/go-fhir-client v0.2.9/go.mod h1:CcU6J3vgxsdjTWry0s2BAJcV6SvdaRTsry9ixR7zqc4=
 github.com/SanteonNL/go-fhir-client v0.2.10 h1:AukeTRFQ49rGsjfcY5BumitBgaKpOHCF1t4BkLTzNqk=
 github.com/SanteonNL/go-fhir-client v0.2.10/go.mod h1:CcU6J3vgxsdjTWry0s2BAJcV6SvdaRTsry9ixR7zqc4=
+github.com/SanteonNL/go-fhir-client v0.2.11 h1:Bi3yNnd5MBBS5egWYW1+CUmH5pGaNjsfqH3pgT2gqRw=
+github.com/SanteonNL/go-fhir-client v0.2.11/go.mod h1:CcU6J3vgxsdjTWry0s2BAJcV6SvdaRTsry9ixR7zqc4=
 github.com/SanteonNL/nuts-policy-enforcement-point v0.0.0-20240805130644-8b92f1cbf865 h1:luArkUx6tzRw/t6bI0kB1FdUJIqukSEanJeEIP9613I=
 github.com/SanteonNL/nuts-policy-enforcement-point v0.0.0-20240805130644-8b92f1cbf865/go.mod h1:mLVFlPbfU6lbrE/TeUQOpDC53aTC/PyOGYgPIR0S1Yw=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=

--- a/orchestrator/go.sum
+++ b/orchestrator/go.sum
@@ -31,6 +31,8 @@ github.com/SanteonNL/go-fhir-client v0.2.10 h1:AukeTRFQ49rGsjfcY5BumitBgaKpOHCF1
 github.com/SanteonNL/go-fhir-client v0.2.10/go.mod h1:CcU6J3vgxsdjTWry0s2BAJcV6SvdaRTsry9ixR7zqc4=
 github.com/SanteonNL/go-fhir-client v0.2.11 h1:Bi3yNnd5MBBS5egWYW1+CUmH5pGaNjsfqH3pgT2gqRw=
 github.com/SanteonNL/go-fhir-client v0.2.11/go.mod h1:CcU6J3vgxsdjTWry0s2BAJcV6SvdaRTsry9ixR7zqc4=
+github.com/SanteonNL/go-fhir-client v0.2.12 h1:NW59ejtC2xyul1QMci7rKpzFaFmstNLGheOvwxa4GSc=
+github.com/SanteonNL/go-fhir-client v0.2.12/go.mod h1:CcU6J3vgxsdjTWry0s2BAJcV6SvdaRTsry9ixR7zqc4=
 github.com/SanteonNL/nuts-policy-enforcement-point v0.0.0-20240805130644-8b92f1cbf865 h1:luArkUx6tzRw/t6bI0kB1FdUJIqukSEanJeEIP9613I=
 github.com/SanteonNL/nuts-policy-enforcement-point v0.0.0-20240805130644-8b92f1cbf865/go.mod h1:mLVFlPbfU6lbrE/TeUQOpDC53aTC/PyOGYgPIR0S1Yw=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=

--- a/orchestrator/lib/coolfhir/azure.go
+++ b/orchestrator/lib/coolfhir/azure.go
@@ -7,7 +7,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	fhirclient "github.com/SanteonNL/go-fhir-client"
-	"github.com/rs/zerolog/log"
 	"golang.org/x/oauth2"
 	"net/http"
 	"net/url"
@@ -108,12 +107,6 @@ func NewAuthRoundTripper(config ClientConfig, fhirClientConfig *fhirclient.Confi
 			return nil, nil, fmt.Errorf("unable to get credential for Azure FHIR API client: %w", err)
 		}
 		httpClient := NewAzureHTTPClient(credential, scopes)
-		oldTransport := httpClient.Transport
-		httpClient.Transport = loggingRoundTripper{
-			name:   "Azure-FHIR",
-			logger: &log.Logger,
-			next:   oldTransport,
-		}
 		transport = httpClient.Transport
 		fhirClient = fhirclient.New(fhirURL, httpClient, fhirClientConfig)
 	case Default:

--- a/orchestrator/lib/coolfhir/error.go
+++ b/orchestrator/lib/coolfhir/error.go
@@ -48,7 +48,7 @@ type ErrorWithCode struct {
 	StatusCode int
 }
 
-func (e *ErrorWithCode) Error() string {
+func (e ErrorWithCode) Error() string {
 	return e.Message
 }
 
@@ -106,7 +106,7 @@ func WriteOperationOutcomeFromError(err error, desc string, httpResponse http.Re
 	} else {
 		// Error type: ErrorWithCode
 		var errorWithCode = new(ErrorWithCode)
-		if errors.As(err, &errorWithCode) {
+		if errors.As(err, errorWithCode) || errors.As(err, &errorWithCode) {
 			if errorWithCode.StatusCode > 0 {
 				statusCode = errorWithCode.StatusCode
 			}

--- a/orchestrator/lib/coolfhir/error.go
+++ b/orchestrator/lib/coolfhir/error.go
@@ -97,15 +97,15 @@ func WriteOperationOutcomeFromError(err error, desc string, httpResponse http.Re
 	var operationOutcome fhir.OperationOutcome
 
 	// Error type: fhirclient.OperationOutcomeError
-	var operationOutcomeErr *fhirclient.OperationOutcomeError
-	if errors.As(err, &operationOutcomeErr) {
+	var operationOutcomeErr = new(fhirclient.OperationOutcomeError)
+	if errors.As(err, operationOutcomeErr) || errors.As(err, &operationOutcomeErr) {
 		if operationOutcomeErr.HttpStatusCode > 0 {
 			statusCode = operationOutcomeErr.HttpStatusCode
 		}
 		operationOutcome = operationOutcomeErr.OperationOutcome
 	} else {
 		// Error type: ErrorWithCode
-		var errorWithCode *ErrorWithCode
+		var errorWithCode = new(ErrorWithCode)
 		if errors.As(err, &errorWithCode) {
 			if errorWithCode.StatusCode > 0 {
 				statusCode = errorWithCode.StatusCode

--- a/orchestrator/lib/coolfhir/proxy.go
+++ b/orchestrator/lib/coolfhir/proxy.go
@@ -170,6 +170,7 @@ func (f fhirClientProxy) sanitizeRequestHeaders(header http.Header) http.Header 
 			nameLC == "referer" ||
 			nameLC == "cookie" ||
 			nameLC == "user-agent" ||
+			nameLC == "accept-encoding" ||
 			nameLC == "authorization" {
 			continue
 		}

--- a/orchestrator/lib/coolfhir/proxy.go
+++ b/orchestrator/lib/coolfhir/proxy.go
@@ -93,9 +93,13 @@ func (l loggingRoundTripper) RoundTrip(request *http.Request) (*http.Response, e
 		l.logger.Debug().Ctx(request.Context()).Msgf("Proxy request headers: %s", strings.Join(headers, ", "))
 	}
 	if l.logger.Trace().Ctx(request.Context()).Enabled() {
-		requestBody, err := io.ReadAll(request.Body)
-		if err != nil {
-			return nil, err
+		var requestBody []byte
+		var err error
+		if request.Body != nil {
+			requestBody, err = io.ReadAll(request.Body)
+			if err != nil {
+				return nil, err
+			}
 		}
 		l.logger.Trace().Ctx(request.Context()).Msgf("Proxying FHIR request body: %s", string(requestBody))
 		request.Body = io.NopCloser(bytes.NewReader(requestBody))

--- a/orchestrator/lib/coolfhir/proxy.go
+++ b/orchestrator/lib/coolfhir/proxy.go
@@ -27,7 +27,7 @@ func NewProxy(name string, logger zerolog.Logger, upstreamBaseUrl *url.URL, prox
 		Rewrite: func(r *httputil.ProxyRequest) {
 			r.Out.URL = upstreamBaseUrl.JoinPath(strings.TrimPrefix(r.In.URL.Path, proxyBasePath))
 			r.Out.URL.RawQuery = r.In.URL.RawQuery
-			r.Out.Host = upstreamBaseUrl.Host
+			r.Out.Host = "" // upstreamBaseUrl.Host
 		},
 		Transport: sanitizingRoundTripper{
 			next: loggingRoundTripper{
@@ -45,7 +45,7 @@ func NewProxy(name string, logger zerolog.Logger, upstreamBaseUrl *url.URL, prox
 				Do(response, response.Body)
 		},
 		ErrorHandler: func(writer http.ResponseWriter, request *http.Request, err error) {
-			logger.Warn().Err(err).Msgf("%s proxy FHIR request failed (url=%s)", name, request.URL.String())
+			logger.Warn().Err(err).Msgf("%s request failed (url=%s)", name, request.URL.String())
 			SendResponse(writer, http.StatusBadGateway, &ErrorWithCode{
 				Message:    "FHIR request failed: " + err.Error(),
 				StatusCode: http.StatusBadGateway,

--- a/orchestrator/lib/coolfhir/proxy.go
+++ b/orchestrator/lib/coolfhir/proxy.go
@@ -3,7 +3,6 @@ package coolfhir
 import (
 	"bytes"
 	"fmt"
-	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir/pipeline"
 	"github.com/rs/zerolog"
 	"io"
 	"net/http"
@@ -39,14 +38,14 @@ func NewProxy(name string, logger zerolog.Logger, upstreamBaseUrl *url.URL, prox
 		//		name:   name,
 		//	},
 		//},
-		ModifyResponse: func(response *http.Response) error {
-			upstreamUrl := upstreamBaseUrl.String()
-			proxyUrl := rewriteUrl.String()
-			return pipeline.New().
-				AppendResponseTransformer(pipeline.ResponseBodyRewriter{Old: []byte(upstreamUrl), New: []byte(proxyUrl)}).
-				AppendResponseTransformer(pipeline.ResponseHeaderRewriter{Old: upstreamUrl, New: proxyUrl}).
-				Do(response, response.Body)
-		},
+		//ModifyResponse: func(response *http.Response) error {
+		//	upstreamUrl := upstreamBaseUrl.String()
+		//	proxyUrl := rewriteUrl.String()
+		//	return pipeline.New().
+		//		AppendResponseTransformer(pipeline.ResponseBodyRewriter{Old: []byte(upstreamUrl), New: []byte(proxyUrl)}).
+		//		AppendResponseTransformer(pipeline.ResponseHeaderRewriter{Old: upstreamUrl, New: proxyUrl}).
+		//		Do(response, response.Body)
+		//},
 		ErrorHandler: func(writer http.ResponseWriter, request *http.Request, err error) {
 			logger.Warn().Err(err).Msgf("%s request failed (url=%s)", name, request.URL.String())
 			SendResponse(writer, http.StatusBadGateway, &ErrorWithCode{

--- a/orchestrator/lib/coolfhir/proxy.go
+++ b/orchestrator/lib/coolfhir/proxy.go
@@ -164,6 +164,7 @@ func (f fhirClientProxy) sanitizeRequestHeaders(header http.Header) http.Header 
 	// Header sanitizing is loosely inspired by:
 	// - https://www.rfc-editor.org/rfc/rfc7231
 	// - https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/header_sanitizing
+	// - httputil.ReverseProxy: remove hop-by-hop headers
 	for name, values := range header {
 		nameLC := strings.ToLower(name)
 		if strings.HasPrefix(nameLC, "x-") ||
@@ -171,7 +172,16 @@ func (f fhirClientProxy) sanitizeRequestHeaders(header http.Header) http.Header 
 			nameLC == "cookie" ||
 			nameLC == "user-agent" ||
 			nameLC == "accept-encoding" ||
-			nameLC == "authorization" {
+			nameLC == "authorization" ||
+			nameLC == "connection" ||
+			nameLC == "proxy-connection" ||
+			nameLC == "keep-alive" ||
+			nameLC == "proxy-authenticate" ||
+			nameLC == "proxy-authorization" ||
+			nameLC == "te" ||
+			nameLC == "trailer" ||
+			nameLC == "transfer-encoding" ||
+			nameLC == "upgrade" {
 			continue
 		}
 		result[name] = values

--- a/orchestrator/lib/coolfhir/proxy.go
+++ b/orchestrator/lib/coolfhir/proxy.go
@@ -22,7 +22,7 @@ import (
 //   - if the proxy is on /fhir, and the reverse proxy binds to /, then proxyBasePath = /fhir and rewriteUrl = /.
 //   - if the proxy is on /, and the reverse proxy binds to /fhir, then proxyBasePath = / and rewriteUrl = /fhir.
 //   - if the proxy is on /fhir, and the reverse proxy binds to /app/fhir, then proxyBasePath = /fhir and rewriteUrl = /app/fhir.
-func NewProxy(logger zerolog.Logger, upstreamBaseUrl *url.URL, proxyBasePath string, rewriteUrl *url.URL, transport http.RoundTripper) *httputil.ReverseProxy {
+func NewProxy(name string, logger zerolog.Logger, upstreamBaseUrl *url.URL, proxyBasePath string, rewriteUrl *url.URL, transport http.RoundTripper) *httputil.ReverseProxy {
 	return &httputil.ReverseProxy{
 		Rewrite: func(r *httputil.ProxyRequest) {
 			r.Out.URL = upstreamBaseUrl.JoinPath("/", strings.TrimPrefix(r.In.URL.Path, proxyBasePath))
@@ -44,7 +44,7 @@ func NewProxy(logger zerolog.Logger, upstreamBaseUrl *url.URL, proxyBasePath str
 				Do(response, response.Body)
 		},
 		ErrorHandler: func(writer http.ResponseWriter, request *http.Request, err error) {
-			logger.Warn().Err(err).Msgf("FHIR request failed (url=%s)", request.URL.String())
+			logger.Warn().Err(err).Msgf("%s proxy FHIR request failed (url=%s)", name, request.URL.String())
 			SendResponse(writer, http.StatusBadGateway, ErrorWithCode{
 				Message:    "FHIR request failed: " + err.Error(),
 				StatusCode: http.StatusBadGateway,
@@ -79,18 +79,19 @@ func (s sanitizingRoundTripper) RoundTrip(request *http.Request) (*http.Response
 var _ http.RoundTripper = &loggingRoundTripper{}
 
 type loggingRoundTripper struct {
+	name   string
 	logger *zerolog.Logger
 	next   http.RoundTripper
 }
 
 func (l loggingRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
-	l.logger.Info().Ctx(request.Context()).Msgf("Proxying FHIR request: %s %s", request.Method, request.URL.String())
+	l.logger.Info().Ctx(request.Context()).Msgf("%s proxying FHIR request: %s %s", l.name, request.Method, request.URL.String())
 	if l.logger.Debug().Ctx(request.Context()).Enabled() {
 		var headers []string
 		for key, values := range request.Header {
 			headers = append(headers, fmt.Sprintf("(%s: %s)", key, strings.Join(values, ", ")))
 		}
-		l.logger.Debug().Ctx(request.Context()).Msgf("Proxy request headers: %s", strings.Join(headers, ", "))
+		l.logger.Debug().Ctx(request.Context()).Msgf("%s proxy FHIR request headers: %s", l.name, strings.Join(headers, ", "))
 	}
 	if l.logger.Trace().Ctx(request.Context()).Enabled() {
 		var requestBody []byte
@@ -101,96 +102,28 @@ func (l loggingRoundTripper) RoundTrip(request *http.Request) (*http.Response, e
 				return nil, err
 			}
 		}
-		l.logger.Trace().Ctx(request.Context()).Msgf("Proxying FHIR request body: %s", string(requestBody))
+		l.logger.Trace().Ctx(request.Context()).Msgf("%s proxy FHIR request body: %s", l.name, string(requestBody))
 		request.Body = io.NopCloser(bytes.NewReader(requestBody))
 	}
 	response, err := l.next.RoundTrip(request)
 	if err != nil {
-		l.logger.Warn().Err(err).Msgf("Proxied FHIR request failed (url=%s)", request.URL.String())
+		l.logger.Warn().Err(err).Msgf("%s proxied FHIR request failed (url=%s)", l.name, request.URL.String())
 	} else {
 		if l.logger.Debug().Ctx(request.Context()).Enabled() {
 			var headers []string
 			for key, values := range response.Header {
 				headers = append(headers, fmt.Sprintf("(%s: %s)", key, strings.Join(values, ", ")))
 			}
-			l.logger.Debug().Ctx(request.Context()).Msgf("Proxied FHIR request response: %s, headers: %s", response.Status, strings.Join(headers, ", "))
+			l.logger.Debug().Ctx(request.Context()).Msgf("%s proxied FHIR response: %s, headers: %s", l.name, response.Status, strings.Join(headers, ", "))
 		}
 		if l.logger.Trace().Ctx(request.Context()).Enabled() {
 			responseBody, err := io.ReadAll(response.Body)
 			if err != nil {
 				return nil, err
 			}
-			l.logger.Trace().Ctx(request.Context()).Msgf("Proxied FHIR response body: %s", string(responseBody))
+			l.logger.Trace().Ctx(request.Context()).Msgf("%s proxied FHIR response body: %s", l.name, string(responseBody))
 			response.Body = io.NopCloser(bytes.NewReader(responseBody))
 		}
 	}
 	return response, err
 }
-
-//func CreateProxy(fhirBaseURL *url.URL) {
-//	result := &httputil.ReverseProxy{
-//		Rewrite: func(r *httputil.ProxyRequest) {
-//			r.SetURL(fhirBaseURL)
-//			cleanHeaders(r.Out.Header)
-//		},
-//	}.ServeHTTP
-//	result.Transport = loggingTransportDecorator{
-//		RoundTripper: fhirHTTPClient.Transport,
-//	}
-//	result.ErrorHandler = func(responseWriter http.ResponseWriter, request *http.Request, err error) {
-//		log.Warn().Err(err).Msgf("Proxy error: %s", sanitizeRequestURL(request.URL).String())
-//		responseWriter.Header().Add("Content-Type", "application/fhir+json")
-//		responseWriter.WriteHeader(http.StatusBadGateway)
-//		diagnostics := "The system tried to proxy the FHIR operation, but an error occurred."
-//		data, _ := json.Marshal(fhir.OperationOutcome{
-//			Issue: []fhir.OperationOutcomeIssue{
-//				{
-//					Severity:    fhir.IssueSeverityError,
-//					Diagnostics: &diagnostics,
-//				},
-//			},
-//		})
-//		_, _ = responseWriter.Write(data)
-//	}
-//}
-//
-//func cleanHeaders(header http.Header) {
-//	for name, _ := range header {
-//		switch name {
-//		case "Content-Type":
-//			continue
-//		case "Accept":
-//			continue
-//		case "Accept-Encoding":
-//			continue
-//		case "User-Agent":
-//			continue
-//		case "X-Request-Id":
-//			// useful for tracing
-//			continue
-//		default:
-//			header.Del(name)
-//		}
-//	}
-//}
-//
-//type loggingTransportDecorator struct {
-//	RoundTripper http.RoundTripper
-//}
-//
-//func (d loggingTransportDecorator) RoundTrip(request *http.Request) (*http.Response, error) {
-//	response, err := d.RoundTripper.RoundTrip(request)
-//	if err != nil {
-//		log.Warn().Msgf("Proxy request failed: %s", sanitizeRequestURL(request.URL).String())
-//	} else {
-//		log.Info().Msgf("Proxied request: %s", sanitizeRequestURL(request.URL).String())
-//	}
-//	return response, err
-//}
-//
-//func sanitizeRequestURL(requestURL *url.URL) *url.URL {
-//	// Query might contain PII (e.g., social security number), so do not log it.
-//	requestURLWithoutQuery := *requestURL
-//	requestURLWithoutQuery.RawQuery = ""
-//	return &requestURLWithoutQuery
-//}

--- a/orchestrator/lib/coolfhir/proxy.go
+++ b/orchestrator/lib/coolfhir/proxy.go
@@ -25,7 +25,7 @@ import (
 func NewProxy(name string, logger zerolog.Logger, upstreamBaseUrl *url.URL, proxyBasePath string, rewriteUrl *url.URL, transport http.RoundTripper) *httputil.ReverseProxy {
 	return &httputil.ReverseProxy{
 		Rewrite: func(r *httputil.ProxyRequest) {
-			r.Out.URL = upstreamBaseUrl.JoinPath("/", strings.TrimPrefix(r.In.URL.Path, proxyBasePath))
+			r.Out.URL = upstreamBaseUrl.JoinPath(strings.TrimPrefix(r.In.URL.Path, proxyBasePath))
 			r.Out.URL.RawQuery = r.In.URL.RawQuery
 			r.Out.Host = upstreamBaseUrl.Host
 		},
@@ -73,6 +73,9 @@ func (s sanitizingRoundTripper) RoundTrip(request *http.Request) (*http.Response
 			nameLC == "authorization" {
 			request.Header.Del(name)
 		}
+	}
+	if request.Method == http.MethodGet {
+		request.Header.Del("Content-Length")
 	}
 	return s.next.RoundTrip(request)
 }

--- a/orchestrator/lib/coolfhir/proxy.go
+++ b/orchestrator/lib/coolfhir/proxy.go
@@ -33,6 +33,7 @@ func NewProxy(name string, logger zerolog.Logger, upstreamBaseUrl *url.URL, prox
 			next: loggingRoundTripper{
 				logger: &logger,
 				next:   transport,
+				name:   name,
 			},
 		},
 		ModifyResponse: func(response *http.Response) error {

--- a/orchestrator/lib/coolfhir/proxy.go
+++ b/orchestrator/lib/coolfhir/proxy.go
@@ -30,12 +30,15 @@ func NewProxy(name string, logger zerolog.Logger, upstreamBaseUrl *url.URL, prox
 			r.Out.Host = "" // upstreamBaseUrl.Host
 		},
 		Transport: sanitizingRoundTripper{
-			next: loggingRoundTripper{
-				logger: &logger,
-				next:   transport,
-				name:   name,
-			},
+			next: transport,
 		},
+		//Transport: sanitizingRoundTripper{
+		//	next: loggingRoundTripper{
+		//		logger: &logger,
+		//		next:   transport,
+		//		name:   name,
+		//	},
+		//},
 		ModifyResponse: func(response *http.Response) error {
 			upstreamUrl := upstreamBaseUrl.String()
 			proxyUrl := rewriteUrl.String()

--- a/orchestrator/lib/coolfhir/proxy.go
+++ b/orchestrator/lib/coolfhir/proxy.go
@@ -28,9 +28,7 @@ func NewProxy(name string, logger zerolog.Logger, upstreamBaseUrl *url.URL, prox
 			r.Out.URL.RawQuery = r.In.URL.RawQuery
 			r.Out.Host = "" // upstreamBaseUrl.Host
 		},
-		Transport: sanitizingRoundTripper{
-			next: transport,
-		},
+		Transport: transport,
 		//Transport: sanitizingRoundTripper{
 		//	next: loggingRoundTripper{
 		//		logger: &logger,

--- a/orchestrator/lib/coolfhir/proxy.go
+++ b/orchestrator/lib/coolfhir/proxy.go
@@ -112,12 +112,12 @@ func (l loggingRoundTripper) RoundTrip(request *http.Request) (*http.Response, e
 			l.logger.Debug().Ctx(request.Context()).Msgf("Proxied FHIR request response: %s, headers: %s", response.Status, strings.Join(headers, ", "))
 		}
 		if l.logger.Trace().Ctx(request.Context()).Enabled() {
-			responseBody, err := io.ReadAll(request.Body)
+			responseBody, err := io.ReadAll(response.Body)
 			if err != nil {
 				return nil, err
 			}
 			l.logger.Trace().Ctx(request.Context()).Msgf("Proxied FHIR response body: %s", string(responseBody))
-			request.Body = io.NopCloser(bytes.NewReader(responseBody))
+			response.Body = io.NopCloser(bytes.NewReader(responseBody))
 		}
 	}
 	return response, err

--- a/orchestrator/lib/coolfhir/proxy_test.go
+++ b/orchestrator/lib/coolfhir/proxy_test.go
@@ -32,7 +32,7 @@ func TestProxy(t *testing.T) {
 	proxyServerMux := http.NewServeMux()
 	proxyTransportRequestHeaders := make(http.Header)
 	proxyBaseUrl, _ := url.Parse("http://localhost/localfhir")
-	proxy := NewProxy(log.Logger, upstreamServerURL, "/localfhir", proxyBaseUrl, decoratingRoundTripper{
+	proxy := NewProxy("Test", log.Logger, upstreamServerURL, "/localfhir", proxyBaseUrl, decoratingRoundTripper{
 		inner: http.DefaultTransport,
 		decorator: func(request *http.Request) *http.Request {
 			for name, value := range proxyTransportRequestHeaders {

--- a/orchestrator/lib/coolfhir/proxy_test.go
+++ b/orchestrator/lib/coolfhir/proxy_test.go
@@ -98,6 +98,14 @@ func TestProxy(t *testing.T) {
 			responseData, _ := io.ReadAll(httpResponse.Body)
 			assert.Contains(t, string(responseData), "Request body is required for POST requests")
 		})
+		t.Run("invalid JSON in request body", func(t *testing.T) {
+			httpRequest, _ := http.NewRequest("POST", proxyServer.URL+"/localfhir/DoPost", bytes.NewReader([]byte(`{invalid json}`)))
+			httpResponse, err := proxyServer.Client().Do(httpRequest)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusBadRequest, httpResponse.StatusCode)
+			responseData, _ := io.ReadAll(httpResponse.Body)
+			assert.Contains(t, string(responseData), "Request body isn't valid JSON")
+		})
 	})
 	t.Run("PUT request", func(t *testing.T) {
 		t.Run("ok", func(t *testing.T) {

--- a/orchestrator/lib/coolfhir/proxy_test.go
+++ b/orchestrator/lib/coolfhir/proxy_test.go
@@ -79,6 +79,7 @@ func TestProxy(t *testing.T) {
 		assert.Empty(t, capturedCookies)
 	})
 	t.Run("cookies are not retained", func(t *testing.T) {
+		t.Skip()
 		// Cookies could contain sensitive information (session tokens), so they should not be proxied
 		httpRequest, _ := http.NewRequest("GET", proxyServer.URL+"/localfhir/Patient", nil)
 		httpRequest.AddCookie(&http.Cookie{
@@ -99,6 +100,7 @@ func TestProxy(t *testing.T) {
 		assert.Equal(t, "application/fhir+json", capturedHeaders.Get("Accept"))
 	})
 	t.Run("request headers are sanitized", func(t *testing.T) {
+		t.Skip()
 		httpRequest, _ := http.NewRequest("GET", proxyServer.URL+"/localfhir/Patient", nil)
 		// There can be numerous X-headers that can contain information that should not be proxied by default (e.g. internal infrastructure details)
 		httpRequest.Header.Set("X-Request-Id", "custom-client")

--- a/orchestrator/lib/coolfhir/proxy_test.go
+++ b/orchestrator/lib/coolfhir/proxy_test.go
@@ -79,7 +79,6 @@ func TestProxy(t *testing.T) {
 		assert.Empty(t, capturedCookies)
 	})
 	t.Run("cookies are not retained", func(t *testing.T) {
-		t.Skip()
 		// Cookies could contain sensitive information (session tokens), so they should not be proxied
 		httpRequest, _ := http.NewRequest("GET", proxyServer.URL+"/localfhir/Patient", nil)
 		httpRequest.AddCookie(&http.Cookie{
@@ -100,7 +99,6 @@ func TestProxy(t *testing.T) {
 		assert.Equal(t, "application/fhir+json", capturedHeaders.Get("Accept"))
 	})
 	t.Run("request headers are sanitized", func(t *testing.T) {
-		t.Skip()
 		httpRequest, _ := http.NewRequest("GET", proxyServer.URL+"/localfhir/Patient", nil)
 		// There can be numerous X-headers that can contain information that should not be proxied by default (e.g. internal infrastructure details)
 		httpRequest.Header.Set("X-Request-Id", "custom-client")

--- a/orchestrator/lib/coolfhir/proxy_test.go
+++ b/orchestrator/lib/coolfhir/proxy_test.go
@@ -1,6 +1,7 @@
 package coolfhir
 
 import (
+	"bytes"
 	fhirclient "github.com/SanteonNL/go-fhir-client"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
@@ -19,7 +20,23 @@ func TestProxy(t *testing.T) {
 	var capturedQueryParams url.Values
 	var capturedCookies []*http.Cookie
 	var capturedHeaders http.Header
-	upstreamServerMux.HandleFunc("GET /fhir/Patient", func(writer http.ResponseWriter, request *http.Request) {
+	upstreamServerMux.HandleFunc("GET /fhir/DoGet", func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+		capturedHost = request.Host
+		capturedQueryParams = request.URL.Query()
+		capturedCookies = request.Cookies()
+		capturedHeaders = request.Header
+		writer.Write([]byte(`{"resourceType":"Patient"}`))
+	})
+	upstreamServerMux.HandleFunc("POST /fhir/DoPost", func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusCreated)
+		capturedHost = request.Host
+		capturedQueryParams = request.URL.Query()
+		capturedCookies = request.Cookies()
+		capturedHeaders = request.Header
+		writer.Write([]byte(`{"resourceType":"Patient"}`))
+	})
+	upstreamServerMux.HandleFunc("PUT /fhir/DoPut", func(writer http.ResponseWriter, request *http.Request) {
 		writer.WriteHeader(http.StatusOK)
 		capturedHost = request.Host
 		capturedQueryParams = request.URL.Query()
@@ -51,12 +68,28 @@ func TestProxy(t *testing.T) {
 		baseUrl, _ := url.Parse(proxyServer.URL + "/localfhir")
 		client := fhirclient.New(baseUrl, http.DefaultClient, nil)
 		var patient fhir.Patient
-		err := client.Read("Patient", &patient, fhirclient.QueryParam("_id", "1"))
+		err := client.Read("DoGet", &patient, fhirclient.QueryParam("_id", "1"))
 		require.NoError(t, err)
 		require.Equal(t, "1", capturedQueryParams.Get("_id"))
 	})
-	t.Run("base request", func(t *testing.T) {
-		httpRequest, _ := http.NewRequest("GET", proxyServer.URL+"/localfhir/Patient", nil)
+	t.Run("GET request", func(t *testing.T) {
+		httpRequest, _ := http.NewRequest("GET", proxyServer.URL+"/localfhir/DoGet", nil)
+		httpResponse, err := proxyServer.Client().Do(httpRequest)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, httpResponse.StatusCode)
+		assert.Empty(t, capturedQueryParams)
+		assert.Empty(t, capturedCookies)
+	})
+	t.Run("POST request", func(t *testing.T) {
+		httpRequest, _ := http.NewRequest("POST", proxyServer.URL+"/localfhir/DoPost", bytes.NewReader([]byte(`{"resourceType":"Patient"}`)))
+		httpResponse, err := proxyServer.Client().Do(httpRequest)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusCreated, httpResponse.StatusCode)
+		assert.Empty(t, capturedQueryParams)
+		assert.Empty(t, capturedCookies)
+	})
+	t.Run("PUT request", func(t *testing.T) {
+		httpRequest, _ := http.NewRequest("PUT", proxyServer.URL+"/localfhir/DoPut", bytes.NewReader([]byte(`{"resourceType":"Patient"}`)))
 		httpResponse, err := proxyServer.Client().Do(httpRequest)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, httpResponse.StatusCode)
@@ -64,14 +97,14 @@ func TestProxy(t *testing.T) {
 		assert.Empty(t, capturedCookies)
 	})
 	t.Run("Host header is rewritten to upstream server hostname", func(t *testing.T) {
-		httpRequest, _ := http.NewRequest("GET", proxyServer.URL+"/localfhir/Patient", nil)
+		httpRequest, _ := http.NewRequest("GET", proxyServer.URL+"/localfhir/DoGet", nil)
 		httpResponse, err := proxyServer.Client().Do(httpRequest)
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusOK, httpResponse.StatusCode)
 		assert.Equal(t, upstreamServerURL.Host, capturedHost)
 	})
 	t.Run("query parameters are retained", func(t *testing.T) {
-		httpRequest, _ := http.NewRequest("GET", proxyServer.URL+"/localfhir/Patient?_search=foo:bar", nil)
+		httpRequest, _ := http.NewRequest("GET", proxyServer.URL+"/localfhir/DoGet?_search=foo:bar", nil)
 		httpResponse, err := proxyServer.Client().Do(httpRequest)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, httpResponse.StatusCode)
@@ -80,7 +113,7 @@ func TestProxy(t *testing.T) {
 	})
 	t.Run("cookies are not retained", func(t *testing.T) {
 		// Cookies could contain sensitive information (session tokens), so they should not be proxied
-		httpRequest, _ := http.NewRequest("GET", proxyServer.URL+"/localfhir/Patient", nil)
+		httpRequest, _ := http.NewRequest("GET", proxyServer.URL+"/localfhir/DoGet", nil)
 		httpRequest.AddCookie(&http.Cookie{
 			Name:  "sid",
 			Value: "test",
@@ -91,7 +124,7 @@ func TestProxy(t *testing.T) {
 		assert.Empty(t, capturedCookies)
 	})
 	t.Run("request headers are proxied", func(t *testing.T) {
-		httpRequest, _ := http.NewRequest("GET", proxyServer.URL+"/localfhir/Patient", nil)
+		httpRequest, _ := http.NewRequest("GET", proxyServer.URL+"/localfhir/DoGet", nil)
 		httpRequest.Header.Set("Accept", "application/fhir+json")
 		httpResponse, err := proxyServer.Client().Do(httpRequest)
 		require.NoError(t, err)
@@ -99,7 +132,7 @@ func TestProxy(t *testing.T) {
 		assert.Equal(t, "application/fhir+json", capturedHeaders.Get("Accept"))
 	})
 	t.Run("request headers are sanitized", func(t *testing.T) {
-		httpRequest, _ := http.NewRequest("GET", proxyServer.URL+"/localfhir/Patient", nil)
+		httpRequest, _ := http.NewRequest("GET", proxyServer.URL+"/localfhir/DoGet", nil)
 		// There can be numerous X-headers that can contain information that should not be proxied by default (e.g. internal infrastructure details)
 		httpRequest.Header.Set("X-Request-Id", "custom-client")
 		// User agent can convey privacy-sensitive information about the client that should not be proxied
@@ -121,7 +154,7 @@ func TestProxy(t *testing.T) {
 		// Authorization header from the proxied request should not be proxied,
 		// but if the http.Client used for proxying sets it, the latter one should be proxied
 		// (used for authentication).
-		httpRequest, _ := http.NewRequest("GET", proxyServer.URL+"/localfhir/Patient", nil)
+		httpRequest, _ := http.NewRequest("GET", proxyServer.URL+"/localfhir/DoGet", nil)
 		httpRequest.Header.Set("Authorization", "Bearer test")
 		defer func() {
 			proxyTransportRequestHeaders = make(http.Header)


### PR DESCRIPTION
On Azure FHIR, the following query returns HTTP 400 Bad Request, without response body:

```
/orca/cpc/cps/fhir/ServiceRequest?identifier=2.16.528.1.1007.3.3.21514.ehr.orders%7C99534756439a
```

The same goes for `ServiceRequest?_id=2`

Fix:

I couldn't find out why it failed, but it was something in the usage of `httputil.ReverseProxy`. I rewrote our FHIR proxy to use `fhirclient.Client`, which worked. This should also improve the consistency of HTTP responses (headers, marshalling format). This thus applies to the actual issue (CPS proxying to Azure FHIR), but is now also used by the CPC->CPS proxy (which uses the same). But tests still work, so should be OK.

Also improved proxy logging (it now logs a proxy name, since some requests are routed through 2 proxies, making logging very hard to understand) and fixed a bug in the FHIR error response marshaller (sometimes an OperationOutcome error wasn't seen as such, depending on whether a pointer to it was passed).

Note that, as of consequence, we don't support anything other than POST, GET and PUT, but I don't think we need to, for now (since we don't support it anyways in ORCA).