### PR TITLE
INT-569: Support DELETE when unmanaged operations are allowed

### DIFF
--- a/orchestrator/careplancontributor/mock/fhirclient_mock.go
+++ b/orchestrator/careplancontributor/mock/fhirclient_mock.go
@@ -80,6 +80,44 @@ func (mr *MockClientMockRecorder) CreateWithContext(ctx, resource, result any, o
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWithContext", reflect.TypeOf((*MockClient)(nil).CreateWithContext), varargs...)
 }
 
+// Delete mocks base method.
+func (m *MockClient) Delete(path string, opts ...fhirclient.Option) error {
+	m.ctrl.T.Helper()
+	varargs := []any{path}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Delete", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockClientMockRecorder) Delete(path any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{path}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockClient)(nil).Delete), varargs...)
+}
+
+// DeleteWithContext mocks base method.
+func (m *MockClient) DeleteWithContext(ctx context.Context, path string, opts ...fhirclient.Option) error {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx, path}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteWithContext", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteWithContext indicates an expected call of DeleteWithContext.
+func (mr *MockClientMockRecorder) DeleteWithContext(ctx, path any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx, path}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWithContext", reflect.TypeOf((*MockClient)(nil).DeleteWithContext), varargs...)
+}
+
 // Path mocks base method.
 func (m *MockClient) Path(path ...string) *url.URL {
 	m.ctrl.T.Helper()

--- a/orchestrator/careplanservice/handle_createtask_test.go
+++ b/orchestrator/careplanservice/handle_createtask_test.go
@@ -131,20 +131,20 @@ func Test_handleCreateTask_NoExistingCarePlan(t *testing.T) {
 			{
 				Response: &fhir.BundleEntryResponse{
 					Location: to.Ptr("CarePlan/1"),
-					Status:   "204 Created",
+					Status:   "201 Created",
 				},
 			},
 			{
 				Response: &fhir.BundleEntryResponse{
 					Location: to.Ptr("CareTeam/2"),
-					Status:   "204 Created",
+					Status:   "201 Created",
 				},
 				Resource: json.RawMessage(`{"resourceType":"CareTeam","id":"2"}`),
 			},
 			{
 				Response: &fhir.BundleEntryResponse{
 					Location: to.Ptr("Task/3"),
-					Status:   "204 Created",
+					Status:   "201 Created",
 				},
 			},
 		},
@@ -364,7 +364,7 @@ func Test_handleCreateTask_NoExistingCarePlan(t *testing.T) {
 			require.NoError(t, err)
 			assert.Len(t, notifications, 2)
 			require.Equal(t, "Task/3", *response.Response.Location)
-			require.Equal(t, "204 Created", response.Response.Status)
+			require.Equal(t, "201 Created", response.Response.Status)
 		})
 	}
 }
@@ -588,7 +588,7 @@ func Test_handleCreateTask_ExistingCarePlan(t *testing.T) {
 			require.NoError(t, err)
 			assert.Len(t, notifications, 1)
 			require.Equal(t, "Task/3", *response.Response.Location)
-			require.Equal(t, "204 Created", response.Response.Status)
+			require.Equal(t, "201 Created", response.Response.Status)
 		})
 	}
 }

