### PR TITLE
INT-481: Cache-Control for FHIR APIs

### DIFF
--- a/orchestrator/careplanservice/service.go
+++ b/orchestrator/careplanservice/service.go
@@ -135,7 +135,8 @@ func (r FHIRHandlerRequest) bundleEntry() fhir.BundleEntry {
 type FHIRHandlerResult func(txResult *fhir.Bundle) (*fhir.BundleEntry, []any, error)
 
 func (s *Service) RegisterHandlers(mux *http.ServeMux) {
-	s.proxy = coolfhir.NewProxy("CPS->FHIR proxy", log.Logger, s.fhirURL, basePath, s.orcaPublicURL.JoinPath(basePath), s.transport)
+	s.proxy = coolfhir.NewProxy("CPS->FHIR proxy", log.Logger, s.fhirURL, basePath,
+		s.orcaPublicURL.JoinPath(basePath), s.transport, true)
 	baseUrl := s.baseUrl()
 	s.profile.RegisterHTTPHandlers(basePath, baseUrl, mux)
 

--- a/orchestrator/careplanservice/service_test.go
+++ b/orchestrator/careplanservice/service_test.go
@@ -63,6 +63,9 @@ func TestService_Proxy(t *testing.T) {
 		require.Equal(t, http.StatusOK, httpResponse.StatusCode)
 		responseData, _ := io.ReadAll(httpResponse.Body)
 		require.JSONEq(t, `{"resourceType":"Task", "intent":"order", "status":"draft"}`, string(responseData))
+		t.Run("caching is allowed", func(t *testing.T) {
+			assert.Equal(t, "must-understand, private", httpResponse.Header.Get("Cache-Control"))
+		})
 	})
 	t.Run("it proxies query parameters", func(t *testing.T) {
 		httpResponse, err := httpClient.Get(frontServer.URL + "/cps/Success?_identifier=foo|bar")

--- a/orchestrator/lib/coolfhir/proxy.go
+++ b/orchestrator/lib/coolfhir/proxy.go
@@ -29,6 +29,7 @@ type fhirClientProxy struct {
 	proxyBasePath   string
 	proxyBaseUrl    *url.URL
 	upstreamBaseUrl *url.URL
+	allowCaching    bool
 }
 
 func (f fhirClientProxy) ServeHTTP(httpResponseWriter http.ResponseWriter, request *http.Request) {
@@ -153,10 +154,19 @@ func (f fhirClientProxy) ServeHTTP(httpResponseWriter http.ResponseWriter, reque
 	}
 	upstreamUrl := f.upstreamBaseUrl.String()
 	proxyUrl := f.proxyBaseUrl.String()
-	pipeline.New().
+	pipe := pipeline.New().
 		AppendResponseTransformer(pipeline.ResponseBodyRewriter{Old: []byte(upstreamUrl), New: []byte(proxyUrl)}).
-		AppendResponseTransformer(pipeline.ResponseHeaderRewriter{Old: upstreamUrl, New: proxyUrl}).
-		DoAndWrite(httpResponseWriter, responseResource, responseStatusCode)
+		AppendResponseTransformer(pipeline.ResponseHeaderRewriter{Old: upstreamUrl, New: proxyUrl})
+	if f.allowCaching {
+		pipe = pipe.AppendResponseTransformer(pipeline.ResponseHeaderSetter{
+			"Cache-Control": {"must-understand, private"},
+		})
+	} else {
+		pipe = pipe.AppendResponseTransformer(pipeline.ResponseHeaderSetter{
+			"Cache-Control": {"no-store"},
+		})
+	}
+	pipe.DoAndWrite(httpResponseWriter, responseResource, responseStatusCode)
 }
 
 func (f fhirClientProxy) sanitizeRequestHeaders(header http.Header) http.Header {
@@ -194,12 +204,14 @@ func (f fhirClientProxy) sanitizeRequestHeaders(header http.Header) http.Header 
 // - upstreamBaseUrl: the FHIR base URL of the upstream FHIR server to which HTTP requests are forwarded, e.g. http://upstream:8080/fhir
 // - proxyBasePath: the base path of the proxy server, e.g. http://example.com/fhir. It is used to rewrite the request URL.
 // - rewriteUrl: the base URL of the proxy server, e.g. http://example.com/fhir. It is used to rewrite URLs in the HTTP response.
+// - allowCaching: controls Cache-Control header directives of HTTP responses.
 // proxyBasePath and rewriteUrl might differ if the proxy server is behind a reverse proxy, which binds to application to a different path.
 // E.g.:
 //   - if the proxy is on /fhir, and the reverse proxy binds to /, then proxyBasePath = /fhir and rewriteUrl = /.
 //   - if the proxy is on /, and the reverse proxy binds to /fhir, then proxyBasePath = / and rewriteUrl = /fhir.
 //   - if the proxy is on /fhir, and the reverse proxy binds to /app/fhir, then proxyBasePath = /fhir and rewriteUrl = /app/fhir.
-func NewProxy(name string, logger zerolog.Logger, upstreamBaseUrl *url.URL, proxyBasePath string, rewriteUrl *url.URL, transport http.RoundTripper) HttpProxy {
+func NewProxy(name string, logger zerolog.Logger, upstreamBaseUrl *url.URL, proxyBasePath string, rewriteUrl *url.URL,
+	transport http.RoundTripper, allowCaching bool) HttpProxy {
 	httpClient := &http.Client{
 		Transport: &loggingRoundTripper{
 			name:   name,
@@ -212,6 +224,7 @@ func NewProxy(name string, logger zerolog.Logger, upstreamBaseUrl *url.URL, prox
 		proxyBasePath:   proxyBasePath,
 		proxyBaseUrl:    rewriteUrl,
 		upstreamBaseUrl: upstreamBaseUrl,
+		allowCaching:    allowCaching,
 	}
 }
 

--- a/orchestrator/lib/coolfhir/proxy_test.go
+++ b/orchestrator/lib/coolfhir/proxy_test.go
@@ -29,6 +29,14 @@ func TestProxy(t *testing.T) {
 		capturedHeaders = request.Header
 		writer.Write([]byte(`{"resourceType":"Patient"}`))
 	})
+	upstreamServerMux.HandleFunc("/fhir/InvalidJsonResponse", func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+		capturedHost = request.Host
+		capturedQueryParams = request.URL.Query()
+		capturedCookies = request.Cookies()
+		capturedHeaders = request.Header
+		writer.Write([]byte(`this is not JSON`))
+	})
 	upstreamServerMux.HandleFunc("POST /fhir/DoPost", func(writer http.ResponseWriter, request *http.Request) {
 		writer.WriteHeader(http.StatusCreated)
 		capturedHost = request.Host
@@ -61,7 +69,7 @@ func TestProxy(t *testing.T) {
 			}
 			return request
 		},
-	})
+	}, false)
 	proxyServer := httptest.NewServer(proxyServerMux)
 	proxyServerMux.HandleFunc("/localfhir/{rest...}", proxy.ServeHTTP)
 
@@ -73,6 +81,26 @@ func TestProxy(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "1", capturedQueryParams.Get("_id"))
 	})
