### PR TITLE
INT-525: Fix redirect to frontend after applaunch

### DIFF
--- a/orchestrator/README.md
+++ b/orchestrator/README.md
@@ -25,6 +25,7 @@ Use the following environment variables to configure the orchestrator:
 - `ORCA_CAREPLANCONTRIBUTOR_APPLAUNCH_SOF_SCOPE`: Any specific scope, for example `launch fhirUser`
 - `ORCA_CAREPLANCONTRIBUTOR_APPLAUNCH_DEMO_ENABLED`: Enable the demo app launch endpoint (default: `false`).
 - `ORCA_CAREPLANCONTRIBUTOR_APPLAUNCH_DEMO_FHIRPROXYURL`: Enable FHIR proxy for demo purposes on `/demo/fhirproxy`, which proxies requests to this URL.
+- `ORCA_CAREPLANCONTRIBUTOR_FRONTEND_URL`: Base URL of the frontend application, to which the browser is redirected on app launch (default: `/frontend`).
 - `ORCA_CAREPLANCONTRIBUTOR_SESSIONTIMEOUT`: Configure the user session timeout, use Golang time.Duration format (default: 15m).
 
 ### Care Plan Contributor Task Filler configuration

--- a/orchestrator/README.md
+++ b/orchestrator/README.md
@@ -25,7 +25,7 @@ Use the following environment variables to configure the orchestrator:
 - `ORCA_CAREPLANCONTRIBUTOR_APPLAUNCH_SOF_SCOPE`: Any specific scope, for example `launch fhirUser`
 - `ORCA_CAREPLANCONTRIBUTOR_APPLAUNCH_DEMO_ENABLED`: Enable the demo app launch endpoint (default: `false`).
 - `ORCA_CAREPLANCONTRIBUTOR_APPLAUNCH_DEMO_FHIRPROXYURL`: Enable FHIR proxy for demo purposes on `/demo/fhirproxy`, which proxies requests to this URL.
-- `ORCA_CAREPLANCONTRIBUTOR_FRONTEND_URL`: Base URL of the frontend application, to which the browser is redirected on app launch (default: `/frontend`).
+- `ORCA_CAREPLANCONTRIBUTOR_FRONTEND_URL`: Base URL of the frontend application, to which the browser is redirected on app launch (default: `/frontend/enrollment/new`).
 - `ORCA_CAREPLANCONTRIBUTOR_SESSIONTIMEOUT`: Configure the user session timeout, use Golang time.Duration format (default: 15m).
 
 ### Care Plan Contributor Task Filler configuration

--- a/orchestrator/careplancontributor/applaunch/demo/service.go
+++ b/orchestrator/careplancontributor/applaunch/demo/service.go
@@ -1,13 +1,11 @@
 package demo
 
 import (
-	"net/http"
-	"net/url"
-	"strings"
-
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor/applaunch/clients"
 	"github.com/SanteonNL/orca/orchestrator/user"
 	"github.com/rs/zerolog/log"
+	"net/http"
+	"net/url"
 )
 
 const fhirLauncherKey = "demo"
@@ -23,27 +21,19 @@ func init() {
 	}
 }
 
-func New(sessionManager *user.SessionManager, config Config, baseURL string, landingUrlPath string) *Service {
-	var appLaunchURL string
-	if strings.HasPrefix(baseURL, "http://") || strings.HasPrefix(baseURL, "https://") {
-		appLaunchURL = baseURL + "/demo-app-launch"
-	} else {
-		appLaunchURL = "http://localhost" + appLaunchURL + "/demo-app-launch"
-	}
-	log.Info().Msgf("Demo app launch is (%s)", appLaunchURL)
+func New(sessionManager *user.SessionManager, config Config, frontendLandingUrl string) *Service {
 	return &Service{
-		sessionManager: sessionManager,
-		config:         config,
-		baseURL:        baseURL,
-		landingUrlPath: landingUrlPath,
+		sessionManager:     sessionManager,
+		config:             config,
+		frontendLandingUrl: frontendLandingUrl,
 	}
 }
 
 type Service struct {
-	sessionManager *user.SessionManager
-	config         Config
-	baseURL        string
-	landingUrlPath string
+	sessionManager     *user.SessionManager
+	config             Config
+	baseURL            string
+	frontendLandingUrl string
 }
 
 func (s *Service) RegisterHandlers(mux *http.ServeMux) {
@@ -95,7 +85,5 @@ func (s *Service) handle(response http.ResponseWriter, request *http.Request) {
 		StringValues: values,
 	})
 	// Redirect to landing page
-	targetURL, _ := url.Parse(s.baseURL)
-	targetURL = targetURL.JoinPath(s.landingUrlPath)
-	http.Redirect(response, request, targetURL.String(), http.StatusFound)
+	http.Redirect(response, request, s.frontendLandingUrl, http.StatusFound)
 }

