### PR TITLE
INT-560: Add authentication user to every log entry

### DIFF
--- a/orchestrator/careplancontributor/applaunch/smartonfhir/service.go
+++ b/orchestrator/careplancontributor/applaunch/smartonfhir/service.go
@@ -143,7 +143,7 @@ func (s *Service) appLaunchRedirectLogic(ctx context.Context, state string, code
 
 	resp, err := http.PostForm(tokenEndpoint, data)
 	if err != nil {
-		log.Error().Ctx(ctx).Err(err).Msg("Failed to exchange authorization code for access token")
+		log.Ctx(ctx).Error().Err(err).Msg("Failed to exchange authorization code for access token")
 		return nil, err
 	}
 	defer resp.Body.Close()
@@ -154,7 +154,7 @@ func (s *Service) appLaunchRedirectLogic(ctx context.Context, state string, code
 
 	var tokenResponse map[string]interface{}
 	if err := json.NewDecoder(resp.Body).Decode(&tokenResponse); err != nil {
-		log.Error().Ctx(ctx).Err(err).Msg("Failed to decode token response")
+		log.Ctx(ctx).Error().Err(err).Msg("Failed to decode token response")
 		return nil, err
 	}
 

--- a/orchestrator/careplancontributor/applaunch/zorgplatform/handle_validation.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/handle_validation.go
@@ -127,8 +127,8 @@ func (s *Service) validateAssertionExpiry(ctx context.Context, doc *etree.Docume
 	created := createdElement.Text()
 	expires := expiresElement.Text()
 
-	log.Trace().Ctx(ctx).Msgf("Token created: %s", created)
-	log.Trace().Ctx(ctx).Msgf("Token expires: %s", expires)
+	log.Ctx(ctx).Trace().Msgf("Token created: %s", created)
+	log.Ctx(ctx).Trace().Msgf("Token expires: %s", expires)
 
 	createdTime, err := time.Parse(time.RFC3339Nano, created)
 	if err != nil {
@@ -224,7 +224,7 @@ func (s *Service) extractPractitioner(ctx context.Context, assertion *etree.Elem
 				result.Name[0].Prefix = []string{strings.TrimSpace(parts[2])}
 			}
 		} else {
-			log.Debug().Ctx(ctx).Msg("Name attribute not found")
+			log.Ctx(ctx).Debug().Msg("Name attribute not found")
 		}
 	}
 	// Role (e.g.: <Role code="223366009" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED_CT"/>)
@@ -266,7 +266,7 @@ func (s *Service) extractPractitioner(ctx context.Context, assertion *etree.Elem
 				Value:  to.Ptr(value),
 			})
 		} else {
-			log.Debug().Ctx(ctx).Msg("Email attribute not found")
+			log.Ctx(ctx).Debug().Msg("Email attribute not found")
 		}
 	}
 
@@ -295,7 +295,7 @@ func (s *Service) extractWorkflowID(ctx context.Context, decryptedAssertion *etr
 		return "", fmt.Errorf("workflow-id attribute not found in the assertion")
 	}
 	workflowId := workflowIdElement.Text()
-	log.Debug().Ctx(ctx).Msgf("Extracted workflow-id: %s", workflowId)
+	log.Ctx(ctx).Debug().Msgf("Extracted workflow-id: %s", workflowId)
 
 	return workflowId, nil
 }

--- a/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
@@ -68,7 +68,7 @@ func newWithClients(ctx context.Context, sessionManager *user.SessionManager, co
 	} else {
 		appLaunchURL = "http://localhost" + appLaunchURL + appLaunchUrl
 	}
-	log.Info().Ctx(ctx).Msgf("Zorgplatform app launch is: %s", appLaunchURL)
+	log.Ctx(ctx).Info().Msgf("Zorgplatform app launch is: %s", appLaunchURL)
 
 	// Load certs: signing, TLS client authentication and decryption certificates
 	var signCert [][]byte
