### PR TITLE
Fix notification focus type being nil

### DIFF
--- a/orchestrator/careplanservice/subscriptions/manager.go
+++ b/orchestrator/careplanservice/subscriptions/manager.go
@@ -76,6 +76,7 @@ func (r DerivingManager) Notify(ctx context.Context, resource interface{}) error
 		careTeam := resource.(*fhir.CareTeam)
 		focus = fhir.Reference{
 			Reference: to.Ptr("CareTeam/" + *careTeam.Id),
+			Type:      to.Ptr("CareTeam"),
 		}
 		for _, participant := range careTeam.Participant {
 			isMemberValid := coolfhir.IsLogicalReference(participant.Member)

--- a/orchestrator/careplanservice/subscriptions/manager_test.go
+++ b/orchestrator/careplanservice/subscriptions/manager_test.go
@@ -51,5 +51,6 @@ func TestDerivingManager_Notify(t *testing.T) {
 		require.NoError(t, err)
 		focus, _ := capturedMember1Notification.GetFocus()
 		require.Equal(t, "http://example.com/fhir/CareTeam/10", *focus.Reference)
+		require.Equal(t, "CareTeam", *focus.Type)
 	})
 }


### PR DESCRIPTION
Fixes the following log line that appears now and then in our logging:

```
CarePlanContributor/Notify failed: Notification focus type is nil
```