### PR TITLE
INT-487: Support non-root base URL in EHR proxy

### DIFF
--- a/orchestrator/lib/coolfhir/util.go
+++ b/orchestrator/lib/coolfhir/util.go
@@ -325,6 +325,22 @@ func FilterFirstIdentifier(identifiers *[]fhir.Identifier, system string) *fhir.
 	return nil
 }
 
+// ParseLocalReference parses a local reference and returns the resource type and the resource ID.
+// If the reference is not in this format, an error is returned.
+func ParseLocalReference(reference string) (string, string, error) {
+	if strings.Count(reference, "/") != 1 {
+		return "", "", errors.New("local reference must contain exactly one '/'")
+	}
+	parts := strings.Split(reference, "/")
+	if parts[0] == "" {
+		return "", "", errors.New("local reference must contain a resource type")
+	}
+	if parts[1] == "" {
+		return "", "", errors.New("local reference must contain a resource ID")
+	}
+	return parts[0], parts[1], nil
+}
+
 // ParseExternalLiteralReference parses an external literal reference and returns the FHIR base URL and the resource reference.
 // For example:
 // - http://example.com/fhir/Patient/123 yields http://example.com/fhir and Patient/123

--- a/orchestrator/lib/coolfhir/util_test.go
+++ b/orchestrator/lib/coolfhir/util_test.go
@@ -847,3 +847,30 @@ func TestParseExternalLiteralReference(t *testing.T) {
 		assert.Empty(t, ref)
 	})
 }
+
+func TestParseLocalReference(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		resourceType, resourceID, err := ParseLocalReference("")
+		require.EqualError(t, err, "local reference must contain exactly one '/'")
+		assert.Empty(t, resourceType)
+		assert.Empty(t, resourceID)
+	})
+	t.Run("no slash", func(t *testing.T) {
+		resourceType, resourceID, err := ParseLocalReference("Patient")
+		require.EqualError(t, err, "local reference must contain exactly one '/'")
+		assert.Empty(t, resourceType)
+		assert.Empty(t, resourceID)
+	})
+	t.Run("no resource ID", func(t *testing.T) {
+		resourceType, resourceID, err := ParseLocalReference("Patient/")
+		require.EqualError(t, err, "local reference must contain a resource ID")
+		assert.Empty(t, resourceType)
+		assert.Empty(t, resourceID)
+	})
+	t.Run("valid", func(t *testing.T) {
+		resourceType, resourceID, err := ParseLocalReference("Patient/123")
+		require.NoError(t, err)
+		assert.Equal(t, "Patient", resourceType)
+		assert.Equal(t, "123", resourceID)
+	})
+}

--- a/viewer_simulator/app/(DashboardLayout)/components/bgz/actions.ts
+++ b/viewer_simulator/app/(DashboardLayout)/components/bgz/actions.ts
@@ -65,7 +65,7 @@ export async function getBgzData(carePlan: CarePlan, careTeam: CareTeam) {
 
 async function fetchBgzData(resourceType: string, query: string, carePlan: CarePlan) {
     const requestUrl = `${process.env.FHIR_AGGREGATE_URL}/${resourceType}/_search`;
-    const xSCPContext = `${process.env.FHIR_BASE_URL}/CarePlan/${carePlan.id}`;
+    const xSCPContext = `${process.env.ORCA_CAREPLANCONTRIBUTOR_CAREPLANSERVICE_URL}/CarePlan/${carePlan.id}`;
     console.log(`Sending request to ${requestUrl} with X-Scp-Context: ${xSCPContext}`);
 
     const response = await fetch(requestUrl, {

--- a/viewer_simulator/app/(DashboardLayout)/components/bgz/actions.ts
+++ b/viewer_simulator/app/(DashboardLayout)/components/bgz/actions.ts
@@ -65,7 +65,7 @@ export async function getBgzData(carePlan: CarePlan, careTeam: CareTeam) {
 
 async function fetchBgzData(resourceType: string, query: string, carePlan: CarePlan) {
     const requestUrl = `${process.env.FHIR_AGGREGATE_URL}/${resourceType}/_search`;
-    const xSCPContext = `${process.env.ORCA_CAREPLANCONTRIBUTOR_CAREPLANSERVICE_URL}/CarePlan/${carePlan.id}`;
+    const xSCPContext = `${process.env.FHIR_BASE_URL}/CarePlan/${carePlan.id}`;
     console.log(`Sending request to ${requestUrl} with X-Scp-Context: ${xSCPContext}`);
 
     const response = await fetch(requestUrl, {


### PR DESCRIPTION
`authorizeScpMember()` fails if the CPS runs on a non-root base URL (e.g. `/orca`), due to the way the CarePlan ID is parsed from the X-SCP-Context URL.