### PR TITLE
INT-544: Remove use of Encounter on Zorgplatform launch

### DIFF
--- a/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
@@ -456,8 +456,7 @@ func (s *Service) getSessionData(ctx context.Context, accessToken string, launch
 	fhirClient := fhirclient.New(apiUrl, s.createZorgplatformApiClient(accessToken), coolfhir.Config())
 
 	// Zorgplatform provides us with a Task, from which we need to derive the Patient and ServiceRequest
-	// - Patient is contained in the Task.encounter but separately requested to include the Practitioner
-	// - ServiceRequest is not provided by Zorgplatform, so we need to create one based on the Task and Encounter
+	// - ServiceRequest is not provided by Zorgplatform, so we need to create one based on the Task
 	var task map[string]interface{}
 	if err = fhirClient.ReadWithContext(ctx, "Task/"+launchContext.WorkflowId, &task); err != nil {
 		return nil, fmt.Errorf("unable to fetch Task resource (id=%s): %w", launchContext.WorkflowId, err)
@@ -468,42 +467,13 @@ func (s *Service) getSessionData(ctx context.Context, accessToken string, launch
 		return nil, err
 	}
 
-	// Search for Encounter, contains Encounter, Organization and Patient
-	if task["context"] == nil {
-		return nil, fmt.Errorf("task.context is not provided")
-	}
-	taskContext := task["context"].(map[string]interface{})
-	encounterId := strings.Split(taskContext["reference"].(string), "/")[1]
-	var encounterSearchResult fhir.Bundle
-	if err = fhirClient.ReadWithContext(ctx, "Encounter", &encounterSearchResult, fhirclient.QueryParam("_id", encounterId)); err != nil {
-		return nil, fmt.Errorf("unable to fetch Encounter resource (id=%s): %w", encounterId, err)
-	}
-	var encounter fhir.Encounter
-	if err := coolfhir.ResourceInBundle(&encounterSearchResult, coolfhir.EntryIsOfType("Encounter"), &encounter); err != nil {
-		return nil, fmt.Errorf("get Encounter from Bundle (id=%s): %w", encounterId, err)
-	}
-	// Get Patient from bundle, specified by Encounter.subject
-	if encounter.Subject == nil || encounter.Subject.Reference == nil {
-		return nil, fmt.Errorf("encounter.subject does not contain a reference to a Patient")
-	}
-
-	if encounter.ServiceProvider == nil || encounter.ServiceProvider.Reference == nil {
-		return nil, fmt.Errorf("encounter.serviceProvider does not contain a reference to an Organization")
-	}
-
-	// Get Organization from bundle, specified by Encounter.serviceProvider
-	var organization fhir.Organization
-	if err := coolfhir.ResourceInBundle(&encounterSearchResult, coolfhir.EntryHasID(*encounter.ServiceProvider.Reference), &organization); err != nil {
-		return nil, fmt.Errorf("get Organization from Bundle (id=%s): %w", encounterId, err)
-	}
-
 	var patientAndPractitionerBundle fhir.Bundle
 	if err = fhirClient.ReadWithContext(ctx, "Patient", &patientAndPractitionerBundle, fhirclient.QueryParam("_include", "Patient:general-practitioner")); err != nil {
 		return nil, fmt.Errorf("unable to fetch Patient and Practitioner bundle: %w", err)
 	}
 	var patient fhir.Patient
-	if err := coolfhir.ResourceInBundle(&patientAndPractitionerBundle, coolfhir.EntryHasID(*encounter.Subject.Reference), &patient); err != nil {
-		return nil, fmt.Errorf("unable to find Patient resource in Bundle (id=%s): %w", *encounter.Subject.Reference, err)
+	if err := coolfhir.ResourceInBundle(&patientAndPractitionerBundle, coolfhir.EntryIsOfType("Patient"), &patient); err != nil {
+		return nil, fmt.Errorf("unable to find Patient resource in Bundle: %w", err)
 	}
 	var practitioner fhir.Practitioner
 	//TODO: The Practitioner has no indetifier set, so we cannot ensure this is the launched Practitioner. Verify with Zorgplatform
@@ -540,16 +510,15 @@ func (s *Service) getSessionData(ctx context.Context, accessToken string, launch
 		Display:   to.Ptr(*reason.Code.Text),
 	}
 
+	// Resolve identity of local care organization
 	identities, err := s.profile.Identities(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("unable to fetch identities: %w", err)
 	}
-	if len(identities) == 0 {
-		return nil, fmt.Errorf("no identities found")
-	} else if len(identities) > 1 {
-		log.Warn().Ctx(ctx).Msgf("More than one identity found, using the first one: %v", identities[0])
+	if len(identities) != 1 {
+		return nil, fmt.Errorf("expected exactly one identity, got %d", len(identities))
 	}
-	localOrgIdentifier := identities[0]
+	organization := identities[0]
 
 	for _, identifier := range patient.Identifier {
 		if identifier.System != nil && *identifier.System == coolfhir.BSNNamingSystem {
@@ -601,7 +570,7 @@ func (s *Service) getSessionData(ctx context.Context, accessToken string, launch
 		},
 		Performer: []fhir.Reference{taskPerformer},
 		Requester: &fhir.Reference{
-			Identifier: &localOrgIdentifier,
+			Identifier: &organization.Identifier[0],
 		},
 	}
 

--- a/orchestrator/careplancontributor/applaunch/zorgplatform/service_test.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/service_test.go
@@ -121,9 +121,6 @@ func TestService(t *testing.T) {
 	zorgplatformHttpServerMux.Handle("GET /api/Task/b526e773-e1a6-4533-bd00-1360c97e745f", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Get Zorgplatform Workflow Task
 		coolfhir.SendResponse(w, http.StatusOK, map[string]interface{}{
-			"context": map[string]interface{}{
-				"reference": "Encounter/enc-123",
-			},
 			"definitionReference": map[string]interface{}{
 				"reference": "ActivityDefinition/1.0",
 			},
@@ -146,27 +143,6 @@ func TestService(t *testing.T) {
 					Id: to.Ptr("prac-123"),
 				}, nil, nil),
 		)
-	}))
-	zorgplatformHttpServerMux.Handle("GET /api/Encounter", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Query().Get("_id") == "enc-123" {
-			enc := fhir.Encounter{
-				Subject: &fhir.Reference{
-					Reference: to.Ptr("Patient/pat-123"),
-				},
-				ServiceProvider: &fhir.Reference{
-					Reference: to.Ptr("Organization/org-123"),
-				},
-			}
-			org := fhir.Organization{
-				Id: to.Ptr("org-123"),
-			}
-			coolfhir.SendResponse(w, http.StatusOK, coolfhir.SearchSet().
-				Append(enc, nil, nil).
-				Append(org, nil, nil),
-			)
-			return
-		}
-		coolfhir.SendResponse(w, http.StatusNotFound, nil)
 	}))
 
 	certDER := certificate.Certificate[0]

--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -316,7 +316,7 @@ func (s *Service) proxyToAllCareTeamMembers(writer http.ResponseWriter, request 
 	endpoints := make(map[string]*url.URL)
 	for _, identifier := range participantIdentifiers {
 		// Don't fetch data from own endpoint, since we don't support querying from multiple endpoints yet
-		if coolfhir.HasIdentifier(identifier, localIdentities...) {
+		if coolfhir.HasIdentifier(identifier, coolfhir.OrganizationIdentifiers(localIdentities)...) {
 			continue
 		}
 		fhirEndpoints, err := s.profile.CsdDirectory().LookupEndpoint(request.Context(), &identifier, profile.FHIRBaseURLEndpointName)

--- a/orchestrator/careplanservice/handle_createtask.go
+++ b/orchestrator/careplanservice/handle_createtask.go
@@ -253,11 +253,13 @@ func basedOn(task fhir.Task) (*string, error) {
 	return task.BasedOn[0].Reference, nil
 }
 
-func isRequesterLocalCareOrganization(profileIdentities []fhir.Identifier, principal auth.Principal) bool {
-	for _, id := range profileIdentities {
-		for _, poid := range principal.Organization.Identifier {
-			if coolfhir.IdentifierEquals(&id, &poid) {
-				return true
+func isRequesterLocalCareOrganization(localIdentities []fhir.Organization, principal auth.Principal) bool {
+	for _, localIdentity := range localIdentities {
+		for _, requesterIdentifier := range principal.Organization.Identifier {
+			for _, localIdentifier := range localIdentity.Identifier {
+				if coolfhir.IdentifierEquals(&localIdentifier, &requesterIdentifier) {
+					return true
+				}
 			}
 		}
 	}

--- a/orchestrator/careplanservice/subscriptions/channels.go
+++ b/orchestrator/careplanservice/subscriptions/channels.go
@@ -37,8 +37,10 @@ func (d InProcessChannelFactory) Create(ctx context.Context, subscriber fhir.Ide
 	localIdentities, err := d.Profile.Identities(ctx)
 	if err == nil {
 		for _, localIdentity := range localIdentities {
-			if coolfhir.IdentifierEquals(&localIdentity, &subscriber) {
-				return InProcessPubSubChannel{}, nil
+			for _, localIdentifier := range localIdentity.Identifier {
+				if coolfhir.IdentifierEquals(&localIdentifier, &subscriber) {
+					return InProcessPubSubChannel{}, nil
+				}
 			}
 		}
 	}

--- a/orchestrator/cmd/profile/nuts/profile_test.go
+++ b/orchestrator/cmd/profile/nuts/profile_test.go
@@ -76,8 +76,9 @@ func TestDutchNutsProfile_identifiersFromCredential(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Len(t, identifiers, 1)
-		assert.Equal(t, coolfhir.URANamingSystem, *identifiers[0].System)
-		assert.Equal(t, "1234", *identifiers[0].Value)
+		assert.Equal(t, coolfhir.URANamingSystem, *identifiers[0].Identifier[0].System)
+		assert.Equal(t, "1234", *identifiers[0].Identifier[0].Value)
+		assert.Equal(t, "Demo Clinic", *identifiers[0].Name)
 	})
 	t.Run("UziServerCertificateCredential", func(t *testing.T) {
 		credential, err := vc.ParseVerifiableCredential("eyJhbGciOiJQUzUxMiIsImtpZCI6ImRpZDp4NTA5OjA6c2hhNTEyOkN0Z0FaZENpSEtsSmNIb1FOWkpod1dDSUN6ZS1EM2R1TzY1cDk1cWJfSDlxVTAtNVUzdXhESWpsR1p3S1ZYeXpBcEdRWWF1Q1oxUlFXZ2p6YWdMYWNROjpzYW46b3RoZXJOYW1lOjIuMTYuNTI4LjEuMTAwNy45OS4yMTEwLTEtODY0NDYtUy04NjQ0Ni0wMC4wMDAtODY0NDY6OnN1YmplY3Q6Tzpab3JnJTIwYmlqJTIwam91JTIwQi5WLjo6c3ViamVjdDpMOlV0cmVjaHQjMCIsInR5cCI6IkpXVCIsIng1YyI6WyItLS0tLUJFR0lOIENFUlRJRklDQVRFLS0tLS1cbk1JSUR5VENDQXJHZ0F3SUJBZ0lVRlRQTytwVWszMlFXc1l5TFlkbExUbWxSV1V3d0RRWUpLb1pJaHZjTkFRRUxcbkJRQXdHekVaTUJjR0ExVUVBd3dRUm1GclpTQlZXa2tnVW05dmRDQkRRVEFlRncweU5ERXhNVFV3T0RJd01UbGFcbkZ3MHlOVEV4TVRVd09ESXdNVGxhTUhNeE16QXhCZ05WQkFNTUtucHZjbWRpYVdwcWIzVXVkR1Z6ZEM1cGJuUmxcblozSmhkR2x2Ymk1NmIzSm5ZbWxxYW05MUxtTnZiVEVhTUJnR0ExVUVDZ3dSV205eVp5QmlhV29nYW05MUlFSXVcblZpNHhFREFPQmdOVkJBY01CMVYwY21WamFIUXhEakFNQmdOVkJBVVRCVGcyTkRRMk1JSUJJakFOQmdrcWhraUdcbjl3MEJBUUVGQUFPQ0FROEFNSUlCQ2dLQ0FRRUF6WmVZazVtM21sdVY5dUJzUDFHNmppMmFnZWhIWlBJUjhLTUlcbmNuMjgyN3BUN3hFdG1wb3FZUDloMVRiVXJyM2Z5anN1TW9oNzFucnVhMzM3dTBrYlpJaC9RZVdhQllXUXV4VStcbklSM1F0MkwzTkhjY01GaTkzTmkxdzEvNXdzU1QwTDh1cGc0b0U0aFlHdE5rZHJnWkcrdDhnRjZEanhvQThJbjJcbkQzdXFtcGpXRXFIM1MrT0lNZ01ZRzU0cXk5elErRTVvaXpxclM4Yy83c1VvMnRRRWJNVVFxR1pyNFIwcUcyTnFcbkNLSzdIWWFFT2tHd2YwL1ZZVXRIR3ZZdFhaM0s2eWkzRUxwRDRYSVdXdVJ0UjNldmpERHpYM1M1a3R2bFowcUJcbjlZNTNabXRWc0x6N3dhdlRQc1pRenQ2Y29iMmQvbUt1UGdiZnBiVGNrUkJjS2tmYnhRSURBUUFCbzRHc01JR3Bcbk1CMEdBMVVkSlFRV01CUUdDQ3NHQVFVRkJ3TUJCZ2dyQmdFRkJRY0RBakJJQmdOVkhSRUVRVEEvb0QwR0ExVUZcbkJhQTJERFF5TGpFMkxqVXlPQzR4TGpFd01EY3VPVGt1TWpFeE1DMHhMVGcyTkRRMkxWTXRPRFkwTkRZdE1EQXVcbk1EQXdMVGcyTkRRMk1CMEdBMVVkRGdRV0JCUjFGR1oyMnJZQThtaVpRdUtSY2NFU0FZZWRKekFmQmdOVkhTTUVcbkdEQVdnQlNic2M5RjhEZXozWGpJY2lYM0g1dTZjdFFTdlRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQVpLUkdcblM1UE5MRDkwNkd3cHF3Z3hTaVU4amNkcXhjdmRNR2NiMmZXRDZSZFI0NG81S2JhVUZvdlp4Y0N3M21uSEo1TXZcblhjSml5L2FiVSt1YWZyMEhjVUdjQlplZkhCcWRYV2FJQzB5OWdSSWFoUXYrelpqMjhIWUVQSnNFWld6V1FDUlBcbmd0K0RobmZVdlQvM1d6NUdHbmNOeEZNRVRBVS9DWmc4NHFYMVRjbHhRbWV3bUp6U3YvelRQSkZWWHcwNk03WFBcbnl2dFhRRUtmMTNINnpKalJGbWlrTStrSzkySFdIRmF3dmRXVWpDbTJEc3ZBYTlON0xERUhnMW55Q2dKTVJjVjVcbndRVXpUQXBQeFpIVy85NmFhMkZkWTNoNTRSSkNDdE04Q1lrV0taTzg5bVdCMUJ1QjhsbUt3aDlzbFQzeUNNTjJcbi9oRURUbTdKeFd6dzFnZjcvdz09XG4tLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tIiwiLS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tXG5NSUlDOWpDQ0FkNmdBd0lCQWdJVVJGQ3FQckwzUVFkQk5PcWt3bVhXTmd4OXBkUXdEUVlKS29aSWh2Y05BUUVMXG5CUUF3R3pFWk1CY0dBMVVFQXd3UVJtRnJaU0JWV2trZ1VtOXZkQ0JEUVRBZUZ3MHlOREV4TVRFeE5ERTFNVGhhXG5GdzB6TkRFeE1Ea3hOREUxTVRoYU1Cc3hHVEFYQmdOVkJBTU1FRVpoYTJVZ1ZWcEpJRkp2YjNRZ1EwRXdnZ0VpXG5NQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUURUNUo4Z0tkeU1KTmkzY3VBbUorTUlMck11XG53ckt5VFJZaGpVVUZISG41cmNWYUhOMGh6QjZ2NXQ3NE50NDB4VVhSTmFvbURjY2xCSU9sd3Q4ZjYySkEycC9qXG44M0VOZmRMclh2VXU5Tk1UaGtxWndaOWR6UndLN2wzVVpCcThOVFFVTzc0VzRNMnF4OG5yWHEzMWVXb2d4VVVJXG5GYzFYT1JoNWVjZWJlTDVtVWIyRTZVbG1EbU5nbTJmR2VTbW1pczh6aWVJK0tLWU9oaS9oWXR5ZWl4cmc3cnhQXG40djBWUnJFc3RjV0FldFJnWFdRWDBFbEF4czBWcnN5Ni92djNwRXRYaHg4d2Iyd2kyeFkxNGQ5SWg4SGRlTkkrXG4rM3dJYlp6NldWTTNmRDVRRkhWMkVaQkgrc29vMHBmS2oydEhzYUR6M0ZQTXVNeklMdDZVNlBUNEFMSWRBZ01CXG5BQUdqTWpBd01BOEdBMVVkRXdRSU1BWUJBZjhDQVFBd0hRWURWUjBPQkJZRUZKdXh6MFh3TjdQZGVNaHlKZmNmXG5tN3B5MUJLOU1BMEdDU3FHU0liM0RRRUJDd1VBQTRJQkFRQWhscGt6Njh4MmRHcE9MWDNGekFiOEVlK1kyT1YrXG5SV0Zwc01FOVpWRFUwNkpFVFBmUENqMDJQSDgybGdVbmM0amVSODFyUFNzSXQyc3NxbTJTNHpiMDJOaXA1OTVjXG5BcUNLdm1CZkVjOWhQUFcydWdwTnhUOFpSVTRMS3JxcFY0bko2bkJ2RHFtR3VINXVxOU5nOWw5U25NM2VLbWRaXG50SktjK1pOQVBLeFZBaXVlTFRkcjZXMlVibUtvWkFSUVEwSkxrRm5aT3huVWtyOHBRZnhVekVJVWtIZzJkV2FhXG5JLzR3bzRQbmk3eFhnZ0ZvUERwVnp0dS9pUDMzWEJMcVhKd3h4SFhocTluYzlKVS9rRVhEdDdqOEVnb3lKbzdKXG5qU0tjanBSZnBHa0U1Z3FxQjRTYTh3QXNBUFVLM2pScmV1eXRsbEF0UVVaUmJDdEhieGNsYzl5QVxuLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLSJdLCJ4NXQiOiJybnFhd2RoUXZ1bl9pa3JzcFBUaHpqblg2NEEifQ.eyJleHAiOjQ4ODUyNTg4NTUsImlzcyI6ImRpZDp4NTA5OjA6c2hhNTEyOkN0Z0FaZENpSEtsSmNIb1FOWkpod1dDSUN6ZS1EM2R1TzY1cDk1cWJfSDlxVTAtNVUzdXhESWpsR1p3S1ZYeXpBcEdRWWF1Q1oxUlFXZ2p6YWdMYWNROjpzYW46b3RoZXJOYW1lOjIuMTYuNTI4LjEuMTAwNy45OS4yMTEwLTEtODY0NDYtUy04NjQ0Ni0wMC4wMDAtODY0NDY6OnN1YmplY3Q6Tzpab3JnJTIwYmlqJTIwam91JTIwQi5WLjo6c3ViamVjdDpMOlV0cmVjaHQiLCJqdGkiOiJjNDkyNzU3My02MjI5LTQzMWMtODcyMC1iNGMxMmQ3MWNmMDMiLCJuYmYiOjE3MzE2NTg4NTUsInN1YiI6ImRpZDp3ZWI6em9yZ2JpampvdS50ZXN0LmludGVncmF0aW9uLnpvcmdiaWpqb3UuY29tOm51dHM6aWFtOjE5YjUxODlkLTIyZWUtNDIwZi05ZGRlLTQxNjhhNDE0ZmNhNSIsInZjIjp7IkBjb250ZXh0IjpbImh0dHBzOi8vd3d3LnczLm9yZy8yMDE4L2NyZWRlbnRpYWxzL3YxIl0sImNyZWRlbnRpYWxTdWJqZWN0IjpbeyJMIjoiVXRyZWNodCIsIk8iOiJab3JnIGJpaiBqb3UgQi5WLiIsImlkIjoiZGlkOndlYjp6b3JnYmlqam91LnRlc3QuaW50ZWdyYXRpb24uem9yZ2JpampvdS5jb206bnV0czppYW06MTliNTE4OWQtMjJlZS00MjBmLTlkZGUtNDE2OGE0MTRmY2E1Iiwib3RoZXJOYW1lIjoiMi4xNi41MjguMS4xMDA3Ljk5LjIxMTAtMS04NjQ0Ni1TLTg2NDQ2LTAwLjAwMC04NjQ0NiJ9XSwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIlV6aVNlcnZlckNlcnRpZmljYXRlQ3JlZGVudGlhbCJdfX0.Vep71UX9iDOExVm6rwmjtVWPx7tYTkjSh7DJuBt20PT6qQa3l4jmyJERQsz7NA4_cSRoZV3HFoqt-wnExPXrD0OHZcTu0LesSkL9My7sOqaUDQjS1lCvceYIexMTfPhJMJm8qGTW0wg9SzJUWbanP6bmuRnq4KCfhCBJt14_HKPk3RfIMBPFhO5jRd_FPgXS3AoHJvcZget4mNDhVavn51Vk7m9HXju9PMKMTKx7l1VyX3MG04C_aTn5Jk9GDCZ9De5UcqyxXWO672MUUZ5_EBK6ajSW3xG2crcnRRHJvN0gBvKLBZJXTW3rOk9Ny0APkhCT4KrSGWc7cb0BKCp-vw")
@@ -88,8 +89,9 @@ func TestDutchNutsProfile_identifiersFromCredential(t *testing.T) {
 
 		require.NoError(t, err)
 		assert.Len(t, identifiers, 1)
-		assert.Equal(t, coolfhir.URANamingSystem, *identifiers[0].System)
-		assert.Equal(t, "86446", *identifiers[0].Value)
+		assert.Equal(t, coolfhir.URANamingSystem, *identifiers[0].Identifier[0].System)
+		assert.Equal(t, "86446", *identifiers[0].Identifier[0].Value)
+		assert.Equal(t, "Zorg bij jou B.V.", *identifiers[0].Name)
 	})
 
 }
@@ -100,12 +102,17 @@ func TestDutchNutsProfile_Identities(t *testing.T) {
 		System: to.Ptr(coolfhir.URANamingSystem),
 		Value:  to.Ptr("1234"),
 	}
+	identity1 := fhir.Organization{
+		Identifier: []fhir.Identifier{identifier1},
+		Name:       to.Ptr("Demo Clinic"),
+	}
 	identifier1VC := vc.VerifiableCredential{
 		Type: []ssi.URI{ssi.MustParseURI("NutsUraCredential")},
 		CredentialSubject: []interface{}{
 			map[string]interface{}{
 				"organization": map[string]interface{}{
-					"ura": *identifier1.Value,
+					"ura":  *identifier1.Value,
+					"name": *identity1.Name,
 				},
 			},
 		},
@@ -113,6 +120,10 @@ func TestDutchNutsProfile_Identities(t *testing.T) {
 	identifier2 := fhir.Identifier{
 		System: to.Ptr(coolfhir.URANamingSystem),
 		Value:  to.Ptr("5678"),
+	}
+	identity2 := fhir.Organization{
+		Identifier: []fhir.Identifier{identifier2},
+		// This care organization doesn't have a name
 	}
 	identifier2VC := vc.VerifiableCredential{
 		Type: []ssi.URI{ssi.MustParseURI("NutsUraCredential")},
@@ -129,6 +140,7 @@ func TestDutchNutsProfile_Identities(t *testing.T) {
 		CredentialSubject: []interface{}{
 			map[string]interface{}{
 				"otherName": "2.16.528.1.1007.99.2110-1-111-S-" + *identifier2.Value + "-00.000-222",
+				"O":         "Demo Clinic",
 			},
 		},
 	}
@@ -165,8 +177,8 @@ func TestDutchNutsProfile_Identities(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Len(t, identities, 2)
-		assert.Contains(t, identities, identifier1)
-		assert.Contains(t, identities, identifier2)
+		assert.Equal(t, identities[0].Identifier[0], identity1.Identifier[0])
+		assert.Equal(t, identities[1].Identifier[0], identity2.Identifier[0])
 	})
 	t.Run("NutsUraCredential and others in wallet", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -183,7 +195,7 @@ func TestDutchNutsProfile_Identities(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Len(t, identities, 1)
-		assert.Contains(t, identities, identifier1)
+		assert.Equal(t, identities[0].Identifier[0], identity1.Identifier[0])
 	})
 	t.Run("initial fetch, then cached", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -200,8 +212,8 @@ func TestDutchNutsProfile_Identities(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Len(t, identities, 2)
-		assert.Contains(t, identities, identifier1)
-		assert.Contains(t, identities, identifier2)
+		assert.Equal(t, identities[0].Identifier[0], identity1.Identifier[0])
+		assert.Equal(t, identities[1].Identifier[0], identity2.Identifier[0])
 
 		identities, err = prof.Identities(ctx)
 		require.NoError(t, err)
@@ -239,8 +251,10 @@ func TestDutchNutsProfile_Identities(t *testing.T) {
 		prof := &DutchNutsProfile{
 			vcrClient: vcrClient,
 			Config:    Config{OwnSubject: "sub"},
-			cachedIdentities: []fhir.Identifier{
-				identifier1,
+			cachedIdentities: []fhir.Organization{
+				{
+					Identifier: []fhir.Identifier{identifier1},
+				},
 			},
 		}
 		vcrClient.EXPECT().GetCredentialsInWalletWithResponse(ctx, "sub").Return(nil, errors.New("failed"))
@@ -248,7 +262,7 @@ func TestDutchNutsProfile_Identities(t *testing.T) {
 		identities, err := prof.Identities(ctx)
 		require.NoError(t, err)
 		require.Len(t, identities, 1)
-		assert.Contains(t, identities, identifier1)
+		assert.Equal(t, identities[0].Identifier[0], identity1.Identifier[0])
 	})
 	t.Run("fetched again when cache is expired", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
@@ -265,8 +279,8 @@ func TestDutchNutsProfile_Identities(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Len(t, identities, 2)
-		assert.Contains(t, identities, identifier1)
-		assert.Contains(t, identities, identifier2)
+		assert.Contains(t, identities, identity1)
+		assert.Contains(t, identities, identity2)
 
 		// expire cache
 		prof.identitiesRefreshedAt = prof.identitiesRefreshedAt.Add(-identitiesCacheTTL)

--- a/orchestrator/cmd/profile/profile.go
+++ b/orchestrator/cmd/profile/profile.go
@@ -30,5 +30,5 @@ type Provider interface {
 	// CsdDirectory returns the directory service for finding endpoints and organizations through Care Service Discovery (IHE-CSD).
 	CsdDirectory() csd.Directory
 	// Identities returns the identities of the local tenant (e.g., a care organization).
-	Identities(ctx context.Context) ([]fhir.Identifier, error)
+	Identities(ctx context.Context) ([]fhir.Organization, error)
 }

--- a/orchestrator/cmd/profile/test.go
+++ b/orchestrator/cmd/profile/test.go
@@ -31,8 +31,8 @@ type TestProfile struct {
 	CSD                    csd.Directory
 }
 
-func (t TestProfile) Identities(_ context.Context) ([]fhir.Identifier, error) {
-	return t.Principal.Organization.Identifier, nil
+func (t TestProfile) Identities(_ context.Context) ([]fhir.Organization, error) {
+	return []fhir.Organization{t.Principal.Organization}, nil
 }
 
 func (t TestProfile) CsdDirectory() csd.Directory {

--- a/orchestrator/lib/coolfhir/util.go
+++ b/orchestrator/lib/coolfhir/util.go
@@ -447,3 +447,11 @@ func TokenToIdentifier(s string) (*fhir.Identifier, error) {
 	}
 	return result, nil
 }
+
+func OrganizationIdentifiers(organizations []fhir.Organization) []fhir.Identifier {
+	var result []fhir.Identifier
+	for _, organization := range organizations {
+		result = append(result, organization.Identifier...)
+	}
+	return result
+}


### PR DESCRIPTION
The FHIR Encounter resource is not always present when launched from ChipSoft HiX, so we can't rely on it. This PR fixes the following:
- Removes resolution of Encounter resource
- Removes identification of Patient resource through `Encounter.subject.reference`; Zorgplatform uses search narrowing, so the only Patient resource returned will be the one specified in the Zorgplatform API auth token (which' BSN was provided in the HiX launch token).
- Removes identification of the local care organization (requesting the order) through the Encounter.
  - Changed this to be loaded from the local wallet
  - We want FHIR `Organization.name` to be set, so I reworked `Profile.Identities()` to return `fhir.Organization` instead of only the organization's identifiers.

Note: this functionality will be slightly changed when we determine the care organization based on the HL7 NL OID of the care organization, contained in the HiX launch token. Then, we need to map these OIDs to organizations (through URA) returned by the profile.