### PR TITLE
Temporarily re-implement viewer searching for task and careplan

### DIFF
--- a/viewer_simulator/app/(DashboardLayout)/components/onboarding/accepted-task-overview.tsx
+++ b/viewer_simulator/app/(DashboardLayout)/components/onboarding/accepted-task-overview.tsx
@@ -22,6 +22,35 @@ export default async function AcceptedTaskOverview() {
         let entries = notificationBundles.flatMap(bundle => bundle.entry || []);
         console.log(`Found [${entries?.length}] bundle resources`);
 
+        // TODO: Remove this once the notification from ehr to viewer is working correctly in dev and test environments
+        if (entries.length === 0) {
+            let requestHeaders = new Headers();
+            requestHeaders.set("Cache-Control", "no-cache")
+            if (process.env.FHIR_AUTHORIZATION_TOKEN) {
+                requestHeaders.set("Authorization", "Bearer " + process.env.FHIR_AUTHORIZATION_TOKEN);
+            }
+            requestHeaders.set("Content-Type", "application/x-www-form-urlencoded");
+            const response = await fetch(`${process.env.FHIR_BASE_URL}/Task/_search`, {
+                method: 'POST',
+                cache: 'no-store',
+                headers: requestHeaders,
+                body: new URLSearchParams({
+                    '_sort': '-_lastUpdated',
+                    '_count': '100'
+                })
+            });
+
+            if (!response.ok) {
+                const errorText = await response.text();
+                console.error('Failed to fetch tasks: ', errorText);
+                throw new Error('Failed to fetch tasks: ' + errorText);
+            }
+
+            const responseBundle = await response.json() as Bundle;
+            entries = responseBundle.entry || [];
+            console.log(`Found [${entries?.length}] Task resources`);
+        }
+
         if (entries?.length) {
             rows = entries.
             filter((entries) => entries.resource?.resourceType === "Task").


### PR DESCRIPTION
The notification mechanism is not working correctly in dev and test, re-enable fetching Task and CarePlan if there are no records so we can still do tests and demos while figuring out the notifications