### PR TITLE
INT-521: Re-index SearchParameter on Azure FHIR if it exists, but isn't in the CapabilityStatement

### DIFF
--- a/orchestrator/careplanservice/service_test.go
+++ b/orchestrator/careplanservice/service_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/SanteonNL/orca/orchestrator/cmd/profile"
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
 	"github.com/SanteonNL/orca/orchestrator/lib/deep"
+	"github.com/SanteonNL/orca/orchestrator/lib/test"
 	"github.com/SanteonNL/orca/orchestrator/lib/to"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
@@ -781,4 +782,53 @@ func Test_collectLiteralReferences(t *testing.T) {
 		"partOf.#1.reference": "https://example.com/fhir/CarePlan/2",
 		"partOf.#2.reference": "CarePlan/3",
 	}, actualRefs)
+}
+
+func TestService_ensureCustomSearchParametersExists(t *testing.T) {
+	ctx := context.Background()
+	t.Run("parameters are created", func(t *testing.T) {
+		fhirClient := test.StubFHIRClient{}
+		service := &Service{
+			fhirClient: &fhirClient,
+		}
+		err := service.ensureCustomSearchParametersExists(ctx)
+		require.NoError(t, err)
+		require.Len(t, fhirClient.CreatedResources["SearchParameter"], 3)
+		// First SearchParameter create, rest should be OK
+		searchParam := fhirClient.CreatedResources["SearchParameter"][0].(fhir.SearchParameter)
+		assert.Equal(t, "CarePlan-subject-identifier", *searchParam.Id)
+		// First SearchParameter re-index, rest should be OK
+		require.Len(t, fhirClient.CreatedResources["Parameters"], 3)
+		searchParamReindex := fhirClient.CreatedResources["Parameters"][0].(fhir.Parameters)
+		assert.Equal(t, "targetSearchParameterTypes", searchParamReindex.Parameter[0].Name)
+		assert.Equal(t, "http://zorgbijjou.nl/SearchParameter/CarePlan-subject-identifier", *searchParamReindex.Parameter[0].ValueString)
+	})
+	t.Run("Azure FHIR: parameter exists, but needs to be re-indexed", func(t *testing.T) {
+		t.Log("SearchParameter exists, but doesn't show up in CapabilityStatement. On Azure FHIR, this indicates the parameter needs to be re-indexed.")
+		fhirClient := test.StubFHIRClient{
+			Resources: []any{
+				fhir.SearchParameter{
+					Url: "http://zorgbijjou.nl/SearchParameter/CarePlan-subject-identifier",
+				},
+				fhir.SearchParameter{
+					Url: "http://santeonnl.github.io/shared-care-planning/cps-searchparameter-task-output-reference.json",
+				},
+				fhir.SearchParameter{
+					Url: "http://santeonnl.github.io/shared-care-planning/cps-searchparameter-task-input-reference.json",
+				},
+			},
+		}
+		service := &Service{
+			fhirClient: &fhirClient,
+		}
+		err := service.ensureCustomSearchParametersExists(ctx)
+		require.NoError(t, err)
+		// SearchParameter isn't created, but is re-indexed.
+		require.Empty(t, fhirClient.CreatedResources["SearchParameter"])
+		require.Len(t, fhirClient.CreatedResources["Parameters"], 3)
+		// Just check the first one
+		searchParamReindex := fhirClient.CreatedResources["Parameters"][0].(fhir.Parameters)
+		assert.Equal(t, "targetSearchParameterTypes", searchParamReindex.Parameter[0].Name)
+		assert.Equal(t, "http://zorgbijjou.nl/SearchParameter/CarePlan-subject-identifier", *searchParamReindex.Parameter[0].ValueString)
+	})
 }

--- a/orchestrator/careplanservice/service_test.go
+++ b/orchestrator/careplanservice/service_test.go
@@ -803,6 +803,48 @@ func TestService_ensureCustomSearchParametersExists(t *testing.T) {
 		assert.Equal(t, "targetSearchParameterTypes", searchParamReindex.Parameter[0].Name)
 		assert.Equal(t, "http://zorgbijjou.nl/SearchParameter/CarePlan-subject-identifier", *searchParamReindex.Parameter[0].ValueString)
 	})
