### PR TITLE
INT-473: Parse passed existing task ID for demo launch

### DIFF
--- a/hospital_simulator/utils/config.ts
+++ b/hospital_simulator/utils/config.ts
@@ -18,7 +18,7 @@ export const getEnrollmentUrl = async (patientId: string, serviceRequestId: stri
             serviceRequest: `ServiceRequest/${serviceRequestId}`,
             practitioner: `Practitioner/${respBundle.entry[0].resource?.id}`, //TODO: Rework to get reference from ServiceRequest.requester - currently an Organization, but should be a PractitionerRole
             iss: `${process.env.FHIR_BASE_URL}`,
-            taskIdentifier: serviceRequestId
+            taskIdentifier: `http://demo-launch/fhir/NamingSystem/task-identifier|${serviceRequestId}`
         }).toString()
     }
 

--- a/orchestrator/careplancontributor/applaunch/demo/service.go
+++ b/orchestrator/careplancontributor/applaunch/demo/service.go
@@ -8,7 +8,6 @@ import (
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor/applaunch/clients"
 	"github.com/SanteonNL/orca/orchestrator/globals"
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
-	"github.com/SanteonNL/orca/orchestrator/lib/to"
 	"github.com/SanteonNL/orca/orchestrator/user"
 	"github.com/rs/zerolog/log"
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
@@ -70,15 +69,19 @@ func (s *Service) handle(response http.ResponseWriter, request *http.Request) {
 		StringValues: values,
 	})
 
