### PR TITLE
Fixes duplicate URL value and task enrollment failure

### DIFF
--- a/deployments/dev/hospital/docker-compose.yaml
+++ b/deployments/dev/hospital/docker-compose.yaml
@@ -72,7 +72,7 @@ services:
       - ORCA_CAREPLANCONTRIBUTOR_ENABLED=true
       - ORCA_CAREPLANCONTRIBUTOR_FHIR_URL=http://fhirstore:8080/fhir
       - ORCA_CAREPLANCONTRIBUTOR_CAREPLANSERVICE_URL=${CAREPLANCONTRIBUTOR_CAREPLANSERVICE_URL}
-      - ORCA_CAREPLANCONTRIBUTOR_FRONTEND_URL=${HOSPITAL_URL}/frontend/enrollment/new
+      - ORCA_CAREPLANCONTRIBUTOR_FRONTEND_URL=${HOSPITAL_URL}/frontend/enrollment
       - ORCA_CAREPLANCONTRIBUTOR_APPLAUNCH_DEMO_ENABLED=true
       - ORCA_CAREPLANCONTRIBUTOR_HEALTHDATAVIEWENDPOINTENABLED=true
       #   Uncomment and set the <...> values below to enable Zorgplatform integration - using zorgplatform production URLs as that is what their developer portal uses

--- a/frontend/lib/fhirUtils.ts
+++ b/frontend/lib/fhirUtils.ts
@@ -185,12 +185,13 @@ export const constructBundleTask = (serviceRequest: ServiceRequest, primaryCondi
     } as Task
 
     if (taskIdentifier) {
-        const systemAndIdentifier = taskIdentifier.split("|")
-        if (systemAndIdentifier.length !== 2) throw new Error("Invalid task identifier - expecting `system|identifier`")
-        task.identifier = [{
-            system: systemAndIdentifier[0],
-            value: systemAndIdentifier[1],
-        }]
+        // TODO: Fix ifNoneExists
+        // const systemAndIdentifier = taskIdentifier.split("|")
+        // if (systemAndIdentifier.length !== 2) throw new Error("Invalid task identifier - expecting `system|identifier`")
+        // task.identifier = [{
+        //     system: systemAndIdentifier[0],
+        //     value: systemAndIdentifier[1],
+        // }]
     }
 
     return task

