### PR TITLE
Frontend: don't upper-case patient name and care organization

### DIFF
--- a/frontend/app/enrollment/new/components/enrollment-details.tsx
+++ b/frontend/app/enrollment/new/components/enrollment-details.tsx
@@ -14,7 +14,7 @@ export default function EnrollmentDetails() {
         (
             <div className="grid grid-cols-[1fr,2fr] gap-y-4 w-[568px]">
                 <div>Patiënt:</div>
-                <div className="font-[500] first-letter:uppercase">{patient ? patientName(patient) : "Onbekend"}</div>
+                <div className="font-[500]">{patient ? patientName(patient) : "Onbekend"}</div>
 
                 <div>Verzoek:</div>
                 <div className="font-[500] first-letter:uppercase">{serviceRequest?.code?.coding?.[0].display || "Onbekend"}</div>
@@ -25,7 +25,7 @@ export default function EnrollmentDetails() {
                 </div>
 
                 <div>Uitvoerende organisatie:</div>
-                <div className="font-[500] first-letter:uppercase">
+                <div className="font-[500]">
                     {organizationName(serviceRequest?.performer?.[0])}
                 </div>
             </div>

--- a/frontend/app/enrollment/task/[taskId]/page.tsx
+++ b/frontend/app/enrollment/task/[taskId]/page.tsx
@@ -26,10 +26,10 @@ export default function EnrollmentTaskPage() {
         return <div className='w-[568px] flex flex-col gap-4'>Taak niet gevonden</div>
     }
 
-    const StatusElement = ({ label, value }: { label: string, value: string }) =>
+    const StatusElement = ({label, value, noUpperCase}: { label: string, value: string, noUpperCase?: boolean | undefined }) =>
         <>
             <div>{label}:</div>
-            <div className="font-[500] first-letter:uppercase">{value}</div>
+            <div className={"font-[500] " + !noUpperCase ? "first-letter:uppercase" : ""}>{value}</div>
         </>
 
     if (task.status === "received") {
@@ -47,7 +47,7 @@ export default function EnrollmentTaskPage() {
                     <p className="text-muted-foreground pb-8">{executionText(task.status)}</p> : <></>
             }
             <div className="grid grid-cols-[1fr,2fr] gap-y-4">
-                <StatusElement label="Patiënt" value={patient ? patientName(patient) : "Onbekend"} />
+                <StatusElement label="Patiënt" value={patient ? patientName(patient) : "Onbekend"} noUpperCase={true} />
                 <StatusElement label="Verzoek" value={task?.focus?.display || "Onbekend"} />
                 <StatusElement label="Diagnose" value={task?.reasonCode?.coding?.[0].display || "Onbekend"} />
                 <StatusElement label="Uitvoerende organisatie" value={organizationName(task.owner)} />


### PR DESCRIPTION
These values aren't display values of codes, but dictated by the EHR (patient name) or as the care organization is registered (from the Verifiable Credential/CSD). So we shouldn't alter the casing.