@@ -359,7 +359,7 @@ func (s *stsAccessTokenRoundTripper) getWorkflowContext(ctx context.Context, car
 	if err != nil {
 		return nil, fmt.Errorf("invalid CarePlan reference (url=%s): %w", carePlanReference, err)
 	}
-	log.Debug().Ctx(ctx).Msgf("Fetching CarePlan resource: %s", localCarePlanRef)
+	log.Ctx(ctx).Debug().Msgf("Fetching CarePlan resource: %s", localCarePlanRef)
 
 	// TODO: group requests, something like:
 	// ?_include=CarePlan:activity-reference&_include:iterate=Task:focus
@@ -371,7 +371,7 @@ func (s *stsAccessTokenRoundTripper) getWorkflowContext(ctx context.Context, car
 	var carePlan fhir.CarePlan
 	err = s.cpsFhirClient().ReadWithContext(ctx, localCarePlanRef, &carePlan)
 	if err != nil {
-		log.Error().Ctx(ctx).Msgf("Unable to fetch CarePlan resource: %v", err)
+		log.Ctx(ctx).Error().Msgf("Unable to fetch CarePlan resource: %v", err)
 		return nil, fmt.Errorf("unable to fetch CarePlan resource: %w", err)
 	}
 
@@ -379,14 +379,14 @@ func (s *stsAccessTokenRoundTripper) getWorkflowContext(ctx context.Context, car
 	var task fhir.Task
 	err = s.cpsFhirClient().ReadWithContext(ctx, *carePlan.Activity[0].Reference.Reference, &task)
 	if err != nil {
-		log.Error().Ctx(ctx).Msgf("Unable to fetch Task resource: %v", err)
+		log.Ctx(ctx).Error().Msgf("Unable to fetch Task resource: %v", err)
 		return nil, fmt.Errorf("unable to fetch Task resource: %w", err)
 	}
 
 	var serviceRequest fhir.ServiceRequest
 	err = s.cpsFhirClient().ReadWithContext(ctx, *task.Focus.Reference, &serviceRequest)
 	if err != nil {
-		log.Error().Ctx(ctx).Msgf("Unable to fetch ServiceRequest resource: %v", err)
+		log.Ctx(ctx).Error().Msgf("Unable to fetch ServiceRequest resource: %v", err)
 		return nil, fmt.Errorf("unable to fetch ServiceRequest resource: %w", err)
 	}
 
@@ -399,7 +399,7 @@ func (s *stsAccessTokenRoundTripper) getWorkflowContext(ctx context.Context, car
 	var patient fhir.Patient
 	err = s.cpsFhirClient().ReadWithContext(ctx, *carePlan.Subject.Reference, &patient)
 	if err != nil {
-		log.Error().Ctx(ctx).Msgf("Unable to fetch Patient resource: %v", err)
+		log.Ctx(ctx).Error().Msgf("Unable to fetch Patient resource: %v", err)
 		return nil, fmt.Errorf("unable to fetch Patient resource: %w", err)
 	}
 
@@ -448,7 +448,7 @@ func (s *Service) getSessionData(ctx context.Context, accessToken string, launch
 	})
 
 	if err != nil {
-		log.Error().Ctx(ctx).Msgf("Failed to check for existing CPS Task resource: %v", err)
+		log.Ctx(ctx).Error().Msgf("Failed to check for existing CPS Task resource: %v", err)
 		return nil, fmt.Errorf("failed to check for existing CPS Task resource: %w", err)
 	}
 
@@ -540,7 +540,7 @@ func (s *Service) getSessionData(ctx context.Context, accessToken string, launch
 	}
 	// Enrich performer URA with registered name
 	if result, err := s.profile.CsdDirectory().LookupEntity(ctx, *taskPerformer.Identifier); err != nil {
-		log.Warn().Ctx(ctx).Err(err).Msgf("Couldn't resolve performer name (ura: %s)", s.config.TaskPerformerUra)
+		log.Ctx(ctx).Warn().Err(err).Msgf("Couldn't resolve performer name (ura: %s)", s.config.TaskPerformerUra)
 	} else {
 		taskPerformer = *result
 	}
@@ -734,6 +734,6 @@ U6OWTXiki5XGd75h6duSZG9qvqymSIuTjA==
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse certificate: %w", err)
 	}
-	log.Info().Ctx(ctx).Msgf("Successfully loaded Zorgplatform certificate, expiry=%s", cert.NotAfter)
+	log.Ctx(ctx).Info().Msgf("Successfully loaded Zorgplatform certificate, expiry=%s", cert.NotAfter)
 	return cert, nil
 }

--- a/orchestrator/careplancontributor/ehr/kafka_client.go
+++ b/orchestrator/careplancontributor/ehr/kafka_client.go
@@ -108,7 +108,7 @@ func NewClient(config KafkaConfig) (KafkaClient, error) {
 		}
 		if config.DebugOnly {
 			ctx := context.Background()
-			log.Info().Ctx(ctx).Msg("Debug mode enabled, writing messages to files in OS temp dir")
+			log.Ctx(ctx).Info().Msg("Debug mode enabled, writing messages to files in OS temp dir")
 			return &DebugClient{}, nil
 		}
 		kafkaClient := newKafkaClient(config)
@@ -247,10 +247,10 @@ func (k *KafkaClientImpl) PingConnection(ctx context.Context) error {
 	}
 	err = client.Ping(ctx)
 	if err != nil {
-		log.Error().Ctx(ctx).Err(err).Msgf("Failed to ping Kafka, message: %s", err.Error())
+		log.Ctx(ctx).Error().Err(err).Msgf("Failed to ping Kafka, message: %s", err.Error())
 		return err
 	} else {
-		log.Info().Ctx(ctx).Msg("Pinged Kafka successfully on startup")
+		log.Ctx(ctx).Info().Msg("Pinged Kafka successfully on startup")
 	}
 	return nil
 }
