### PR TITLE
Return notifications properly in create task handler

### DIFF
--- a/orchestrator/careplanservice/handle_createtask.go
+++ b/orchestrator/careplanservice/handle_createtask.go
@@ -239,7 +239,7 @@ func (s *Service) handleCreateTask(ctx context.Context, request FHIRHandlerReque
 			notifications = append(notifications, &updatedCareTeam)
 		}
 
-		return result, []any{&createdTask}, nil
+		return result, notifications, nil
 	}, nil
 }
 


### PR DESCRIPTION
While looking at the code to see how a `CarePlan` is being created I noticed that the result handler of `handleCreateTask(..)` populates an array of notifications but incorrectly returns a hardcoded slice instead which results in a missing notification for the `CareTeam` in a task.

It seems like this should work similarly to `handleUpdateTask(..)` (which does return the `notifications` variable).