### PR TITLE
Remove dangling err check

### DIFF
--- a/orchestrator/careplanservice/handle_createtask.go
+++ b/orchestrator/careplanservice/handle_createtask.go
@@ -223,9 +223,7 @@ func (s *Service) handleCreateTask(ctx context.Context, request FHIRHandlerReque
 			return nil, fmt.Errorf("failed to update CarePlan: %w", err)
 		}
 	}
-	if err != nil {
-		return nil, fmt.Errorf("failed to create Task: %w", err)
-	}
+	
 	return func(txResult *fhir.Bundle) (*fhir.BundleEntry, []any, error) {
 		var createdTask fhir.Task
 		result, err := coolfhir.NormalizeTransactionBundleResponseEntry(s.fhirClient, s.fhirURL, &taskBundleEntry, &txResult.Entry[taskEntryIdx], &createdTask)


### PR DESCRIPTION
While looking at the code to see how a `CarePlan` is being created I noticed a dangling err check. I'm pretty sure it's a left-over of code that has been refactored.