+	t.Run("cache headers", func(t *testing.T) {
+		t.Run("no caching", func(t *testing.T) {
+			httpResponse, err := proxyServer.Client().Get(proxyServer.URL + "/localfhir/DoGet")
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, httpResponse.StatusCode)
+			assert.Equal(t, "no-store", httpResponse.Header.Get("Cache-Control"))
+		})
+		t.Run("private caching only", func(t *testing.T) {
+			proxy.(*fhirClientProxy).allowCaching = true
+			t.Cleanup(func() {
+				proxy.(*fhirClientProxy).allowCaching = false
+			})
+			httpResponse, err := proxyServer.Client().Get(proxyServer.URL + "/localfhir/DoGet")
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, httpResponse.StatusCode)
+			assert.Equal(t, "must-understand, private", httpResponse.Header.Get("Cache-Control"))
+			assert.Empty(t, httpResponse.Header.Get("Pragma"))
+		})
+	})
+
 	t.Run("GET request", func(t *testing.T) {
 		httpRequest, _ := http.NewRequest("GET", proxyServer.URL+"/localfhir/DoGet", nil)
 		httpResponse, err := proxyServer.Client().Do(httpRequest)


### PR DESCRIPTION
- No caching for browser-facing FHIR APIs
- Private caching for system-facing FHIR APIs