@@ -265,10 +265,10 @@ func (k *KafkaClientImpl) PingConnection(ctx context.Context) error {
 // Returns:
 //   - error: An error if the message could not be produced.
 func (k *KafkaClientImpl) SubmitMessage(ctx context.Context, key string, value string) error {
-	log.Debug().Ctx(ctx).Msgf("SubmitMessage, submitting key %s", key)
+	log.Ctx(ctx).Debug().Msgf("SubmitMessage, submitting key %s", key)
 	client, err := k.Connect(ctx)
 	if err != nil {
-		log.Error().Ctx(ctx).Err(err).Msgf("Connect failed with %s", err.Error())
+		log.Ctx(ctx).Error().Err(err).Msgf("Connect failed with %s", err.Error())
 		return err
 	}
 	record := kgo.KeyStringRecord(key, value)
@@ -277,7 +277,7 @@ func (k *KafkaClientImpl) SubmitMessage(ctx context.Context, key string, value s
 	var lastErr error
 	for _, s := range sync {
 		if s.Err != nil {
-			log.Error().Ctx(ctx).Err(s.Err).Msgf("Error during submission %s, with topic %s", s.Err.Error(), record.Topic)
+			log.Ctx(ctx).Error().Err(s.Err).Msgf("Error during submission %s, with topic %s", s.Err.Error(), record.Topic)
 			lastErr = s.Err
 		}
 	}
@@ -287,10 +287,10 @@ func (k *KafkaClientImpl) SubmitMessage(ctx context.Context, key string, value s
 	// Make sure all messages are flushed before returning
 	err = client.Flush(ctx)
 	if err != nil {
-		log.Error().Ctx(ctx).Err(err).Msgf("kafka flush failed %s", err.Error())
+		log.Ctx(ctx).Error().Err(err).Msgf("kafka flush failed %s", err.Error())
 		return err
 	}
-	log.Debug().Ctx(ctx).Msgf("SubmitMessage, submitted key %s", key)
+	log.Ctx(ctx).Debug().Msgf("SubmitMessage, submitted key %s", key)
 	return nil
 }
 
@@ -306,17 +306,17 @@ func (k *KafkaClientImpl) SubmitMessage(ctx context.Context, key string, value s
 //   - error: An error if the file could not be written.
 func (k *DebugClient) SubmitMessage(ctx context.Context, key string, value string) error {
 	name := path.Join(os.TempDir(), strings.ReplaceAll(key, ":", "_")+".json")
-	log.Debug().Ctx(ctx).Msgf("DebugClient, write to file: %s", name)
+	log.Ctx(ctx).Debug().Msgf("DebugClient, write to file: %s", name)
 	err := os.WriteFile(name, []byte(value), 0644)
 	if err != nil {
-		log.Warn().Ctx(ctx).Msgf("DebugClient, failed to write to file: %s, err: %s", name, err.Error())
+		log.Ctx(ctx).Warn().Msgf("DebugClient, failed to write to file: %s, err: %s", name, err.Error())
 		return err
 	}
 	return nil
 }
 
 func (k *DebugClient) PingConnection(ctx context.Context) error {
-	log.Debug().Ctx(ctx).Msgf("DebugClient: pong")
+	log.Ctx(ctx).Debug().Msgf("DebugClient: pong")
 	return nil
 }
 
@@ -332,7 +332,7 @@ func (k *DemoClient) SubmitMessage(ctx context.Context, key string, value string
 	jsonValue := strings.ReplaceAll(value, " ", "")
 	jsonValue = strings.ReplaceAll(jsonValue, "\n", "")
 	jsonValue = strings.ReplaceAll(jsonValue, "\t", "")
-	log.Debug().Ctx(ctx).Msgf("DemoClient, submitting message %s - %s", key, jsonValue)
+	log.Ctx(ctx).Debug().Msgf("DemoClient, submitting message %s - %s", key, jsonValue)
 
 	req, err := http.NewRequestWithContext(ctx, "POST", k.messageEndpoint, strings.NewReader(jsonValue))
 	if err != nil {
@@ -353,12 +353,12 @@ func (k *DemoClient) SubmitMessage(ctx context.Context, key string, value string
 		return err
 	}
 
-	log.Debug().Ctx(ctx).Msgf("DemoClient, successfully sent message to endpoint")
+	log.Ctx(ctx).Debug().Msgf("DemoClient, successfully sent message to endpoint")
 	return nil
 }
 
 func (k *DemoClient) PingConnection(ctx context.Context) error {
-	log.Debug().Ctx(ctx).Msgf("DemoClient: pong")
+	log.Ctx(ctx).Debug().Msgf("DemoClient: pong")
 	return nil
 }
 

--- a/orchestrator/careplancontributor/ehr/notifier.go
+++ b/orchestrator/careplancontributor/ehr/notifier.go
@@ -52,7 +52,7 @@ func (b *BundleSet) addBundle(bundle ...fhir.Bundle) {
 func (n *kafkaNotifier) NotifyTaskAccepted(ctx context.Context, cpsClient fhirclient.Client, task *fhir.Task) error {
 
 	ref := "Task/" + *task.Id
-	log.Debug().Ctx(ctx).Msgf("NotifyTaskAccepted Task (ref=%s) to Kafka", ref)
+	log.Ctx(ctx).Debug().Msgf("NotifyTaskAccepted Task (ref=%s) to Kafka", ref)
 	id := uuid.NewString()
 	bundles := BundleSet{
 		Id:   id,
@@ -77,7 +77,7 @@ func (n *kafkaNotifier) NotifyTaskAccepted(ctx context.Context, cpsClient fhircl
 	}
 
 	patientForRefs := findForReferences(ctx, tasks)
-	log.Debug().Ctx(ctx).Msgf("Found %d patientForRefs", len(patientForRefs))
+	log.Ctx(ctx).Debug().Msgf("Found %d patientForRefs", len(patientForRefs))
 	result, err := fetchRefs(ctx, cpsClient, patientForRefs)
 	if err != nil {
 		return err
@@ -85,7 +85,7 @@ func (n *kafkaNotifier) NotifyTaskAccepted(ctx context.Context, cpsClient fhircl
 	bundles.addBundle(*result...)
 
 	focusRefs := findFocusReferences(ctx, tasks)
-	log.Debug().Ctx(ctx).Msgf("Found %d focusRefs", len(focusRefs))
+	log.Ctx(ctx).Debug().Msgf("Found %d focusRefs", len(focusRefs))
 	result, err = fetchRefs(ctx, cpsClient, focusRefs)
 	if err != nil {
 		return err
@@ -93,7 +93,7 @@ func (n *kafkaNotifier) NotifyTaskAccepted(ctx context.Context, cpsClient fhircl
 	bundles.addBundle(*result...)
 
 	basedOnRefs := findBasedOnReferences(ctx, tasks)
-	log.Debug().Ctx(ctx).Msgf("Found %d basedOnRefs", len(basedOnRefs))
+	log.Ctx(ctx).Debug().Msgf("Found %d basedOnRefs", len(basedOnRefs))
 	result, err = fetchRefs(ctx, cpsClient, basedOnRefs)
 	if err != nil {
 		return err
@@ -101,7 +101,7 @@ func (n *kafkaNotifier) NotifyTaskAccepted(ctx context.Context, cpsClient fhircl
 	bundles.addBundle(*result...)
 
 	questionnaireRefs := findQuestionnaireInputs(tasks)
-	log.Debug().Ctx(ctx).Msgf("Found %d questionnaireRefs", len(questionnaireRefs))
+	log.Ctx(ctx).Debug().Msgf("Found %d questionnaireRefs", len(questionnaireRefs))
 	result, err = fetchRefs(ctx, cpsClient, questionnaireRefs)
 	if err != nil {
 		return err
@@ -131,7 +131,7 @@ func findForReferences(ctx context.Context, tasks []fhir.Task) []string {
 		if task.For != nil {
 			patientReference := task.For.Reference
 			if patientReference != nil {
-				log.Debug().Ctx(ctx).Msgf("Found patientReference %s", *patientReference)
+				log.Ctx(ctx).Debug().Msgf("Found patientReference %s", *patientReference)
 				patientForRefs = append(patientForRefs, *patientReference)
 			}
 		}
@@ -152,7 +152,7 @@ func findFocusReferences(ctx context.Context, tasks []fhir.Task) []string {
 		if task.Focus != nil {
 			focusReference := task.Focus.Reference
 			if focusReference != nil {
-				log.Debug().Ctx(ctx).Msgf("Found focusReference %s", *focusReference)
+				log.Ctx(ctx).Debug().Msgf("Found focusReference %s", *focusReference)
 				focusRefs = append(focusRefs, *focusReference)
 			}
 		}
@@ -175,7 +175,7 @@ func findBasedOnReferences(ctx context.Context, tasks []fhir.Task) []string {
 			for _, reference := range basedOnReferences {
 				basedOnReference := reference.Reference
 				if basedOnReference != nil {
-					log.Debug().Ctx(ctx).Msgf("Found basedOnReference %s", *basedOnReference)
+					log.Ctx(ctx).Debug().Msgf("Found basedOnReference %s", *basedOnReference)
 					basedOnRefs = append(basedOnRefs, *basedOnReference)
 				}
 			}
@@ -361,13 +361,13 @@ func sendBundle(ctx context.Context, set BundleSet, kafkaClient KafkaClient) err
 	if err != nil {
 		return err
 	}
-	log.Debug().Ctx(ctx).Msgf("Sending set for task (ref=%s) to Kafka", set.task)
+	log.Ctx(ctx).Debug().Msgf("Sending set for task (ref=%s) to Kafka", set.task)
 	err = kafkaClient.SubmitMessage(ctx, set.Id, string(jsonData))
 	if err != nil {
-		log.Warn().Ctx(ctx).Msgf("Sending set for task (ref=%s) to Kafka failed, error: %s", set.task, err.Error())
+		log.Ctx(ctx).Warn().Msgf("Sending set for task (ref=%s) to Kafka failed, error: %s", set.task, err.Error())
 		return errors.Wrap(err, "failed to send task to Kafka")
 	}
 
-	log.Debug().Ctx(ctx).Msgf("Successfully sent task (ref=%s) to Kafka", set.task)
+	log.Ctx(ctx).Debug().Msgf("Successfully sent task (ref=%s) to Kafka", set.task)
 	return nil
 }

--- a/orchestrator/careplancontributor/handle_taskfiller_test.go
+++ b/orchestrator/careplancontributor/handle_taskfiller_test.go
@@ -435,7 +435,7 @@ func TestService_getSubTask(t *testing.T) {
 	require.NotNil(t, questionnaire)
 
 	questionnaireRef := "urn:uuid:" + *questionnaire.Id
-	log.Info().Ctx(context.Background()).Msgf("Creating a new Enrollment Criteria subtask - questionnaireRef: %s", questionnaireRef)
+	log.Info().Msgf("Creating a new Enrollment Criteria subtask - questionnaireRef: %s", questionnaireRef)
 	subtask := service.getSubTask(&primaryTask, questionnaireRef)
 
 	expectedSubTaskInput := []fhir.TaskInput{

--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -61,7 +61,7 @@ func New(
 		// Use embedded workflow provider
 		memoryWorkflowProvider := &taskengine.MemoryWorkflowProvider{}
 		for _, bundleUrl := range config.TaskFiller.QuestionnaireSyncURLs {
-			log.Info().Ctx(ctx).Msgf("Loading Task Filler Questionnaires/HealthcareService resources from URL: %s", bundleUrl)
+			log.Ctx(ctx).Info().Msgf("Loading Task Filler Questionnaires/HealthcareService resources from URL: %s", bundleUrl)
 			if err := memoryWorkflowProvider.LoadBundle(ctx, bundleUrl); err != nil {
 				return nil, fmt.Errorf("failed to load Task Filler Questionnaires/HealthcareService resources (url=%s): %w", bundleUrl, err)
 			}
@@ -76,12 +76,12 @@ func New(
 		// Load Questionnaire-related resources for the Task Filler Engine from the configured URLs into the Questionnaire FHIR API
 		go func(ctx context.Context, client fhirclient.Client) {
 			if len(config.TaskFiller.QuestionnaireSyncURLs) > 0 {
-				log.Info().Ctx(ctx).Msgf("Synchronizing Task Filler Questionnaires resources to local FHIR store from %d URLs", len(config.TaskFiller.QuestionnaireSyncURLs))
+				log.Ctx(ctx).Info().Msgf("Synchronizing Task Filler Questionnaires resources to local FHIR store from %d URLs", len(config.TaskFiller.QuestionnaireSyncURLs))
 				for _, u := range config.TaskFiller.QuestionnaireSyncURLs {
 					if err := coolfhir.ImportResources(ctx, questionnaireFhirClient, []string{"Questionnaire", "HealthcareService"}, u); err != nil {
-						log.Error().Ctx(ctx).Err(err).Msgf("Failed to synchronize Task Filler Questionnaire resources (url=%s)", u)
+						log.Ctx(ctx).Error().Err(err).Msgf("Failed to synchronize Task Filler Questionnaire resources (url=%s)", u)
 					} else {
-						log.Debug().Ctx(ctx).Msgf("Synchronized Task Filler Questionnaire resources (url=%s)", u)
+						log.Ctx(ctx).Debug().Msgf("Synchronized Task Filler Questionnaire resources (url=%s)", u)
 					}
 				}
 			}
@@ -494,7 +494,7 @@ func (s Service) handleNotification(ctx context.Context, resource any) error {
 		}
 	}
 
-	log.Info().Ctx(ctx).Msgf("Received notification: Reference %s, Type: %s", *focusReference.Reference, *focusReference.Type)
+	log.Ctx(ctx).Info().Msgf("Received notification: Reference %s, Type: %s", *focusReference.Reference, *focusReference.Type)
 
 	if focusReference.Reference == nil {
 		return &coolfhir.ErrorWithCode{
@@ -538,14 +538,14 @@ func (s Service) handleNotification(ctx context.Context, resource any) error {
 			return err
 		}
 	default:
-		log.Info().Ctx(ctx).Msgf("Received notification of type %s is not yet supported", *focusReference.Type)
+		log.Ctx(ctx).Info().Msgf("Received notification of type %s is not yet supported", *focusReference.Type)
 	}
 
 	return nil
 }
 
 func (s Service) rejectTask(ctx context.Context, client fhirclient.Client, task fhir.Task, rejection TaskRejection) error {
-	log.Info().Ctx(ctx).Msgf("Rejecting task (id=%s, reason=%s)", *task.Id, rejection.FormatReason())
+	log.Ctx(ctx).Info().Msgf("Rejecting task (id=%s, reason=%s)", *task.Id, rejection.FormatReason())
 	task.Status = fhir.TaskStatusRejected
 	task.StatusReason = &fhir.CodeableConcept{
 		Text: to.Ptr(rejection.FormatReason()),

--- a/orchestrator/careplanservice/handle_createtask.go
+++ b/orchestrator/careplanservice/handle_createtask.go
@@ -20,7 +20,7 @@ import (
 )
 
 func (s *Service) handleCreateTask(ctx context.Context, request FHIRHandlerRequest, tx *coolfhir.BundleBuilder) (FHIRHandlerResult, error) {
-	log.Info().Ctx(ctx).Msg("Creating Task")
+	log.Ctx(ctx).Info().Msg("Creating Task")
 	var task fhir.Task
 	if err := json.Unmarshal(request.ResourceData, &task); err != nil {
 		return nil, fmt.Errorf("invalid %T: %w", task, coolfhir.BadRequestError(err))
@@ -59,12 +59,12 @@ func (s *Service) handleCreateTask(ctx context.Context, request FHIRHandlerReque
 	// Enrich Task.Requester and Task.Owner with info from CSD (if available), typically to add the organization name
 	// TODO: CSD is queried again later, to get the notification endpoint. We should optimize/cache this. Maybe in the context.Context?
 	if entity, err := s.profile.CsdDirectory().LookupEntity(ctx, *task.Requester.Identifier); err != nil {
-		log.Info().Ctx(ctx).Err(err).Msgf("Unable to lookup Task.requester in CSD, won't be enriched.")
+		log.Ctx(ctx).Info().Err(err).Msgf("Unable to lookup Task.requester in CSD, won't be enriched.")
 	} else {
 		task.Requester = entity
 	}
 	if entity, err := s.profile.CsdDirectory().LookupEntity(ctx, *task.Owner.Identifier); err != nil {
-		log.Info().Ctx(ctx).Err(err).Msgf("Unable to lookup Task.owner in CSD, won't be enriched.")
+		log.Ctx(ctx).Info().Err(err).Msgf("Unable to lookup Task.owner in CSD, won't be enriched.")
 	} else {
 		task.Owner = entity
 	}

--- a/orchestrator/careplanservice/handle_getcondition.go
+++ b/orchestrator/careplanservice/handle_getcondition.go
@@ -30,7 +30,7 @@ func (s *Service) handleGetCondition(ctx context.Context, id string, headers *fh
 			}
 		}
 	} else {
-		log.Warn().Ctx(ctx).Msg("Condition does not have Patient as subject, can't verify access")
+		log.Ctx(ctx).Warn().Msg("Condition does not have Patient as subject, can't verify access")
 		return nil, &coolfhir.ErrorWithCode{
 			Message:    "Participant does not have access to Condition",
 			StatusCode: http.StatusForbidden,

--- a/orchestrator/careplanservice/handle_updatetask.go
+++ b/orchestrator/careplanservice/handle_updatetask.go
@@ -16,7 +16,7 @@ import (
 )
 
 func (s *Service) handleUpdateTask(ctx context.Context, request FHIRHandlerRequest, tx *coolfhir.BundleBuilder) (FHIRHandlerResult, error) {
-	log.Info().Ctx(ctx).Msgf("Updating Task: %s", request.RequestUrl)
+	log.Ctx(ctx).Info().Msgf("Updating Task: %s", request.RequestUrl)
 	var task fhir.Task
 	if err := json.Unmarshal(request.ResourceData, &task); err != nil {
 		return nil, fmt.Errorf("invalid %T: %w", task, coolfhir.BadRequestError(err))

--- a/orchestrator/careplanservice/subscriptions/manager.go
+++ b/orchestrator/careplanservice/subscriptions/manager.go
@@ -43,7 +43,7 @@ func (r DerivingManager) Notify(ctx context.Context, resource interface{}) error
 			Reference: to.Ptr("Task/" + *task.Id),
 			Type:      to.Ptr("Task"),
 		}
-		log.Info().Ctx(ctx).Msgf("Notifying subscribers for Task %s", *task.Id)
+		log.Ctx(ctx).Info().Msgf("Notifying subscribers for Task %s", *task.Id)
 		isOwnerValid := false
 		if task.Owner != nil {
 			isOwnerValid = coolfhir.IsLogicalIdentifier(task.Owner.Identifier)
@@ -53,9 +53,9 @@ func (r DerivingManager) Notify(ctx context.Context, resource interface{}) error
 		} else {
 			ownerJSON, err := json.Marshal(task.Owner)
 			if err != nil {
-				log.Error().Ctx(ctx).Msgf("Failed to marshal owner to JSON: %s", err)
+				log.Ctx(ctx).Error().Msgf("Failed to marshal owner to JSON: %s", err)
 			} else {
-				log.Warn().Ctx(ctx).Msgf("Owner LogicalIdentifier is invalid: %s", string(ownerJSON))
+				log.Ctx(ctx).Warn().Msgf("Owner LogicalIdentifier is invalid: %s", string(ownerJSON))
 			}
 		}
 		isRequesterValid := false
@@ -67,9 +67,9 @@ func (r DerivingManager) Notify(ctx context.Context, resource interface{}) error
 		} else {
 			requesterJSON, err := json.Marshal(task.Requester)
 			if err != nil {
-				log.Error().Ctx(ctx).Msgf("Failed to marshal requester to JSON: %s", err)
+				log.Ctx(ctx).Error().Msgf("Failed to marshal requester to JSON: %s", err)
 			} else {
-				log.Warn().Ctx(ctx).Msgf("Requester LogicalIdentifier is invalid: %s", string(requesterJSON))
+				log.Ctx(ctx).Warn().Msgf("Requester LogicalIdentifier is invalid: %s", string(requesterJSON))
 			}
 		}
 	case "CareTeam":
@@ -84,9 +84,9 @@ func (r DerivingManager) Notify(ctx context.Context, resource interface{}) error
 			} else {
 				memberJSON, err := json.Marshal(participant.Member)
 				if err != nil {
-					log.Error().Ctx(ctx).Msgf("Failed to marshal member to JSON: %s", err)
+					log.Ctx(ctx).Error().Msgf("Failed to marshal member to JSON: %s", err)
 				} else {
-					log.Warn().Ctx(ctx).Msgf("Member LogicalReference is invalid: %s", string(memberJSON))
+					log.Ctx(ctx).Warn().Msgf("Member LogicalReference is invalid: %s", string(memberJSON))
 				}
 			}
 		}
@@ -94,7 +94,7 @@ func (r DerivingManager) Notify(ctx context.Context, resource interface{}) error
 		return fmt.Errorf("subscription manager does not support notifying for resource type: %T", resource)
 	}
 
-	log.Info().Ctx(ctx).Msgf("Notifying %d subscriber(s) for update on resource: %s", len(subscribers), *focus.Reference)
+	log.Ctx(ctx).Info().Msgf("Notifying %d subscriber(s) for update on resource: %s", len(subscribers), *focus.Reference)
 
 	return r.notifyAll(ctx, timeFunc(), focus, subscribers)
 }

--- a/orchestrator/careplanservice/util.go
+++ b/orchestrator/careplanservice/util.go
@@ -19,7 +19,7 @@ import (
 
 // Writes an OperationOutcome based on the given error as HTTP response.
 func (s *Service) writeOperationOutcomeFromError(ctx context.Context, err error, desc string, httpResponse http.ResponseWriter) {
-	log.Info().Ctx(ctx).Msgf("%s failed: %v", desc, err)
+	log.Ctx(ctx).Info().Msgf("%s failed: %v", desc, err)
 	diagnostics := fmt.Sprintf("%s failed: %s", desc, err.Error())
 
 	issue := fhir.OperationOutcomeIssue{
@@ -217,7 +217,7 @@ func filterMatchingResourcesInBundle(ctx context.Context, bundle *fhir.Bundle, r
 		if err != nil {
 			// We don't want to fail the whole operation if one resource fails to unmarshal.
 			// Replace result bundle entry with an OperationOutcome to inform the client something went wrong.
-			log.Error().Ctx(ctx).Msgf("filterMatchingResourcesInBundle: Failed to unmarshal resource: %v", err)
+			log.Ctx(ctx).Error().Msgf("filterMatchingResourcesInBundle: Failed to unmarshal resource: %v", err)
 			newBundle.Entry[j] = coolfhir.CreateOperationOutcomeBundleEntryFromError(err, "Failed to unmarshal resource")
 			j++
 			continue
@@ -228,7 +228,7 @@ func filterMatchingResourcesInBundle(ctx context.Context, bundle *fhir.Bundle, r
 				parts := strings.Split(ref, "/")
 				if len(parts) != 2 {
 					// Replace result bundle entry with an OperationOutcome, since we couldn't resolve it
-					log.Error().Ctx(ctx).Msgf("filterMatchingResourcesInBundle: Invalid reference format: %s", ref)
+					log.Ctx(ctx).Error().Msgf("filterMatchingResourcesInBundle: Invalid reference format: %s", ref)
 					newBundle.Entry[j] = coolfhir.CreateOperationOutcomeBundleEntryFromError(fmt.Errorf("Invalid reference format: %s", ref), "Invalid reference format")
 					j++
 					continue

--- a/orchestrator/cmd/profile/nuts/auth.go
+++ b/orchestrator/cmd/profile/nuts/auth.go
@@ -27,21 +27,21 @@ func (d DutchNutsProfile) Authenticator(resourceServerURL *url.URL, fn func(writ
 		userInfo := middleware.UserInfo(request.Context())
 		if userInfo == nil {
 			// would be weird, should've been handled by middleware.Secure()
-			log.Error().Msg("User info not found in context")
+			log.Ctx(request.Context()).Error().Msg("User info not found in context")
 			http.Error(response, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
 
 		organization, err := claimsToOrganization(userInfo)
 		if err != nil {
-			log.Err(err).Msg("Invalid user info in context")
+			log.Ctx(request.Context()).Err(err).Msg("Invalid user info in context")
 			http.Error(response, "Unauthorized", http.StatusUnauthorized)
 			return
 		}
 		principal := auth.Principal{
 			Organization: *organization,
 		}
-		log.Info().Msgf("Authenticated user: %v", principal)
+		log.Ctx(request.Context()).Debug().Msgf("Authenticated user: %v", principal)
 		fn(response, request.WithContext(auth.WithPrincipal(request.Context(), principal)))
 	})
 }

--- a/orchestrator/cmd/profile/nuts/auth_test.go
+++ b/orchestrator/cmd/profile/nuts/auth_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"github.com/SanteonNL/orca/orchestrator/lib/auth"
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"io"
@@ -28,6 +29,7 @@ func TestDutchNutsProfile_Authenticator(t *testing.T) {
 		var capturedPrincipal auth.Principal
 		var capturedError error
 		handler := profile.Authenticator(resourceServerURL, func(writer http.ResponseWriter, request *http.Request) {
+			log.Ctx(request.Context()).Info().Msg("test")
 			capturedPrincipal, capturedError = auth.PrincipalFromContext(request.Context())
 			_, _ = io.ReadAll(request.Body)
 			writer.WriteHeader(http.StatusOK)

--- a/orchestrator/cmd/profile/nuts/profile.go
+++ b/orchestrator/cmd/profile/nuts/profile.go
@@ -131,7 +131,7 @@ func (d *DutchNutsProfile) Identities(ctx context.Context) ([]fhir.Organization,
 	if time.Since(d.identitiesRefreshedAt) > identitiesCacheTTL || len(d.cachedIdentities) == 0 {
 		identifiers, err := d.identities(ctx)
 		if err != nil {
-			log.Warn().Ctx(ctx).Err(err).Msg("Failed to refresh local identities using Nuts node")
+			log.Ctx(ctx).Warn().Err(err).Msg("Failed to refresh local identities using Nuts node")
 			if d.cachedIdentities == nil {
 				// If we don't have a cached value, we can't return anything, so return the error.
 				return nil, fmt.Errorf("failed to load local identities: %w", err)
@@ -160,7 +160,7 @@ func (d DutchNutsProfile) identities(ctx context.Context) ([]fhir.Organization, 
 	for _, cred := range *response.JSON200 {
 		identities, err := d.identifiersFromCredential(cred)
 		if err != nil {
-			log.Warn().Ctx(ctx).Err(err).Msgf("Failed to extract identities from credential: %s", cred.ID)
+			log.Ctx(ctx).Warn().Err(err).Msgf("Failed to extract identities from credential: %s", cred.ID)
 			continue
 		}
 		results = append(results, identities...)

--- a/orchestrator/globals/globals.go
+++ b/orchestrator/globals/globals.go
@@ -3,7 +3,13 @@ package globals
 import (
 	"crypto/tls"
 	fhirclient "github.com/SanteonNL/go-fhir-client"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 )
+
+func init() {
+	zerolog.DefaultContextLogger = &log.Logger
+}
 
 var CarePlanServiceFhirClient fhirclient.Client
 

--- a/orchestrator/lib/auth/auth.go
+++ b/orchestrator/lib/auth/auth.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
+	"github.com/rs/zerolog/log"
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
 )
 
@@ -23,13 +25,20 @@ func PrincipalFromContext(ctx context.Context) (Principal, error) {
 }
 
 func WithPrincipal(ctx context.Context, principal Principal) context.Context {
-	return context.WithValue(ctx, principalContextKey, principal)
+	ctx = context.WithValue(ctx, principalContextKey, principal)
+	// Add a child logger with the 'principal' field set, to log it on every log line related to this request
+	ctx = log.Ctx(ctx).With().Str("principal", principal.ID()).Logger().WithContext(ctx)
+	return ctx
 }
 
 var _ fmt.Stringer = Principal{}
 
 type Principal struct {
 	Organization fhir.Organization
+}
+
+func (u Principal) ID() string {
+	return coolfhir.ToString(u.Organization.Identifier[0])
 }
 
 func (u Principal) String() string {

--- a/orchestrator/lib/coolfhir/util.go
+++ b/orchestrator/lib/coolfhir/util.go
@@ -419,7 +419,7 @@ func GetTaskByIdentifier(ctx context.Context, fhirClient fhirclient.Client, iden
 		if err := ResourceInBundle(&existingTaskBundle, EntryIsOfType("Task"), &existingTask); err != nil {
 			return nil, fmt.Errorf("unable to get existing CPS Task resource from search bundle: %v", err)
 		}
-		log.Debug().Ctx(ctx).Msg("Found existing CPS Task resource for demo task")
+		log.Ctx(ctx).Debug().Msg("Found existing CPS Task resource for demo task")
 		return &existingTask, nil
 	} else if len(existingTaskBundle.Entry) > 1 {
 		return nil, fmt.Errorf("found multiple existing CPS Tasks for identifier: %s", *identifier.System+"|"+*identifier.Value)

--- a/orchestrator/main.go
+++ b/orchestrator/main.go
@@ -13,6 +13,7 @@ func main() {
 		log.Fatal().Err(err).Msg("Failed to load configuration")
 	}
 	zerolog.SetGlobalLevel(config.LogLevel)
+	zerolog.DefaultContextLogger = &log.Logger
 	log.Info().Msgf("Public interface listens on %s", config.Public.Address)
 	log.Info().Msgf("Using Nuts API on %s", config.Nuts.API.URL)
 	if err := cmd.Start(context.Background(), *config); err != nil {


### PR DESCRIPTION
Set during authentication, it causes the user to be added as field to log entries. This means we log the URA of the authenticated organization as `principal` field in `<system>|<value>` format.

For example:

```json
{"level":"info","principal":"http://fhir.nl/fhir/NamingSystem/ura|1","time":"2025-01-26T08:42:13+01:00","message":"test"}
```