--- a/orchestrator/careplanservice/service.go
+++ b/orchestrator/careplanservice/service.go
@@ -150,7 +150,7 @@ func (s *Service) RegisterHandlers(mux *http.ServeMux) {
 	// Creating a resource
 	mux.HandleFunc("POST "+basePath+"/{type}", s.profile.Authenticator(baseUrl, func(httpResponse http.ResponseWriter, request *http.Request) {
 		resourceType := request.PathValue("type")
-		s.handleCreateOrUpdate(request, httpResponse, resourceType, "CarePlanService/Create"+resourceType)
+		s.handleModification(request, httpResponse, resourceType, "CarePlanService/Create"+resourceType)
 	}))
 	// Searching for a resource via POST
 	mux.HandleFunc("POST "+basePath+"/{type}/_search", s.profile.Authenticator(baseUrl, func(httpResponse http.ResponseWriter, request *http.Request) {
@@ -169,12 +169,12 @@ func (s *Service) RegisterHandlers(mux *http.ServeMux) {
 	mux.HandleFunc("PUT "+basePath+"/{type}/{id}", s.profile.Authenticator(baseUrl, func(httpResponse http.ResponseWriter, request *http.Request) {
 		resourceType := request.PathValue("type")
 		resourceId := request.PathValue("id")
-		s.handleCreateOrUpdate(request, httpResponse, resourceType+"/"+resourceId, "CarePlanService/Update"+resourceType)
+		s.handleModification(request, httpResponse, resourceType+"/"+resourceId, "CarePlanService/Update"+resourceType)
 	}))
 	// Updating a resource by selecting it based on query params
 	mux.HandleFunc("PUT "+basePath+"/{type}", s.profile.Authenticator(baseUrl, func(httpResponse http.ResponseWriter, request *http.Request) {
 		resourceType := request.PathValue("type")
-		s.handleCreateOrUpdate(request, httpResponse, resourceType, "CarePlanService/Update"+resourceType)
+		s.handleModification(request, httpResponse, resourceType, "CarePlanService/Update"+resourceType)
 	}))
 	// Handle reading a specific resource instance
 	mux.HandleFunc("GET "+basePath+"/{type}/{id}", s.profile.Authenticator(baseUrl, func(httpResponse http.ResponseWriter, request *http.Request) {
@@ -185,12 +185,12 @@ func (s *Service) RegisterHandlers(mux *http.ServeMux) {
 	if s.allowUnmanagedFHIROperations {
 		mux.HandleFunc("DELETE "+basePath+"/{type}", s.profile.Authenticator(baseUrl, func(httpResponse http.ResponseWriter, request *http.Request) {
 			resourceType := request.PathValue("type")
-			s.handleCreateOrUpdate(request, httpResponse, resourceType, "CarePlanService/Delete"+resourceType)
+			s.handleModification(request, httpResponse, resourceType, "CarePlanService/Delete"+resourceType)
 		}))
 		mux.HandleFunc("DELETE "+basePath+"/{type}/{id}", s.profile.Authenticator(baseUrl, func(httpResponse http.ResponseWriter, request *http.Request) {
 			resourceType := request.PathValue("type")
 			resourceID := request.PathValue("id")
-			s.handleCreateOrUpdate(request, httpResponse, resourceType+"/"+resourceID, "CarePlanService/Delete"+resourceType)
+			s.handleModification(request, httpResponse, resourceType+"/"+resourceID, "CarePlanService/Delete"+resourceType)
 		}))
 	}
 }
@@ -275,7 +275,7 @@ func (s *Service) handleUnmanagedOperation(request FHIRHandlerRequest, tx *coolf
 	}, nil
 }
 
-func (s *Service) handleCreateOrUpdate(httpRequest *http.Request, httpResponse http.ResponseWriter, resourcePath string, operationName string) {
+func (s *Service) handleModification(httpRequest *http.Request, httpResponse http.ResponseWriter, resourcePath string, operationName string) {
 	tx := coolfhir.Transaction()
 	var bodyBytes []byte
 	if httpRequest.Body != nil {

--- a/orchestrator/go.mod
+++ b/orchestrator/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.1
 	github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus v1.7.4
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates v1.3.0
-	github.com/SanteonNL/go-fhir-client v0.2.16
+	github.com/SanteonNL/go-fhir-client v0.3.0
 	github.com/SanteonNL/nuts-policy-enforcement-point v0.0.0-20240805130644-8b92f1cbf865
 	github.com/beevik/etree v1.4.1
 	github.com/braineet/saml v0.4.15

--- a/orchestrator/go.sum
+++ b/orchestrator/go.sum
@@ -31,6 +31,8 @@ github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/SanteonNL/go-fhir-client v0.2.16 h1:XwNxJXiGU7QPjkTGIbXeME7ZNYBbrSBIKqCZB5/uv5A=
 github.com/SanteonNL/go-fhir-client v0.2.16/go.mod h1:CcU6J3vgxsdjTWry0s2BAJcV6SvdaRTsry9ixR7zqc4=
+github.com/SanteonNL/go-fhir-client v0.3.0 h1:7w82+W2BmOLFBLm1iPZnFuL9/XMMsqbbxARZf1nrrxk=
+github.com/SanteonNL/go-fhir-client v0.3.0/go.mod h1:CcU6J3vgxsdjTWry0s2BAJcV6SvdaRTsry9ixR7zqc4=
 github.com/SanteonNL/nuts-policy-enforcement-point v0.0.0-20240805130644-8b92f1cbf865 h1:luArkUx6tzRw/t6bI0kB1FdUJIqukSEanJeEIP9613I=
 github.com/SanteonNL/nuts-policy-enforcement-point v0.0.0-20240805130644-8b92f1cbf865/go.mod h1:mLVFlPbfU6lbrE/TeUQOpDC53aTC/PyOGYgPIR0S1Yw=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=

--- a/orchestrator/lib/coolfhir/bundle_test.go
+++ b/orchestrator/lib/coolfhir/bundle_test.go
@@ -145,7 +145,7 @@ func TestFetchBundleEntry(t *testing.T) {
 		require.NotEmpty(t, actualEntry.Resource)
 		require.Equal(t, "200", actualEntry.Response.Status)
 	})
-	t.Run("resource read from request BundleEntry.request.url, which doesn't contain a local reference nor logical identifier (not supported now)", func(t *testing.T) {
+	t.Run("delete with 204 No Content", func(t *testing.T) {
 		requestEntry := &fhir.BundleEntry{
 			Request: &fhir.BundleEntryRequest{
 				Url: "Task",
@@ -153,11 +153,14 @@ func TestFetchBundleEntry(t *testing.T) {
 		}
 		responseEntry := &fhir.BundleEntry{
 			Response: &fhir.BundleEntryResponse{
-				Status: "200",
+				Status: "204 No Content",
 			},
 		}
-		_, err := NormalizeTransactionBundleResponseEntry(ctx, fhirClient, fhirBaseUrl, requestEntry, responseEntry, nil)
-		require.EqualError(t, err, "failed to determine resource for transaction response bundle entry, see log for more details")
+		var actualResult fhir.Task
+		actualEntry, err := NormalizeTransactionBundleResponseEntry(ctx, fhirClient, fhirBaseUrl, requestEntry, responseEntry, &actualResult)
+		require.NoError(t, err)
+		require.Nil(t, actualEntry.Resource)
+		require.Equal(t, "204 No Content", actualEntry.Response.Status)
 	})
 	t.Run("result to unmarshal into is nil", func(t *testing.T) {
 		responseEntry := &fhir.BundleEntry{

--- a/orchestrator/lib/coolfhir/proxy.go
+++ b/orchestrator/lib/coolfhir/proxy.go
@@ -150,6 +150,8 @@ func (f *FHIRClientProxy) ServeHTTP(httpResponseWriter http.ResponseWriter, requ
 		}
 	case http.MethodPut:
 		err = f.client.UpdateWithContext(request.Context(), outRequestUrl.Path, requestResource, &responseResource, params...)
+	case http.MethodDelete:
+		err = f.client.DeleteWithContext(request.Context(), outRequestUrl.Path, params...)
 	default:
 		SendResponse(httpResponseWriter, http.StatusMethodNotAllowed, BadRequest("Method not allowed: %s", request.Method))
 		return

--- a/orchestrator/lib/test/fhirclient.go
+++ b/orchestrator/lib/test/fhirclient.go
@@ -160,6 +160,16 @@ func (s StubFHIRClient) UpdateWithContext(ctx context.Context, path string, reso
 	panic("implement me")
 }
 
+func (s StubFHIRClient) Delete(path string, opts ...fhirclient.Option) error {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (s StubFHIRClient) DeleteWithContext(ctx context.Context, path string, opts ...fhirclient.Option) error {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (s StubFHIRClient) Path(path ...string) *url.URL {
 	panic("implement me")
 }


### PR DESCRIPTION
Useful for cleaning up test data, since testing sometimes involves creating a new patient in the downstream EHR.

This allows parties to delete the related resources (e.g. Task, CarePlan, ServiceRequest and Patient) and re-send the order.

A lot of the changes are associated with FHIR API returning no response body in case the delete succeeds (204 No Content)