### PR TITLE
Ensure URL is non-nil before proceeding in workflow

### DIFF
--- a/orchestrator/careplancontributor/handle_taskfiller.go
+++ b/orchestrator/careplancontributor/handle_taskfiller.go
@@ -223,11 +223,13 @@ func (s *Service) createSubTaskOrAcceptPrimaryTask(ctx context.Context, cpsClien
 							ReasonDetail: err,
 						}
 					}
-					nextStep, err = workflow.Proceed(*fetchedQuestionnaire.Url)
-					if err != nil {
-						log.Error().Ctx(ctx).Err(err).Msgf("Unable to determine next questionnaire (previous URL=%s)", *fetchedQuestionnaire.Url)
-					} else {
-						break
+					if fetchedQuestionnaire.Url != nil {
+						nextStep, err = workflow.Proceed(*fetchedQuestionnaire.Url)
+						if err != nil {
+							log.Error().Ctx(ctx).Err(err).Msgf("Unable to determine next questionnaire (previous URL=%s)", *fetchedQuestionnaire.Url)
+						} else {
+							break
+						}
 					}
 				}
 			}


### PR DESCRIPTION
This update adds a check to confirm that the fetched questionnaire's URL is not nil before attempting to proceed in the workflow. This prevents potential nil pointer dereference errors and enhances the robustness of the error handling mechanism. 