### PR TITLE
INT-524: Fix superfluous horizontal scroll bar

### DIFF
--- a/frontend/app/enrollment/layout.tsx
+++ b/frontend/app/enrollment/layout.tsx
@@ -33,7 +33,7 @@ export default function EnrollmentLayout({ children }: { children: React.ReactNo
                 </nav>
                 <div className='text-2xl pt-2'>{isLastStep ? "Verzoek geaccepteerd" : isFirstStep ? "Verzoek controleren" : title}</div>
             </div>
-            <div className="h-px bg-gray-200 mb-10 w-[calc(100%+3rem)] -mx-6"></div>
+            <div className="h-px bg-gray-200 mb-10"></div>
             <div className="max-w-7xl px-5 w-full mx-auto">
                 {children}
             </div>


### PR DESCRIPTION
The horizontal ruler exceeded the viewport width due to a width calculation that added extra margin, for reasons to me unknown. `div` elements span the full parent element width by default, so there's no need for setting width (at least, to my limited CSS knowledge).