### PR TITLE
INT-570: Handle empty matched conditional create resource result on Azure FHIR

### DIFF
--- a/orchestrator/careplanservice/handle_createtask.go
+++ b/orchestrator/careplanservice/handle_createtask.go
@@ -223,10 +223,10 @@ func (s *Service) handleCreateTask(ctx context.Context, request FHIRHandlerReque
 			return nil, fmt.Errorf("failed to update CarePlan: %w", err)
 		}
 	}
-	
+
 	return func(txResult *fhir.Bundle) (*fhir.BundleEntry, []any, error) {
 		var createdTask fhir.Task
-		result, err := coolfhir.NormalizeTransactionBundleResponseEntry(s.fhirClient, s.fhirURL, &taskBundleEntry, &txResult.Entry[taskEntryIdx], &createdTask)
+		result, err := coolfhir.NormalizeTransactionBundleResponseEntry(ctx, s.fhirClient, s.fhirURL, &taskBundleEntry, &txResult.Entry[taskEntryIdx], &createdTask)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/orchestrator/careplanservice/handle_createtask_test.go
+++ b/orchestrator/careplanservice/handle_createtask_test.go
@@ -341,7 +341,7 @@ func Test_handleCreateTask_NoExistingCarePlan(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			mockFHIRClient.EXPECT().Read("Task/3", gomock.Any(), gomock.Any()).DoAndReturn(func(path string, result interface{}, option ...fhirclient.Option) error {
+			mockFHIRClient.EXPECT().ReadWithContext(gomock.Any(), "Task/3", gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, path string, result interface{}, option ...fhirclient.Option) error {
 				data, _ := json.Marshal(tt.createdTask)
 				*(result.(*[]byte)) = data
 				return tt.errorFromRead

--- a/orchestrator/careplanservice/handle_updatetask.go
+++ b/orchestrator/careplanservice/handle_updatetask.go
@@ -128,7 +128,7 @@ func (s *Service) handleUpdateTask(ctx context.Context, request FHIRHandlerReque
 
 	return func(txResult *fhir.Bundle) (*fhir.BundleEntry, []any, error) {
 		var updatedTask fhir.Task
-		result, err := coolfhir.NormalizeTransactionBundleResponseEntry(s.fhirClient, s.fhirURL, &taskBundleEntry, &txResult.Entry[idx], &updatedTask)
+		result, err := coolfhir.NormalizeTransactionBundleResponseEntry(ctx, s.fhirClient, s.fhirURL, &taskBundleEntry, &txResult.Entry[idx], &updatedTask)
 		if errors.Is(err, coolfhir.ErrEntryNotFound) {
 			// Bundle execution succeeded, but could not read result entry.
 			// Just respond with the original Task that was sent.

--- a/orchestrator/careplanservice/service.go
+++ b/orchestrator/careplanservice/service.go
@@ -259,7 +259,7 @@ func (s *Service) handleUnmanagedOperation(request FHIRHandlerRequest, tx *coolf
 	tx.AppendEntry(requestBundleEntry)
 	idx := len(tx.Entry) - 1
 	return func(txResult *fhir.Bundle) (*fhir.BundleEntry, []any, error) {
-		result, err := coolfhir.NormalizeTransactionBundleResponseEntry(s.fhirClient, s.fhirURL, &requestBundleEntry, &txResult.Entry[idx], nil)
+		result, err := coolfhir.NormalizeTransactionBundleResponseEntry(request.Context, s.fhirClient, s.fhirURL, &requestBundleEntry, &txResult.Entry[idx], nil)
 		return result, nil, err
 	}, nil
 }

--- a/orchestrator/careplanservice/service_test.go
+++ b/orchestrator/careplanservice/service_test.go
@@ -301,8 +301,8 @@ func TestService_DefaultOperationHandler(t *testing.T) {
 		}
 		ctrl := gomock.NewController(t)
 		fhirClient := mock.NewMockClient(ctrl)
-		fhirClient.EXPECT().Read("ServiceRequest/123", gomock.Any(), gomock.Any()).
-			DoAndReturn(func(_ string, resultResource interface{}, opts ...fhirclient.Option) error {
+		fhirClient.EXPECT().ReadWithContext(gomock.Any(), "ServiceRequest/123", gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ string, resultResource interface{}, opts ...fhirclient.Option) error {
 				reflect.ValueOf(resultResource).Elem().Set(reflect.ValueOf(expectedServiceRequestJson))
 				return nil
 			})

--- a/orchestrator/lib/coolfhir/bundle.go
+++ b/orchestrator/lib/coolfhir/bundle.go
@@ -1,6 +1,7 @@
 package coolfhir
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -208,17 +209,22 @@ func ExecuteTransaction(fhirClient fhirclient.Client, bundle fhir.Bundle) (fhir.
 // - Change the response.location property to a relative URL if it was an absolute URL
 // - Read the resource being referenced and unmarshal it into the given result argument (so it can be used for notification).
 // - Set the response.resource property to the read resource
-func NormalizeTransactionBundleResponseEntry(fhirClient fhirclient.Client, fhirBaseURL *url.URL, requestEntry *fhir.BundleEntry, responseEntry *fhir.BundleEntry, result interface{}) (*fhir.BundleEntry, error) {
+func NormalizeTransactionBundleResponseEntry(ctx context.Context, fhirClient fhirclient.Client, fhirBaseURL *url.URL, requestEntry *fhir.BundleEntry, responseEntry *fhir.BundleEntry, result interface{}) (*fhir.BundleEntry, error) {
 	if responseEntry.Response == nil {
 		return nil, errors.New("entry.Response is nil")
 	}
 	resultEntry := *responseEntry
 	// Enrich result with resource from FHIR server
 	if resultEntry.Resource == nil {
-		// Microsoft Azure FHIR: when PUT-ing a resource, the resultEntry entry might not contain a location.
-		//                       in that case, the location is the same as the request URL.
+		// Microsoft Azure FHIR:
+		// - When PUT-ing a resource, the resultEntry entry might not contain a location.
+		//   In that case, the location is the same as the request URL.
+		// - When POST-ing a resource with IfNoneExist and the resource already exists, the resource itself isn't returned.
+		//   It only returns: {"response":{"status":"200"}}
+		//   In theory, this could be fixed with the 'Prefer: return=representation' header, but Azure FHIR doesn't support it.
+		//   See https://github.com/microsoft/fhir-server/issues/2431
 		var resourcePath string
-		var requestOptions []fhirclient.Option
+		var searchParams url.Values
 		if resultEntry.Response.Location != nil {
 			resourcePath = *resultEntry.Response.Location
 			// HAPI uses relative Location URLs, Microsoft Azure FHIR uses absolute URLs.
@@ -241,22 +247,64 @@ func NormalizeTransactionBundleResponseEntry(fhirClient fhirclient.Client, fhirB
 				return nil, err
 			}
 			resourcePath = entryRequestUrl.Path
-			for key, values := range entryRequestUrl.Query() {
-				for _, value := range values {
-					requestOptions = append(requestOptions, fhirclient.QueryParam(key, value))
-				}
+			searchParams = entryRequestUrl.Query()
+		} else if requestEntry.Request.IfNoneExist != nil {
+			// Azure FHIR behavior: conditional create matched existing resource, Azure FHIR only returns "200 OK".
+			// Need to find the existing resource by the IfNoneExist query parameters.
+			q, err := url.Parse("?" + *requestEntry.Request.IfNoneExist)
+			if err != nil {
+				return nil, err
 			}
+			resourcePath = requestEntry.Request.Url
+			searchParams = q.Query()
 		}
+
+		//if resourcePath == "" {
+		//	// Might be conditional update or create
+		//	if requestEntry.Request.IfNoneExist != nil {
+		//		// TODO: Might have to support the other conditional parameters as well?
+		//		// Azure FHIR (contrary to HAPI) only returns "200 OK" for conditional creates that match an existing resource.
+		//		// Need to find the existing resource by the IfNoneExist query parameters.
+		//		var resultBundle fhir.Bundle
+		//		if err := fhirClient.SearchWithContext(ctx, requestEntry.Request.Url, &resultBundle, requestOptions...); err != nil {
+		//		} else {
+		//			responseBundleEntryJson, _ := json.Marshal(responseEntry)
+		//			log.Error().Msgf("Failed to determine resource path from FHIR transaction resultEntry bundle: %s", string(responseBundleEntryJson))
+		//			return nil, errors.New("failed to determine resource for transaction response bundle entry, see log for more details")
+		//		}
+		//	} else {
+		//		// We have a path to the resource, just get it
+		//		var resourceData []byte
+		//		if err := fhirClient.Read(resourcePath, &resourceData, requestOptions...); err != nil {
+		//			return nil, errors.Join(ErrEntryNotFound, fmt.Errorf("failed to retrieve result Bundle entry (resource=%s): %w", resourcePath, err))
+		//		}
+		//		resultEntry.Resource = resourceData
+		//	}
+
 		if resourcePath == "" {
 			responseBundleEntryJson, _ := json.Marshal(responseEntry)
 			log.Error().Msgf("Failed to determine resource path from FHIR transaction resultEntry bundle: %s", string(responseBundleEntryJson))
 			return nil, errors.New("failed to determine resource for transaction response bundle entry, see log for more details")
 		}
-		var resourceData []byte
-		if err := fhirClient.Read(resourcePath, &resourceData, requestOptions...); err != nil {
-			return nil, errors.Join(ErrEntryNotFound, fmt.Errorf("failed to retrieve result Bundle entry (resource=%s): %w", resourcePath, err))
+		if len(searchParams) == 0 {
+			var resourceData []byte
+			if err := fhirClient.ReadWithContext(ctx, resourcePath, &resourceData); err != nil {
+				return nil, errors.Join(ErrEntryNotFound, fmt.Errorf("failed to retrieve result Bundle entry (resource=%s): %w", resourcePath, err))
+			}
+			resultEntry.Resource = resourceData
+		} else {
+			var resultBundle fhir.Bundle
+			if err := fhirClient.SearchWithContext(ctx, resourcePath, searchParams, &resultBundle); err != nil {
+				return nil, errors.Join(ErrEntryNotFound, fmt.Errorf("failed to search for result Bundle entry (resource=%s): %w", resourcePath, err))
+			}
+			if len(resultBundle.Entry) == 0 {
+				return nil, errors.Join(ErrEntryNotFound, fmt.Errorf("no result Bundle entry found (resource=%s)", resourcePath))
+			}
+			if len(resultBundle.Entry) > 1 {
+				return nil, errors.New("multiple result Bundle entries found, expected 1")
+			}
+			resultEntry.Resource = resultBundle.Entry[0].Resource
 		}
-		resultEntry.Resource = resourceData
 	}
 	if len(resultEntry.Resource) != 0 && result != nil {
 		if err := json.Unmarshal(resultEntry.Resource, result); err != nil {

--- a/orchestrator/lib/coolfhir/bundle.go
+++ b/orchestrator/lib/coolfhir/bundle.go
@@ -293,17 +293,17 @@ func NormalizeTransactionBundleResponseEntry(ctx context.Context, fhirClient fhi
 			}
 			resultEntry.Resource = resourceData
 		} else {
-			var resultBundle fhir.Bundle
-			if err := fhirClient.SearchWithContext(ctx, resourcePath, searchParams, &resultBundle); err != nil {
+			var searchResultBundle fhir.Bundle
+			if err := fhirClient.SearchWithContext(ctx, resourcePath, searchParams, &searchResultBundle); err != nil {
 				return nil, errors.Join(ErrEntryNotFound, fmt.Errorf("failed to search for result Bundle entry (resource=%s): %w", resourcePath, err))
 			}
-			if len(resultBundle.Entry) == 0 {
+			if len(searchResultBundle.Entry) == 0 {
 				return nil, errors.Join(ErrEntryNotFound, fmt.Errorf("no result Bundle entry found (resource=%s)", resourcePath))
 			}
-			if len(resultBundle.Entry) > 1 {
+			if len(searchResultBundle.Entry) > 1 {
 				return nil, errors.New("multiple result Bundle entries found, expected 1")
 			}
-			resultEntry.Resource = resultBundle.Entry[0].Resource
+			resultEntry.Resource = searchResultBundle.Entry[0].Resource
 		}
 	}
 	if len(resultEntry.Resource) != 0 && result != nil {


### PR DESCRIPTION
Azure FHIR only returns 200 OK when a conditional create matched an existing resource. Our normalization code didn't know what to do in this case.

The normalization code already reads the resource in case the FHIR API doesn't return it, looking at things like `location` properties and upserts. But, we didn't handle `ifNoneExist` yet. In this case, we need to do a search.

Also improved the existing "search" for upserts (it used a `Read()` before, so the returned result was incorrect).

Also added passing of context to the FHIR client, so tracing headers and time-outs (which we both don't have yet) will be honored.