### PR TITLE
INT-464: Implement in-memory workflow provider 

### DIFF
--- a/orchestrator/careplancontributor/config.go
+++ b/orchestrator/careplancontributor/config.go
@@ -38,9 +38,6 @@ func (c Config) Validate() error {
 	if c.CarePlanService.URL == "" {
 		return errors.New("careplancontributor.careplanservice.url is not configured")
 	}
-	if c.FHIR.BaseURL == "" {
-		return errors.New("careplancontributor.fhir.baseurl is not configured")
-	}
 	return nil
 }
 

--- a/orchestrator/careplancontributor/config_test.go
+++ b/orchestrator/careplancontributor/config_test.go
@@ -17,15 +17,6 @@ func TestConfig_Validate(t *testing.T) {
 		}.Validate()
 		require.EqualError(t, err, "careplancontributor.careplanservice.url is not configured")
 	})
-	t.Run("missing FHIR base URL", func(t *testing.T) {
-		err := Config{
-			Enabled: true,
-			CarePlanService: CarePlanServiceConfig{
-				URL: "http://example.com",
-			},
-		}.Validate()
-		require.EqualError(t, err, "careplancontributor.fhir.baseurl is not configured")
-	})
 }
 
 func TestDefaultConfig(t *testing.T) {

--- a/orchestrator/careplancontributor/taskengine/workflow.go
+++ b/orchestrator/careplancontributor/taskengine/workflow.go
@@ -95,6 +95,8 @@ type MemoryWorkflowProvider struct {
 	healthcareServices []fhir.HealthcareService
 }
 
+// LoadBundle fetches the FHIR Bundle from the given URL and adds the contained Questionnaires and HealthcareServices to the provider.
+// They can then be used to provide workflows.
 func (e *MemoryWorkflowProvider) LoadBundle(ctx context.Context, bundleUrl string) error {
 	var bundle fhir.Bundle
 	parsedBundleUrl, err := url.Parse(bundleUrl)

--- a/orchestrator/careplancontributor/taskengine/workflow_test.go
+++ b/orchestrator/careplancontributor/taskengine/workflow_test.go
@@ -1,0 +1,83 @@
+package taskengine
+
+import (
+	"context"
+	"github.com/SanteonNL/orca/orchestrator/lib/to"
+	"github.com/stretchr/testify/require"
+	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestMemoryFHIRResourcesWorkflowProvider_Provide(t *testing.T) {
+	httpServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if strings.Contains(request.URL.String(), "healthcareservice") {
+			data, err := os.ReadFile("testdata/healthcareservice-bundle.json")
+			if err != nil {
+				panic(err)
+			}
+			writer.WriteHeader(http.StatusOK)
+			_, _ = writer.Write(data)
+		} else if strings.Contains(request.URL.String(), "questionnaire") {
+			data, err := os.ReadFile("testdata/questionnaire-bundle.json")
+			if err != nil {
+				panic(err)
+			}
+			writer.WriteHeader(http.StatusOK)
+			_, _ = writer.Write(data)
+		} else {
+			writer.WriteHeader(http.StatusNotFound)
+		}
+	}))
+
+	provider := &MemoryWorkflowProvider{}
+	require.NoError(t, provider.LoadBundle(context.Background(), httpServer.URL+"/healthcareservice"))
+	require.NoError(t, provider.LoadBundle(context.Background(), httpServer.URL+"/questionnaire"))
+
+	serviceCode := fhir.Coding{
+		System: to.Ptr("http://snomed.info/sct"),
+		Code:   to.Ptr("719858009"),
+	}
+	conditionCode := fhir.Coding{
+		System: to.Ptr("http://snomed.info/sct"),
+		Code:   to.Ptr("84114007"),
+	}
+
+	t.Run("provide workflow", func(t *testing.T) {
+		t.Run("ok", func(t *testing.T) {
+			workflow, err := provider.Provide(context.Background(), serviceCode, conditionCode)
+			require.NoError(t, err)
+			require.NotNil(t, workflow)
+		})
+		t.Run("service not supported", func(t *testing.T) {
+			serviceCode := fhir.Coding{
+				System: to.Ptr("http://snomed.info/sct"),
+				Code:   to.Ptr("134"),
+			}
+			_, err := provider.Provide(context.Background(), serviceCode, conditionCode)
+			require.ErrorIs(t, err, ErrWorkflowNotFound)
+		})
+		t.Run("condition not supported", func(t *testing.T) {
+			conditionCode := fhir.Coding{
+				System: to.Ptr("http://snomed.info/sct"),
+				Code:   to.Ptr("1234"),
+			}
+			_, err := provider.Provide(context.Background(), serviceCode, conditionCode)
+			require.ErrorIs(t, err, ErrWorkflowNotFound)
+		})
+	})
+	t.Run("load questionnaire", func(t *testing.T) {
+		t.Run("ok", func(t *testing.T) {
+			workflow, err := provider.Provide(context.Background(), serviceCode, conditionCode)
+			require.NoError(t, err)
+			require.NotNil(t, workflow)
+
+			questionnaire, err := provider.QuestionnaireLoader().Load(context.Background(), workflow.Start().QuestionnaireUrl)
+			require.NoError(t, err)
+			require.NotNil(t, questionnaire)
+		})
+	})
+}

--- a/orchestrator/lib/coolfhir/util.go
+++ b/orchestrator/lib/coolfhir/util.go
@@ -282,7 +282,7 @@ func IsScpTask(task *fhir.Task) bool {
 	return false
 }
 
-// Returns all identifiers matching the given system from the provided array of identifiers
+// FilterIdentifier returns all identifiers matching the given system from the provided array of identifiers
 func FilterIdentifier(identifiers *[]fhir.Identifier, system string) *[]fhir.Identifier {
 	if identifiers == nil {
 		return &[]fhir.Identifier{}
@@ -299,7 +299,7 @@ func FilterIdentifier(identifiers *[]fhir.Identifier, system string) *[]fhir.Ide
 	return &result
 }
 
-// Returns the first identifier matching the given system from the provided array of identifiers
+// FilterFirstIdentifier returns the first identifier matching the given system from the provided array of identifiers
 func FilterFirstIdentifier(identifiers *[]fhir.Identifier, system string) *fhir.Identifier {
 	if identifiers == nil {
 		return nil
@@ -331,4 +331,16 @@ func SendResponse(httpResponse http.ResponseWriter, httpStatus int, resource int
 	if err != nil {
 		log.Err(err).Msgf("Failed to write response: %s", string(data))
 	}
+}
+
+func ContainsCoding(code fhir.Coding, concepts ...fhir.CodeableConcept) bool {
+	for _, codeableConcept := range concepts {
+		for _, currCoding := range codeableConcept.Coding {
+			if (code.Code != nil && currCoding.Code != nil && *code.Code == *currCoding.Code) &&
+				(code.System != nil && currCoding.System != nil && *code.System == *currCoding.System) {
+				return true
+			}
+		}
+	}
+	return false
 }


### PR DESCRIPTION
As alternative to Questionnaire/HealthcareService FHIR resources from FHIR API. Useful if a vendor doesn't want to load questionnaires/healthcareservices in their FHIR instance.

It filters the HealthcareService and Questionnaire v.s. the ServiceRequest code and Condition code in-memory, instead of searching them in the FHIR API.

The downside is, that on boot the (external) source of the FHIR bundles MUST be up and running, otherwise ORCA will fail to start.