--- a/orchestrator/careplancontributor/applaunch/demo/service.go
+++ b/orchestrator/careplancontributor/applaunch/demo/service.go
@@ -3,6 +3,7 @@ package demo
 import (
 	"net/http"
 	"net/url"
+	"strings"
 
 	fhirclient "github.com/SanteonNL/go-fhir-client"
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor/applaunch/clients"
@@ -89,5 +90,9 @@ func (s *Service) handle(response http.ResponseWriter, request *http.Request) {
 
 	// Redirect to landing page
 	log.Debug().Ctx(request.Context()).Msg("No existing CPS Task resource found for demo task with identifier: " + values["taskIdentifier"])
-	http.Redirect(response, request, s.frontendLandingUrl+"/new", http.StatusFound)
+	redirect := s.frontendLandingUrl
+	if !strings.HasSuffix(s.frontendLandingUrl, "/new") {
+		redirect += "/new"
+	}
+	http.Redirect(response, request, redirect, http.StatusFound)
 }

--- a/orchestrator/careplancontributor/applaunch/demo/service_test.go
+++ b/orchestrator/careplancontributor/applaunch/demo/service_test.go
@@ -1,6 +1,7 @@
 package demo
 
 import (
+	"github.com/SanteonNL/orca/orchestrator/lib/must"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -32,7 +33,7 @@ func TestService_handle(t *testing.T) {
 
 	t.Run("root base URL", func(t *testing.T) {
 		sessionManager := user.NewSessionManager(time.Minute)
-		service := Service{sessionManager: sessionManager, baseURL: "/", frontendLandingUrl: "/cpc/"}
+		service := Service{sessionManager: sessionManager, baseURL: "/", frontendLandingUrl: must.ParseURL("/cpc/")}
 		response := httptest.NewRecorder()
 		request := httptest.NewRequest("GET", "/demo-app-launch?patient=a&serviceRequest=b&practitioner=c&iss=https://example.com/fhir&taskIdentifier=10", nil)
 
@@ -43,7 +44,7 @@ func TestService_handle(t *testing.T) {
 	})
 	t.Run("subpath base URL", func(t *testing.T) {
 		sessionManager := user.NewSessionManager(time.Minute)
-		service := Service{sessionManager: sessionManager, baseURL: "/orca", frontendLandingUrl: "/frontend/landing"}
+		service := Service{sessionManager: sessionManager, baseURL: "/orca", frontendLandingUrl: must.ParseURL("/frontend/landing")}
 		response := httptest.NewRecorder()
 		request := httptest.NewRequest("GET", "/demo-app-launch?patient=a&serviceRequest=b&practitioner=c&iss=https://example.com/fhir&taskIdentifier=10", nil)
 
@@ -54,7 +55,7 @@ func TestService_handle(t *testing.T) {
 	})
 	t.Run("should destroy previous session", func(t *testing.T) {
 		sessionManager := user.NewSessionManager(time.Minute)
-		service := Service{sessionManager: sessionManager, baseURL: "/orca", frontendLandingUrl: "/cpc/"}
+		service := Service{sessionManager: sessionManager, baseURL: "/orca", frontendLandingUrl: must.ParseURL("/cpc/")}
 		response := httptest.NewRecorder()
 		request := httptest.NewRequest("GET", "/demo-app-launch?patient=a&serviceRequest=b&practitioner=c&iss=https://example.com/fhir&taskIdentifier=10", nil)
 
@@ -73,7 +74,7 @@ func TestService_handle(t *testing.T) {
 	})
 	t.Run("should restore task", func(t *testing.T) {
 		sessionManager := user.NewSessionManager(time.Minute)
-		service := Service{sessionManager: sessionManager, baseURL: "/orca", frontendLandingUrl: "/frontend/enrollment"}
+		service := Service{sessionManager: sessionManager, baseURL: "/orca", frontendLandingUrl: must.ParseURL("/frontend/enrollment")}
 		response := httptest.NewRecorder()
 		request := httptest.NewRequest("GET", "/demo-app-launch?patient=a&serviceRequest=b&practitioner=c&iss=https://example.com/fhir&taskIdentifier=20", nil)
 

--- a/orchestrator/careplancontributor/applaunch/smartonfhir/service.go
+++ b/orchestrator/careplancontributor/applaunch/smartonfhir/service.go
@@ -31,10 +31,10 @@ type Service struct {
 	stateToTokenUrlMap map[string]string //TODO: move to redis
 	mu                 *sync.Mutex
 	sessionManager     *user.SessionManager
-	landingUrlPath     string
+	landingUrlPath     *url.URL
 }
 
-func New(config Config, manager *user.SessionManager, landingUrlPath string) *Service {
+func New(config Config, manager *user.SessionManager, landingUrlPath *url.URL) *Service {
 	return &Service{
 		config:             config,
 		stateToTokenUrlMap: make(map[string]string),
@@ -123,7 +123,7 @@ func (s *Service) handleSmartAppLaunchRedirect(response http.ResponseWriter, req
 			"access_token": tokenResponse["access_token"].(string),
 		},
 	})
-	http.Redirect(response, request, s.landingUrlPath, http.StatusFound)
+	http.Redirect(response, request, s.landingUrlPath.String(), http.StatusFound)
 }
 
 func (s *Service) appLaunchRedirectLogic(ctx context.Context, state string, code string) (map[string]interface{}, error) {

--- a/orchestrator/careplancontributor/applaunch/zorgplatform/service_test.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/service_test.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	fhirclient "github.com/SanteonNL/go-fhir-client"
 	"github.com/SanteonNL/orca/orchestrator/globals"
+	"github.com/SanteonNL/orca/orchestrator/lib/must"
 	"github.com/SanteonNL/orca/orchestrator/lib/test"
 	"github.com/jellydator/ttlcache/v3"
 	"hash"
@@ -202,7 +203,7 @@ func TestService(t *testing.T) {
 	}
 
 	sessionManager := user.NewSessionManager(time.Minute)
-	service, err := newWithClients(context.Background(), sessionManager, cfg, httpServer.URL, "/frontend", keysClient, certsClient, profile.Test())
+	service, err := newWithClients(context.Background(), sessionManager, cfg, httpServer.URL, must.ParseURL("/frontend"), keysClient, certsClient, profile.Test())
 	require.NoError(t, err)
 	service.secureTokenService = &stubSecureTokenService{}
 	service.RegisterHandlers(httpServerMux)
@@ -625,7 +626,6 @@ func setupCarePlanService(t *testing.T) *httptest.Server {
 		})
 	})
 	httpServer := httptest.NewServer(mux)
-	baseURL, _ := url.Parse(httpServer.URL)
-	globals.CarePlanServiceFhirClient = fhirclient.New(baseURL.JoinPath("fhir"), http.DefaultClient, nil)
+	globals.CarePlanServiceFhirClient = fhirclient.New(must.ParseURL(httpServer.URL).JoinPath("fhir"), http.DefaultClient, nil)
 	return httpServer
 }

--- a/orchestrator/cmd/server.go
+++ b/orchestrator/cmd/server.go
@@ -7,6 +7,7 @@ import (
 	"github.com/SanteonNL/orca/orchestrator/globals"
 	"github.com/rs/zerolog/log"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"sync"
@@ -54,13 +55,14 @@ func Start(ctx context.Context, config Config) error {
 	}
 	if config.CarePlanContributor.Enabled {
 		// App Launches
-		var ehrFhirProxy coolfhir.HttpProxy
-		services = append(services, smartonfhir.New(config.CarePlanContributor.AppLaunch.SmartOnFhir, sessionManager, config.CarePlanContributor.FrontendConfig.URL))
+		frontendUrl, _ := url.Parse(config.CarePlanContributor.FrontendConfig.URL)
+		services = append(services, smartonfhir.New(config.CarePlanContributor.AppLaunch.SmartOnFhir, sessionManager, frontendUrl))
 		if config.CarePlanContributor.AppLaunch.Demo.Enabled {
-			services = append(services, demo.New(sessionManager, config.CarePlanContributor.AppLaunch.Demo, config.CarePlanContributor.FrontendConfig.URL))
+			services = append(services, demo.New(sessionManager, config.CarePlanContributor.AppLaunch.Demo, frontendUrl))
 		}
+		var ehrFhirProxy coolfhir.HttpProxy
 		if config.CarePlanContributor.AppLaunch.ZorgPlatform.Enabled {
-			service, err := zorgplatform.New(sessionManager, config.CarePlanContributor.AppLaunch.ZorgPlatform, config.Public.URL, config.CarePlanContributor.FrontendConfig.URL, activeProfile)
+			service, err := zorgplatform.New(sessionManager, config.CarePlanContributor.AppLaunch.ZorgPlatform, config.Public.URL, frontendUrl, activeProfile)
 			if err != nil {
 				return fmt.Errorf("failed to create Zorgplatform AppLaunch service: %w", err)
 			}

--- a/orchestrator/lib/must/util.go
+++ b/orchestrator/lib/must/util.go
@@ -1,0 +1,11 @@
+package must
+
+import "net/url"
+
+func ParseURL(s string) *url.URL {
+	u, err := url.Parse(s)
+	if err != nil {
+		panic("invalid URL: " + err.Error())
+	}
+	return u
+}


### PR DESCRIPTION
Ran into two issues that @rolandgroen also brought up so decided to fix them as it is simple.

One is that enrollment went to a 404 due to the URL having "/new/new" at the end, the other is some leftover change from the ifNotExists revert that was not removed, this has been commented as it was causing enrollment to fail. This issue was picked up on the main branch 