### PR TITLE
INT-496: ORCA CPC ZbJ | BUG: The questionnaire is created multiple times in the FHIR store, causing the task submission to fail.

### DIFF
--- a/orchestrator/careplancontributor/handle_taskfiller.go
+++ b/orchestrator/careplancontributor/handle_taskfiller.go
@@ -268,14 +268,12 @@ func (s *Service) createSubTaskOrAcceptPrimaryTask(ctx context.Context, cpsClien
 	}
 
 	// Create a new SubTask based on the Questionnaire reference
-	questionnaireRef := "urn:uuid:" + *questionnaire.Id
+	questionnaireRef := "Questionnaire/" + *questionnaire.Id
 	subtask := s.getSubTask(primaryTask, questionnaireRef)
 	subtaskRef := "urn:uuid:" + *subtask.Id
 
 	tx := coolfhir.Transaction().
-		Create(questionnaire, coolfhir.WithFullUrl(questionnaireRef), func(entry *fhir.BundleEntry) {
-			entry.Request.Url = "Questionnaire" // TODO: remove this after changed to fhir.Questionnaire
-		}).
+		Update(questionnaire, questionnaireRef).
 		Create(subtask, coolfhir.WithFullUrl(subtaskRef))
 
 	bundle := tx.Bundle()


### PR DESCRIPTION
Use "Update" for Questionnaire creation in transaction.

Replaced `Create` with `Update` for the Questionnaire in the FHIR transaction, aligning with the correct resource reference format. Adjusted the `questionnaireRef` to use "Questionnaire/" prefix for consistency with FHIR standards. Removed obsolete comment and unnecessary entry modifications.