-	existingTask, err := coolfhir.GetTaskByIdentifier(request.Context(), s.cpsFhirClient(), fhir.Identifier{
-		System: to.Ptr(demoTaskSystemSystem),
-		Value:  to.Ptr(values["taskIdentifier"]),
-	})
-
-	if err != nil {
-		log.Error().Err(err).Ctx(request.Context()).Msg("Existing CPS Task check failed for task with identifier: " + values["taskIdentifier"])
-		http.Error(response, "Failed to check for existing CPS Task resource", http.StatusInternalServerError)
-		return
+	var existingTask *fhir.Task
+	if values["taskIdentifier"] != "" {
+		taskIdentifier, err := coolfhir.TokenToIdentifier(values["taskIdentifier"])
+		if err != nil {
+			http.Error(response, "Failed to parse task identifier: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		existingTask, err = coolfhir.GetTaskByIdentifier(request.Context(), s.cpsFhirClient(), *taskIdentifier)
+		if err != nil {
+			log.Error().Err(err).Ctx(request.Context()).Msg("Existing CPS Task check failed for task with identifier: " + coolfhir.ToString(taskIdentifier))
+			http.Error(response, "Failed to check for existing CPS Task resource", http.StatusInternalServerError)
+			return
+		}
 	}
 
 	if existingTask != nil {

--- a/orchestrator/careplancontributor/applaunch/demo/service_test.go
+++ b/orchestrator/careplancontributor/applaunch/demo/service_test.go
@@ -19,7 +19,7 @@ func TestService_handle(t *testing.T) {
 		Id: to.Ptr("12345678910"),
 		Identifier: []fhir.Identifier{
 			{
-				System: to.Ptr(demoTaskSystemSystem),
+				System: to.Ptr("unit-test-system"),
 				Value:  to.Ptr("20"),
 			},
 		},
@@ -34,7 +34,7 @@ func TestService_handle(t *testing.T) {
 		sessionManager := user.NewSessionManager(time.Minute)
 		service := Service{sessionManager: sessionManager, baseURL: "/", frontendLandingUrl: "/cpc/"}
 		response := httptest.NewRecorder()
-		request := httptest.NewRequest("GET", "/demo-app-launch?patient=a&serviceRequest=b&practitioner=c&iss=https://example.com/fhir&taskIdentifier=10", nil)
+		request := httptest.NewRequest("GET", "/demo-app-launch?patient=a&serviceRequest=b&practitioner=c&iss=https://example.com/fhir&taskIdentifier=unit-test-system|10", nil)
 
 		service.handle(response, request)
 
@@ -45,7 +45,7 @@ func TestService_handle(t *testing.T) {
 		sessionManager := user.NewSessionManager(time.Minute)
 		service := Service{sessionManager: sessionManager, baseURL: "/orca", frontendLandingUrl: "/frontend/landing"}
 		response := httptest.NewRecorder()
-		request := httptest.NewRequest("GET", "/demo-app-launch?patient=a&serviceRequest=b&practitioner=c&iss=https://example.com/fhir&taskIdentifier=10", nil)
+		request := httptest.NewRequest("GET", "/demo-app-launch?patient=a&serviceRequest=b&practitioner=c&iss=https://example.com/fhir&taskIdentifier=unit-test-system|10", nil)
 
 		service.handle(response, request)
 
@@ -56,7 +56,7 @@ func TestService_handle(t *testing.T) {
 		sessionManager := user.NewSessionManager(time.Minute)
 		service := Service{sessionManager: sessionManager, baseURL: "/orca", frontendLandingUrl: "/cpc/"}
 		response := httptest.NewRecorder()
-		request := httptest.NewRequest("GET", "/demo-app-launch?patient=a&serviceRequest=b&practitioner=c&iss=https://example.com/fhir&taskIdentifier=10", nil)
+		request := httptest.NewRequest("GET", "/demo-app-launch?patient=a&serviceRequest=b&practitioner=c&iss=https://example.com/fhir&taskIdentifier=unit-test-system|20", nil)
 
 		service.handle(response, request)
 		require.Equal(t, 1, sessionManager.SessionCount())
@@ -64,7 +64,7 @@ func TestService_handle(t *testing.T) {
 		// Now launch the second session - copy the cookies so the session is retained
 		cookies := response.Result().Cookies()
 		response = httptest.NewRecorder()
-		request = httptest.NewRequest("GET", "/demo-app-launch?patient=a&serviceRequest=b&practitioner=c&iss=https://example.com/fhir&taskIdentifier=10", nil)
+		request = httptest.NewRequest("GET", "/demo-app-launch?patient=a&serviceRequest=b&practitioner=c&iss=https://example.com/fhir&taskIdentifier=unit-test-system|20", nil)
 		for _, cookie := range cookies {
 			request.AddCookie(cookie)
 		}
@@ -75,7 +75,7 @@ func TestService_handle(t *testing.T) {
 		sessionManager := user.NewSessionManager(time.Minute)
 		service := Service{sessionManager: sessionManager, baseURL: "/orca", frontendLandingUrl: "/frontend/enrollment"}
 		response := httptest.NewRecorder()
-		request := httptest.NewRequest("GET", "/demo-app-launch?patient=a&serviceRequest=b&practitioner=c&iss=https://example.com/fhir&taskIdentifier=20", nil)
+		request := httptest.NewRequest("GET", "/demo-app-launch?patient=a&serviceRequest=b&practitioner=c&iss=https://example.com/fhir&taskIdentifier=unit-test-system|20", nil)
 
 		service.handle(response, request)
 

--- a/orchestrator/lib/coolfhir/util.go
+++ b/orchestrator/lib/coolfhir/util.go
@@ -427,3 +427,23 @@ func GetTaskByIdentifier(ctx context.Context, fhirClient fhirclient.Client, iden
 
 	return nil, nil
 }
+
+// TokenToIdentifier parses a token string into an fhir.Identifier, as specified by https://www.hl7.org/fhir/search.html#token.
+// E.g.: system|code, system|, |code
+func TokenToIdentifier(s string) (*fhir.Identifier, error) {
+	parts := strings.Split(s, "|")
+	if len(parts) != 2 {
+		return nil, errors.New("identifier search token must contain exactly one '|'")
+	}
+	if parts[0] == "" && parts[1] == "" {
+		return nil, errors.New("identifier search token must contain a system, or a code, or both")
+	}
+	result := &fhir.Identifier{}
+	if parts[0] != "" {
+		result.System = &parts[0]
+	}
+	if parts[1] != "" {
+		result.Value = &parts[1]
+	}
+	return result, nil
+}

--- a/orchestrator/lib/coolfhir/util_test.go
+++ b/orchestrator/lib/coolfhir/util_test.go
@@ -959,3 +959,34 @@ func TestGetTaskByIdentifier(t *testing.T) {
 		})
 	}
 }
+
+func TestTokenToIdentifier(t *testing.T) {
+	t.Run("system and code", func(t *testing.T) {
+		identifier, err := TokenToIdentifier("http://example.com|123")
+		require.NoError(t, err)
+		assert.Equal(t, "http://example.com", *identifier.System)
+		assert.Equal(t, "123", *identifier.Value)
+	})
+	t.Run("system only", func(t *testing.T) {
+		identifier, err := TokenToIdentifier("http://example.com|")
+		require.NoError(t, err)
+		assert.Equal(t, "http://example.com", *identifier.System)
+		assert.Nil(t, identifier.Value)
+	})
+	t.Run("code only", func(t *testing.T) {
+		identifier, err := TokenToIdentifier("|123")
+		require.NoError(t, err)
+		assert.Nil(t, identifier.System)
+		assert.Equal(t, "123", *identifier.Value)
+	})
+	t.Run("neither", func(t *testing.T) {
+		identifier, err := TokenToIdentifier("|")
+		require.EqualError(t, err, "identifier search token must contain a system, or a code, or both")
+		assert.Nil(t, identifier)
+	})
+	t.Run("invalid format", func(t *testing.T) {
+		identifier, err := TokenToIdentifier("http://example.com")
+		require.EqualError(t, err, "identifier search token must contain exactly one '|'")
+		assert.Nil(t, identifier)
+	})
+}


### PR DESCRIPTION
Instead of double-encoding the system in the token