### PR TITLE
INT-511: FHIR proxy ignores upstream errors on POST-search

### DIFF
--- a/orchestrator/lib/coolfhir/proxy.go
+++ b/orchestrator/lib/coolfhir/proxy.go
@@ -128,7 +128,8 @@ func (f fhirClientProxy) ServeHTTP(httpResponseWriter http.ResponseWriter, reque
 		err = f.client.ReadWithContext(request.Context(), outRequestUrl.Path, &responseResource, params...)
 	case http.MethodPost:
 		if strings.HasSuffix(request.URL.Path, "/_search") {
-			values, err := url.ParseQuery(string(requestData))
+			var values url.Values
+			values, err = url.ParseQuery(string(requestData))
 			if err == nil {
 				err = f.client.SearchWithContext(request.Context(), strings.TrimSuffix(outRequestUrl.Path, "/_search"), values, &responseResource, params...)
 			}

--- a/orchestrator/lib/coolfhir/proxy_test.go
+++ b/orchestrator/lib/coolfhir/proxy_test.go
@@ -81,6 +81,14 @@ func TestProxy(t *testing.T) {
 		capturedHeaders = request.Header
 		writer.Write([]byte(`this is not JSON`))
 	})
+	upstreamServerMux.HandleFunc("POST /fhir/DoPost/InvalidJsonResponse/_search", func(writer http.ResponseWriter, request *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+		capturedHost = request.Host
+		capturedQueryParams = request.URL.Query()
+		capturedCookies = request.Cookies()
+		capturedHeaders = request.Header
+		writer.Write([]byte(`this is not JSON`))
+	})
 	upstreamServer := httptest.NewServer(upstreamServerMux)
 	upstreamServerURL, _ := url.Parse(upstreamServer.URL)
 	upstreamServerURL.Path = "/fhir"
@@ -190,6 +198,13 @@ func TestProxy(t *testing.T) {
 			require.NoError(t, err)
 			assert.Equal(t, http.StatusOK, httpResponse.StatusCode)
 			assert.Empty(t, capturedBody)
+		})
+		t.Run("upstream error (not valid JSON)", func(t *testing.T) {
+			httpResponse, err := proxyServer.Client().Post(proxyServer.URL+"/localfhir/DoPost/InvalidJsonResponse/_search", "application/x-www-form-urlencoded", nil)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusBadGateway, httpResponse.StatusCode)
+			responseData, _ := io.ReadAll(httpResponse.Body)
+			assert.Contains(t, string(responseData), "FHIR response unmarshal failed")
 		})
 		t.Run("invalid combination of ID and search fails", func(t *testing.T) {
 			httpRequest, _ := http.NewRequest("POST", proxyServer.URL+"/localfhir/DoPost/1/_search", bytes.NewReader([]byte(`foo=bar`)))


### PR DESCRIPTION
A new `err` var was used that shadowed the shared `err` var, which caused the proxy to return status code `0` (which causes issues downstream).