--- a/orchestrator/careplancontributor/applaunch/demo/service_test.go
+++ b/orchestrator/careplancontributor/applaunch/demo/service_test.go
@@ -13,7 +13,7 @@ import (
 func TestService_handle(t *testing.T) {
 	t.Run("root base URL", func(t *testing.T) {
 		sessionManager := user.NewSessionManager(time.Minute)
-		service := Service{sessionManager: sessionManager, baseURL: "/", landingUrlPath: "/cpc/"}
+		service := Service{sessionManager: sessionManager, baseURL: "/", frontendLandingUrl: "/cpc/"}
 		response := httptest.NewRecorder()
 		request := httptest.NewRequest("GET", "/demo-app-launch?patient=a&serviceRequest=b&practitioner=c&iss=https://example.com/fhir", nil)
 
@@ -24,18 +24,18 @@ func TestService_handle(t *testing.T) {
 	})
 	t.Run("subpath base URL", func(t *testing.T) {
 		sessionManager := user.NewSessionManager(time.Minute)
-		service := Service{sessionManager: sessionManager, baseURL: "/orca", landingUrlPath: "/cpc/"}
+		service := Service{sessionManager: sessionManager, baseURL: "/orca", frontendLandingUrl: "/frontend/landing"}
 		response := httptest.NewRecorder()
 		request := httptest.NewRequest("GET", "/demo-app-launch?patient=a&serviceRequest=b&practitioner=c&iss=https://example.com/fhir", nil)
 
 		service.handle(response, request)
 
 		require.Equal(t, http.StatusFound, response.Code)
-		require.Equal(t, "/orca/cpc/", response.Header().Get("Location"))
+		require.Equal(t, "/frontend/landing", response.Header().Get("Location"))
 	})
 	t.Run("should destroy previous session", func(t *testing.T) {
 		sessionManager := user.NewSessionManager(time.Minute)
-		service := Service{sessionManager: sessionManager, baseURL: "/orca", landingUrlPath: "/cpc/"}
+		service := Service{sessionManager: sessionManager, baseURL: "/orca", frontendLandingUrl: "/cpc/"}
 		response := httptest.NewRecorder()
 		request := httptest.NewRequest("GET", "/demo-app-launch?patient=a&serviceRequest=b&practitioner=c&iss=https://example.com/fhir", nil)
 

--- a/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
@@ -33,7 +33,7 @@ const launcherKey = "zorgplatform"
 const appLaunchUrl = "/zorgplatform-app-launch"
 const zorgplatformWorkflowIdSystem = "http://sts.zorgplatform.online/ws/claims/2017/07/workflow/workflow-id"
 
-func New(sessionManager *user.SessionManager, config Config, baseURL string, landingUrlPath string, profile profile.Provider) (*Service, error) {
+func New(sessionManager *user.SessionManager, config Config, baseURL string, frontendLandingUrl string, profile profile.Provider) (*Service, error) {
 	azKeysClient, err := azkeyvault.NewKeysClient(config.AzureConfig.KeyVaultConfig.KeyVaultURL, config.AzureConfig.CredentialType, false)
 	if err != nil {
 		return nil, fmt.Errorf("unable to create Azure Key Vault client: %w", err)
@@ -45,10 +45,10 @@ func New(sessionManager *user.SessionManager, config Config, baseURL string, lan
 
 	ctx := context.Background()
 
-	return newWithClients(ctx, sessionManager, config, baseURL, landingUrlPath, azKeysClient, azCertClient, profile)
+	return newWithClients(ctx, sessionManager, config, baseURL, frontendLandingUrl, azKeysClient, azCertClient, profile)
 }
 
-func newWithClients(ctx context.Context, sessionManager *user.SessionManager, config Config, baseURL string, landingUrlPath string,
+func newWithClients(ctx context.Context, sessionManager *user.SessionManager, config Config, baseURL string, frontendLandingUrl string,
 	keysClient azkeyvault.KeysClient, certsClient azkeyvault.CertificatesClient, profile profile.Provider) (*Service, error) {
 	var appLaunchURL string
 	if strings.HasPrefix(baseURL, "http://") || strings.HasPrefix(baseURL, "https://") {
@@ -135,7 +135,7 @@ func newWithClients(ctx context.Context, sessionManager *user.SessionManager, co
 		sessionManager:        sessionManager,
 		config:                config,
 		baseURL:               baseURL,
-		landingUrlPath:        landingUrlPath,
+		frontendLandingUrl:    frontendLandingUrl,
 		signingCertificate:    signCert,
 		signingCertificateKey: signCertKey.SigningKey(),
 		tlsClientCertificate:  &tlsClientCert,
@@ -162,7 +162,7 @@ type Service struct {
 	sessionManager         *user.SessionManager
 	config                 Config
 	baseURL                string
-	landingUrlPath         string
+	frontendLandingUrl     string
 	signingCertificate     [][]byte
 	signingCertificateKey  stdCrypto.Signer
 	tlsClientCertificate   *tls.Certificate
@@ -179,8 +179,9 @@ func (s *Service) RegisterHandlers(mux *http.ServeMux) {
 
 func (s *Service) EhrFhirProxy() coolfhir.HttpProxy {
 	targetFhirBaseUrl, _ := url.Parse(s.config.ApiUrl)
-	proxyBasePath := "/cpc/fhir"
-	rewriteUrl, _ := url.Parse(s.baseURL + proxyBasePath)
+	const proxyBasePath = "/cpc/fhir"
+	rewriteUrl, _ := url.Parse(s.baseURL)
+	rewriteUrl = rewriteUrl.JoinPath(proxyBasePath)
 	result := coolfhir.NewProxy("App->EHR (ZPF)", log.Logger, targetFhirBaseUrl, proxyBasePath, rewriteUrl, &stsAccessTokenRoundTripper{
 		transport:          s.zorgplatformHttpClient.Transport,
 		cpsFhirClient:      s.cpsFhirClient,
@@ -373,10 +374,8 @@ func (s *Service) handleLaunch(response http.ResponseWriter, request *http.Reque
 	s.sessionManager.Create(response, *sessionData)
 
 	// Redirect to landing page
-	targetURL, _ := url.Parse(s.baseURL)
-	targetURL = targetURL.JoinPath(s.landingUrlPath)
 	log.Info().Ctx(request.Context()).Msg("Successfully launched through ChipSoft HiX app launch")
-	http.Redirect(response, request, targetURL.String(), http.StatusFound)
+	http.Redirect(response, request, s.frontendLandingUrl, http.StatusFound)
 }
 
 func (s *Service) registerFhirClientFactory(config Config) {

--- a/orchestrator/careplancontributor/applaunch/zorgplatform/service_test.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/service_test.go
@@ -199,9 +199,9 @@ func TestService(t *testing.T) {
 	}
 
 	sessionManager := user.NewSessionManager(time.Minute)
-	service, err := newWithClients(context.Background(), sessionManager, cfg, httpServer.URL, "/", keysClient, certsClient, profile.Test())
-	service.secureTokenService = &stubSecureTokenService{}
+	service, err := newWithClients(context.Background(), sessionManager, cfg, httpServer.URL, "/frontend", keysClient, certsClient, profile.Test())
 	require.NoError(t, err)
+	service.secureTokenService = &stubSecureTokenService{}
 	service.RegisterHandlers(httpServerMux)
 
 	client := &http.Client{
@@ -216,6 +216,7 @@ func TestService(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Equal(t, http.StatusFound, launchHttpResponse.StatusCode)
+	require.Equal(t, "/frontend", launchHttpResponse.Header.Get("Location"))
 
 	t.Run("assert user session", func(t *testing.T) {
 		sessionData := user.SessionFromHttpResponse(sessionManager, launchHttpResponse)

--- a/orchestrator/careplancontributor/config.go
+++ b/orchestrator/careplancontributor/config.go
@@ -16,7 +16,7 @@ func DefaultConfig() Config {
 		AppLaunch:      applaunch.DefaultConfig(),
 		SessionTimeout: 15 * time.Minute,
 		FrontendConfig: FrontendConfig{
-			URL: "/frontend",
+			URL: "/frontend/enrollment/new",
 		},
 	}
 }

--- a/orchestrator/careplancontributor/config.go
+++ b/orchestrator/careplancontributor/config.go
@@ -2,8 +2,8 @@ package careplancontributor
 
 import (
 	"errors"
-	"strings"
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor/ehr"
+	"strings"
 	"time"
 
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor/applaunch"
@@ -15,6 +15,9 @@ func DefaultConfig() Config {
 		Enabled:        true,
 		AppLaunch:      applaunch.DefaultConfig(),
 		SessionTimeout: 15 * time.Minute,
+		FrontendConfig: FrontendConfig{
+			URL: "/frontend",
+		},
 	}
 }
 

--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -26,7 +26,7 @@ import (
 )
 
 const basePath = "/cpc"
-const LandingURL = basePath + "/"
+const FrontendLandingPath = "/enrollment/new"
 
 // The care plan header key may be provided as X-SCP-Context but will be changed due to the Go http client canonicalization
 const carePlanURLHeaderKey = "X-Scp-Context"
@@ -108,7 +108,7 @@ func New(
 		cpsClientFactory: func(baseURL *url.URL) fhirclient.Client {
 			return fhirclient.New(baseURL, httpClient, coolfhir.Config())
 		},
-		notifier:                ehr.NewNotifier(kafkaClient),
+		notifier:                      ehr.NewNotifier(kafkaClient),
 		healthdataviewEndpointEnabled: config.HealthDataViewEndpointEnabled,
 	}
 	pubsub.DefaultSubscribers.FhirSubscriptionNotify = result.handleNotification

--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -26,7 +26,6 @@ import (
 )
 
 const basePath = "/cpc"
-const FrontendLandingPath = "/enrollment/new"
 
 // The care plan header key may be provided as X-SCP-Context but will be changed due to the Go http client canonicalization
 const carePlanURLHeaderKey = "X-Scp-Context"

--- a/orchestrator/cmd/server.go
+++ b/orchestrator/cmd/server.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"path"
 	"time"
 
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor"
@@ -41,13 +42,14 @@ func Start(config Config) error {
 	}
 	if config.CarePlanContributor.Enabled {
 		// App Launches
+		var frontendLandingUrl = path.Join(config.CarePlanContributor.FrontendConfig.URL, careplancontributor.FrontendLandingPath)
 		var ehrFhirProxy coolfhir.HttpProxy
-		services = append(services, smartonfhir.New(config.CarePlanContributor.AppLaunch.SmartOnFhir, sessionManager, careplancontributor.LandingURL))
+		services = append(services, smartonfhir.New(config.CarePlanContributor.AppLaunch.SmartOnFhir, sessionManager, frontendLandingUrl))
 		if config.CarePlanContributor.AppLaunch.Demo.Enabled {
-			services = append(services, demo.New(sessionManager, config.CarePlanContributor.AppLaunch.Demo, config.Public.URL, careplancontributor.LandingURL))
+			services = append(services, demo.New(sessionManager, config.CarePlanContributor.AppLaunch.Demo, frontendLandingUrl))
 		}
 		if config.CarePlanContributor.AppLaunch.ZorgPlatform.Enabled {
-			service, err := zorgplatform.New(sessionManager, config.CarePlanContributor.AppLaunch.ZorgPlatform, config.Public.URL, careplancontributor.LandingURL, activeProfile)
+			service, err := zorgplatform.New(sessionManager, config.CarePlanContributor.AppLaunch.ZorgPlatform, config.Public.URL, frontendLandingUrl, activeProfile)
 			if err != nil {
 				return fmt.Errorf("failed to create Zorgplatform AppLaunch service: %w", err)
 			}

--- a/orchestrator/cmd/server.go
+++ b/orchestrator/cmd/server.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"path"
 	"time"
 
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor"
@@ -42,14 +41,13 @@ func Start(config Config) error {
 	}
 	if config.CarePlanContributor.Enabled {
 		// App Launches
-		var frontendLandingUrl = path.Join(config.CarePlanContributor.FrontendConfig.URL, careplancontributor.FrontendLandingPath)
 		var ehrFhirProxy coolfhir.HttpProxy
-		services = append(services, smartonfhir.New(config.CarePlanContributor.AppLaunch.SmartOnFhir, sessionManager, frontendLandingUrl))
+		services = append(services, smartonfhir.New(config.CarePlanContributor.AppLaunch.SmartOnFhir, sessionManager, config.CarePlanContributor.FrontendConfig.URL))
 		if config.CarePlanContributor.AppLaunch.Demo.Enabled {
-			services = append(services, demo.New(sessionManager, config.CarePlanContributor.AppLaunch.Demo, frontendLandingUrl))
+			services = append(services, demo.New(sessionManager, config.CarePlanContributor.AppLaunch.Demo, config.CarePlanContributor.FrontendConfig.URL))
 		}
 		if config.CarePlanContributor.AppLaunch.ZorgPlatform.Enabled {
-			service, err := zorgplatform.New(sessionManager, config.CarePlanContributor.AppLaunch.ZorgPlatform, config.Public.URL, frontendLandingUrl, activeProfile)
+			service, err := zorgplatform.New(sessionManager, config.CarePlanContributor.AppLaunch.ZorgPlatform, config.Public.URL, config.CarePlanContributor.FrontendConfig.URL, activeProfile)
 			if err != nil {
 				return fmt.Errorf("failed to create Zorgplatform AppLaunch service: %w", err)
 			}


### PR DESCRIPTION
Before, there was a redirect to the frontend if the user requested an unknown URL. But, this caused weird redirects, so it was removed. But now, the redirect after app launch is broken since they redirected to an incorrect URL.

Previously, it redirected to `/orca/cpc` (if `/orca` were the configured base URL), now it correctly redirects to the `/frontend/enrollment/new` URL.