### PR TITLE
INT-559 | Prevent duplicate Task enrollment

### DIFF
--- a/frontend/lib/fhirUtils.ts
+++ b/frontend/lib/fhirUtils.ts
@@ -119,7 +119,7 @@ const cleanPatient = (patient: Patient) => {
     return cleanedPatient;
 }
 
-const cleanServiceRequest = (serviceRequest: ServiceRequest, patient: Patient, patientReference: string) => {
+const cleanServiceRequest = (serviceRequest: ServiceRequest, patient: Patient, patientReference: string, taskIdentifier?: string) => {
     // Clean up the ServiceRequest by removing relative references - the CPS won't understand them
     const cleanedServiceRequest = {...serviceRequest, id: undefined};
 
@@ -146,6 +146,10 @@ const cleanServiceRequest = (serviceRequest: ServiceRequest, patient: Patient, p
         if (item?.reference) {
             delete item.reference;
         }
+    }
+
+    if (taskIdentifier) {
+        cleanedServiceRequest.identifier = parseTaskIdentifier(taskIdentifier);
     }
 
     return cleanedServiceRequest;
@@ -185,16 +189,20 @@ export const constructBundleTask = (serviceRequest: ServiceRequest, primaryCondi
     } as Task
 
     if (taskIdentifier) {
-        const systemAndIdentifier = taskIdentifier.split("|")
-        if (systemAndIdentifier.length !== 2) throw new Error("Invalid task identifier - expecting `system|identifier`")
-        task.identifier = [{
-            system: systemAndIdentifier[0],
-            value: systemAndIdentifier[1],
-        }]
+        task.identifier = parseTaskIdentifier(taskIdentifier);
     }
 
     return task
 }
+
+const parseTaskIdentifier = (taskIdentifier: string) => {
+    const systemAndIdentifier = taskIdentifier.split("|");
+    if (systemAndIdentifier.length !== 2) throw new Error("Invalid task identifier - expecting `system|identifier`");
+    return [{
+        system: systemAndIdentifier[0],
+        value: systemAndIdentifier[1],
+    }];
+};
 
 export const constructTaskBundle = (serviceRequest: ServiceRequest, primaryCondition: Condition, patient: Patient, taskIdentifier?: string): Bundle & {
     type: "transaction"
@@ -202,11 +210,11 @@ export const constructTaskBundle = (serviceRequest: ServiceRequest, primaryCondi
     const cleanedPatient = cleanPatient(patient);
     const serviceRequestEntry = {
         fullUrl: "urn:uuid:serviceRequest",
-        resource: cleanServiceRequest(serviceRequest, patient, "urn:uuid:patient"),
+        resource: cleanServiceRequest(serviceRequest, patient, "urn:uuid:patient", taskIdentifier),
         request: {
             method: "POST",
             url: "ServiceRequest",
-            ifNoneExist: `_id=${serviceRequest.id}`,
+            ifNoneExist: "",
         }
     }
     const taskEntry = {
@@ -219,6 +227,7 @@ export const constructTaskBundle = (serviceRequest: ServiceRequest, primaryCondi
         }
     }
     if (taskIdentifier) {
+        serviceRequestEntry.request.ifNoneExist = `identifier=${taskIdentifier}`
         taskEntry.request.ifNoneExist = `identifier=${taskIdentifier}`
     }
     const bundle = {

--- a/frontend/lib/fhirUtils.ts
+++ b/frontend/lib/fhirUtils.ts
@@ -206,7 +206,7 @@ export const constructTaskBundle = (serviceRequest: ServiceRequest, primaryCondi
         request: {
             method: "POST",
             url: "ServiceRequest",
-            ifNoneExist: `ServiceRequest?_id=${serviceRequest.id}`,
+            ifNoneExist: `_id=${serviceRequest.id}`,
         }
     }
     const taskEntry = {
@@ -219,7 +219,7 @@ export const constructTaskBundle = (serviceRequest: ServiceRequest, primaryCondi
         }
     }
     if (taskIdentifier) {
-        taskEntry.request.ifNoneExist = `Task?identifier=${taskIdentifier}`
+        taskEntry.request.ifNoneExist = `identifier=${taskIdentifier}`
     }
     const bundle = {
         resourceType: "Bundle",
@@ -231,7 +231,7 @@ export const constructTaskBundle = (serviceRequest: ServiceRequest, primaryCondi
                 request: {
                     method: "POST",
                     url: "Patient",
-                    ifNoneExist: `Patient?identifier=http://fhir.nl/fhir/NamingSystem/bsn|${getBsn(patient)}`
+                    ifNoneExist: `identifier=http://fhir.nl/fhir/NamingSystem/bsn|${getBsn(patient)}`
                 }
             },
             serviceRequestEntry,

--- a/frontend/lib/fhirUtils.ts
+++ b/frontend/lib/fhirUtils.ts
@@ -185,13 +185,12 @@ export const constructBundleTask = (serviceRequest: ServiceRequest, primaryCondi
     } as Task
 
     if (taskIdentifier) {
-        // TODO: Fix ifNoneExists
-        // const systemAndIdentifier = taskIdentifier.split("|")
-        // if (systemAndIdentifier.length !== 2) throw new Error("Invalid task identifier - expecting `system|identifier`")
-        // task.identifier = [{
-        //     system: systemAndIdentifier[0],
-        //     value: systemAndIdentifier[1],
-        // }]
+        const systemAndIdentifier = taskIdentifier.split("|")
+        if (systemAndIdentifier.length !== 2) throw new Error("Invalid task identifier - expecting `system|identifier`")
+        task.identifier = [{
+            system: systemAndIdentifier[0],
+            value: systemAndIdentifier[1],
+        }]
     }
 
     return task
@@ -207,7 +206,7 @@ export const constructTaskBundle = (serviceRequest: ServiceRequest, primaryCondi
         request: {
             method: "POST",
             url: "ServiceRequest",
-            ifNoneExist: "",
+            ifNoneExist: `ServiceRequest?_id=${serviceRequest.id}`,
         }
     }
     const taskEntry = {
@@ -220,9 +219,7 @@ export const constructTaskBundle = (serviceRequest: ServiceRequest, primaryCondi
         }
     }
     if (taskIdentifier) {
-        // TODO: Fix ifNoneExists
-        // serviceRequestEntry.request.ifNoneExist = `identifier=${taskIdentifier}`
-        // taskEntry.request.ifNoneExist = `identifier=${taskIdentifier}`
+        taskEntry.request.ifNoneExist = `Task?identifier=${taskIdentifier}`
     }
     const bundle = {
         resourceType: "Bundle",
@@ -234,8 +231,7 @@ export const constructTaskBundle = (serviceRequest: ServiceRequest, primaryCondi
                 request: {
                     method: "POST",
                     url: "Patient",
-                    // TODO: Fix ifNoneExists
-                    // ifNoneExist: `identifier=http://fhir.nl/fhir/NamingSystem/bsn|${getBsn(patient)}`
+                    ifNoneExist: `Patient?identifier=http://fhir.nl/fhir/NamingSystem/bsn|${getBsn(patient)}`
                 }
             },
             serviceRequestEntry,

--- a/hospital_simulator/app/(DashboardLayout)/components/service-requests/create-service-request-dialog.tsx
+++ b/hospital_simulator/app/(DashboardLayout)/components/service-requests/create-service-request-dialog.tsx
@@ -238,8 +238,7 @@ function createServiceRequestBundle(firstName: string, lastName: string, conditi
                 "request": {
                     "method": "POST",
                     "url": "Organization",
-                    // TODO: Fix ifNoneExists
-                    // "ifNoneExist": `identifier=${performerIdentifier.system}|${performerIdentifier.value}`
+                    "ifNoneExist": `Organization?identifier=${performerIdentifier.system}|${performerIdentifier.value}`
                 }
             },
             {
@@ -288,8 +287,7 @@ function createServiceRequestBundle(firstName: string, lastName: string, conditi
                 "request": {
                     "method": "POST",
                     "url": "Practitioner",
-                    // TODO: Fix ifNoneExists
-                    // "ifNoneExist": "identifier=http://fhir.nl/fhir/NamingSystem/uzi|uzi-001"
+                    "ifNoneExist": "Practitioner?identifier=http://fhir.nl/fhir/NamingSystem/uzi|uzi-001"
                 }
             },
             {
@@ -325,8 +323,7 @@ function createServiceRequestBundle(firstName: string, lastName: string, conditi
                 "request": {
                     "method": "POST",
                     "url": "PractitionerRole",
-                    // TODO: Fix ifNoneExists
-                    // "ifNoneExist": "identifier=http://fhir.nl/fhir/NamingSystem/uzi|uzi-001"
+                    "ifNoneExist": "PractitionerRole?identifier=http://fhir.nl/fhir/NamingSystem/uzi|uzi-001"
                 }
             },
             {
@@ -335,8 +332,7 @@ function createServiceRequestBundle(firstName: string, lastName: string, conditi
                 "request": {
                     "method": "POST",
                     "url": "Organization",
-                    // TODO: Fix ifNoneExists
-                    // "ifNoneExist": `identifier=${requesterIdentifier.system}|${requesterIdentifier.value}`
+                    "ifNoneExist": `Organization?identifier=${requesterIdentifier.system}|${requesterIdentifier.value}`
                 }
             },
             {

--- a/hospital_simulator/app/(DashboardLayout)/components/service-requests/create-service-request-dialog.tsx
+++ b/hospital_simulator/app/(DashboardLayout)/components/service-requests/create-service-request-dialog.tsx
@@ -238,7 +238,7 @@ function createServiceRequestBundle(firstName: string, lastName: string, conditi
                 "request": {
                     "method": "POST",
                     "url": "Organization",
-                    "ifNoneExist": `Organization?identifier=${performerIdentifier.system}|${performerIdentifier.value}`
+                    "ifNoneExist": `identifier=${performerIdentifier.system}|${performerIdentifier.value}`
                 }
             },
             {
@@ -287,7 +287,7 @@ function createServiceRequestBundle(firstName: string, lastName: string, conditi
                 "request": {
                     "method": "POST",
                     "url": "Practitioner",
-                    "ifNoneExist": "Practitioner?identifier=http://fhir.nl/fhir/NamingSystem/uzi|uzi-001"
+                    "ifNoneExist": "identifier=http://fhir.nl/fhir/NamingSystem/uzi|uzi-001"
                 }
             },
             {
@@ -323,7 +323,7 @@ function createServiceRequestBundle(firstName: string, lastName: string, conditi
                 "request": {
                     "method": "POST",
                     "url": "PractitionerRole",
-                    "ifNoneExist": "PractitionerRole?identifier=http://fhir.nl/fhir/NamingSystem/uzi|uzi-001"
+                    "ifNoneExist": "identifier=http://fhir.nl/fhir/NamingSystem/uzi|uzi-001"
                 }
             },
             {
@@ -332,7 +332,7 @@ function createServiceRequestBundle(firstName: string, lastName: string, conditi
                 "request": {
                     "method": "POST",
                     "url": "Organization",
-                    "ifNoneExist": `Organization?identifier=${requesterIdentifier.system}|${requesterIdentifier.value}`
+                    "ifNoneExist": `identifier=${requesterIdentifier.system}|${requesterIdentifier.value}`
                 }
             },
             {


### PR DESCRIPTION
Re-enable IfNoneExists headers to ensure enrollment is persisted for the same task per ServiceRequest, prevents duplicate ServiceRequests and Tasks from being created