+	t.Run("parameters exist", func(t *testing.T) {
+		fhirClient := test.StubFHIRClient{
+			Resources: []any{
+				fhir.SearchParameter{
+					Url: "http://zorgbijjou.nl/SearchParameter/CarePlan-subject-identifier",
+				},
+				fhir.SearchParameter{
+					Url: "http://santeonnl.github.io/shared-care-planning/cps-searchparameter-task-output-reference.json",
+				},
+				fhir.SearchParameter{
+					Url: "http://santeonnl.github.io/shared-care-planning/cps-searchparameter-task-input-reference.json",
+				},
+			},
+			Metadata: fhir.CapabilityStatement{
+				Rest: []fhir.CapabilityStatementRest{
+					{
+						Resource: []fhir.CapabilityStatementRestResource{
+							{
+								SearchParam: []fhir.CapabilityStatementRestResourceSearchParam{
+									{
+										Definition: to.Ptr("http://zorgbijjou.nl/SearchParameter/CarePlan-subject-identifier"),
+									},
+									{
+										Definition: to.Ptr("http://santeonnl.github.io/shared-care-planning/cps-searchparameter-task-output-reference.json"),
+									},
+									{
+										Definition: to.Ptr("http://santeonnl.github.io/shared-care-planning/cps-searchparameter-task-input-reference.json"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		service := &Service{
+			fhirClient: &fhirClient,
+		}
+		err := service.ensureCustomSearchParametersExists(ctx)
+		require.NoError(t, err)
+		require.Empty(t, fhirClient.CreatedResources)
+	})
 	t.Run("Azure FHIR: parameter exists, but needs to be re-indexed", func(t *testing.T) {
 		t.Log("SearchParameter exists, but doesn't show up in CapabilityStatement. On Azure FHIR, this indicates the parameter needs to be re-indexed.")
 		fhirClient := test.StubFHIRClient{

--- a/orchestrator/lib/test/fhirclient.go
+++ b/orchestrator/lib/test/fhirclient.go
@@ -1,0 +1,181 @@
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	fhirclient "github.com/SanteonNL/go-fhir-client"
+	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
+	"github.com/SanteonNL/orca/orchestrator/lib/to"
+	"github.com/google/uuid"
+	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
+	"net/url"
+	"strings"
+)
+
+type BaseResource struct {
+	Id         string            `json:"id"`
+	Identifier []fhir.Identifier `json:"identifier"`
+	Type       string            `json:"resourceType"`
+	Data       []byte            `json:"-"`
+	URL        string            `json:"url"`
+}
+
+var _ fhirclient.Client = &StubFHIRClient{}
+
+type StubFHIRClient struct {
+	Resources []any
+	Metadata  fhir.CapabilityStatement
+	// CreatedResources is a list of resources that have been created using this client.
+	// It's not used by the client itself, but can be used by tests to verify that the client has been used correctly.
+	CreatedResources map[string][]any
+}
+
+func (s StubFHIRClient) Read(path string, target any, opts ...fhirclient.Option) error {
+	return s.ReadWithContext(context.Background(), path, target, opts...)
+}
+
+func (s StubFHIRClient) ReadWithContext(ctx context.Context, path string, target any, opts ...fhirclient.Option) error {
+	if path == "metadata" {
+		unmarshalInto(s.Metadata, &target)
+		return nil
+	}
+	for _, resource := range s.Resources {
+		var baseResource BaseResource
+		unmarshalInto(resource, &baseResource)
+		if path == baseResource.Type+"/"+baseResource.Id {
+			if err := json.Unmarshal(baseResource.Data, target); err != nil {
+				panic(err)
+			}
+			return nil
+		}
+	}
+	return errors.New("resource not found")
+}
+
+func (s StubFHIRClient) Create(resource any, result any, opts ...fhirclient.Option) error {
+	return s.CreateWithContext(context.Background(), resource, result, opts...)
+}
+
+func (s StubFHIRClient) Search(resourceType string, query url.Values, target any, opts ...fhirclient.Option) error {
+	return s.SearchWithContext(context.Background(), resourceType, query, target, opts...)
+}
+
+func (s StubFHIRClient) SearchWithContext(ctx context.Context, resourceType string, query url.Values, target any, opts ...fhirclient.Option) error {
+	var candidates []BaseResource
+	for _, res := range s.Resources {
+		var baseResource BaseResource
+		unmarshalInto(res, &baseResource)
+		if baseResource.Type == resourceType {
+			candidates = append(candidates, baseResource)
+		}
+	}
+
+	filterCandidates := func(predicate func(BaseResource) bool) {
+		var filtered []BaseResource
+		for _, candidate := range candidates {
+			if predicate(candidate) {
+				filtered = append(filtered, candidate)
+			}
+		}
+		candidates = filtered
+	}
+
+	for name, values := range query {
+		if len(values) != 1 {
+			return fmt.Errorf("multiple values for query parameter: %s", name)
+		}
+		value := values[0]
+		switch name {
+		case "identifier":
+			token := strings.Split(value, "|")
+			filterCandidates(func(candidate BaseResource) bool {
+				for _, identifier := range candidate.Identifier {
+					if (token[0] == "" || to.EmptyString(identifier.System) == token[0]) &&
+						(token[1] == "" || to.EmptyString(identifier.Value) == token[1]) {
+						return true
+					}
+				}
+				return false
+			})
+		case "url":
+			filterCandidates(func(candidate BaseResource) bool {
+				return candidate.URL == value
+			})
+		default:
+			return fmt.Errorf("unsupported query parameter: %s", name)
+		}
+	}
+
+	result := fhir.Bundle{
+		Type:  fhir.BundleTypeSearchset,
+		Total: to.Ptr(len(candidates)),
+	}
+	for _, candidate := range candidates {
+		result.Entry = append(result.Entry, fhir.BundleEntry{
+			Resource: candidate.Data,
+		})
+	}
+	resultJSON, _ := json.Marshal(result)
+	return json.Unmarshal(resultJSON, target)
+}
+
+func (s *StubFHIRClient) CreateWithContext(_ context.Context, resource any, result any, opts ...fhirclient.Option) error {
+	resourceType := coolfhir.ResourceType(resource)
+	if resourceType == "" {
+		return fmt.Errorf("can't defer resource type of %T", resource)
+	}
+	var resourceAsMap = make(map[string]interface{})
+	unmarshalInto(resource, resourceAsMap)
+	if resourceAsMap["id"] == nil {
+		resourceAsMap["id"] = uuid.NewString()
+	} else {
+		// Check if it doesn't already exist
+		for _, existingResource := range s.Resources {
+			var existingResourceBase BaseResource
+			unmarshalInto(existingResource, &existingResourceBase)
+			if resourceType == existingResourceBase.Type && existingResourceBase.Id == resourceAsMap["id"] {
+				return errors.New("resource already exists")
+			}
+		}
+	}
+	s.Resources = append(s.Resources, resource)
+	if s.CreatedResources == nil {
+		s.CreatedResources = make(map[string][]any)
+	}
+	s.CreatedResources[resourceType] = append(s.CreatedResources[resourceType], resource)
+	unmarshalInto(resource, result)
+	return nil
+}
+
+func (s StubFHIRClient) Update(path string, resource any, result any, opts ...fhirclient.Option) error {
+	panic("implement me")
+}
+
+func (s StubFHIRClient) UpdateWithContext(ctx context.Context, path string, resource any, result any, opts ...fhirclient.Option) error {
+	panic("implement me")
+}
+
+func (s StubFHIRClient) Path(path ...string) *url.URL {
+	panic("implement me")
+}
+
+func unmarshalInto(resource interface{}, target interface{}) {
+	resJSON, err := json.Marshal(resource)
+	if err != nil {
+		panic(err)
+	}
+	switch t := target.(type) {
+	case *[]byte:
+		*t = resJSON
+	default:
+		if err := json.Unmarshal(resJSON, &target); err != nil {
+			panic(err)
+		}
+		baseResource, ok := target.(*BaseResource)
+		if ok {
+			baseResource.Data = resJSON
+		}
+	}
+}

--- a/orchestrator/lib/to/util.go
+++ b/orchestrator/lib/to/util.go
@@ -13,6 +13,13 @@ func NilString(value string) *string {
 	return &value
 }
 
+func EmptyString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
 // Value returns the value of a pointer or the zero value of the type if the pointer is nil.
 func Value[T any](v *T) T {
 	if v == nil {


### PR DESCRIPTION
The SearchParameter existed, but wasn't working. It also wasn't in the CapabilityStatement, which indicates it needs to be re-indexed:

> The new search parameter will appear in the capability statement of the FHIR server after you POST the search parameter to the database and reindex your database. Viewing the SearchParameter in the capability statement is the only way tell if a search parameter is supported in your FHIR server. If you can find the search parameter, but cannot see it in the capability statement, you still need to index the search parameter. You can POST multiple search parameters before triggering a reindex operation.

(https://learn.microsoft.com/en-us/azure/healthcare-apis/azure-api-for-fhir/how-to-do-custom-search)

I also made creating the SearchParameters less fiddly, and made it less forgiving when it fails (I've never seen it fail, and it's essential functionality).