### PR TITLE
INT-568: Fix proxy to CPS to work with exteral CPS' too (used by Viewer)

### DIFF
--- a/orchestrator/cmd/profile/nuts/profile.go
+++ b/orchestrator/cmd/profile/nuts/profile.go
@@ -96,7 +96,7 @@ func (d DutchNutsProfile) HttpClient(ctx context.Context, serverIdentity fhir.Id
 	var authzServerURL string
 	switch to.EmptyString(serverIdentity.System) {
 	case "https://build.fhir.org/http.html#root":
-		log.Ctx(ctx).Info().Msg("Using CapabilityStatement for OAuth2 token acquisition")
+		log.Ctx(ctx).Trace().Msg("Using CapabilityStatement for OAuth2 token acquisition")
 		// FHIR base URL: need to look up CapabilityStatement
 		capabilityStatement, err := d.readCapabilityStatement(ctx, *serverIdentity.Value)
 		if err != nil {
@@ -121,7 +121,7 @@ func (d DutchNutsProfile) HttpClient(ctx context.Context, serverIdentity fhir.Id
 			return nil, fmt.Errorf("no OAuth Authorization Server URL found in CapabilityStatement, expected at CapabilityStatement.rest.security.service.extension[%s]", nutsAuthorizationServerExtensionURL)
 		}
 	case coolfhir.URANamingSystem:
-		log.Ctx(ctx).Info().Msg("Using CSD lookup for OAuth2 token acquisition")
+		log.Ctx(ctx).Trace().Msg("Using CSD lookup for OAuth2 token acquisition")
 		// Care Plan Contributor: need to look up authz server URL in CSD
 		authServerURLEndpoints, err := d.csd.LookupEndpoint(ctx, &serverIdentity, authzServerURLEndpointName)
 		if err != nil {
@@ -135,7 +135,7 @@ func (d DutchNutsProfile) HttpClient(ctx context.Context, serverIdentity fhir.Id
 		return nil, fmt.Errorf("unsupported server identity system: %s", *serverIdentity.System)
 	}
 
-	log.Ctx(ctx).Info().Msg("Authorization server URL: " + authzServerURL)
+	log.Ctx(ctx).Debug().Msgf("Using OAuth2 Authorization Server URL: %s", authzServerURL)
 	parsedAuthzServerURL, err := url.Parse(authzServerURL)
 	if err != nil {
 		return nil, err

--- a/orchestrator/cmd/profile/nuts/profile.go
+++ b/orchestrator/cmd/profile/nuts/profile.go
@@ -135,6 +135,7 @@ func (d DutchNutsProfile) HttpClient(ctx context.Context, serverIdentity fhir.Id
 		return nil, fmt.Errorf("unsupported server identity system: %s", *serverIdentity.System)
 	}
 
+	log.Ctx(ctx).Info().Msg("Authorization server URL: " + authzServerURL)
 	parsedAuthzServerURL, err := url.Parse(authzServerURL)
 	if err != nil {
 		return nil, err

--- a/orchestrator/cmd/profile/nuts/profile.go
+++ b/orchestrator/cmd/profile/nuts/profile.go
@@ -289,7 +289,7 @@ func (d DutchNutsProfile) CapabilityStatement(cp *fhir.CapabilityStatement) {
 			Extension: []fhir.Extension{
 				{
 					Url:         nutsAuthorizationServerExtensionURL,
-					ValueString: to.Ptr(d.Config.Public.URL),
+					ValueString: to.Ptr(d.Config.Public.Parse().JoinPath("oauth2", d.Config.OwnSubject).String()),
 				},
 			},
 		})

--- a/orchestrator/cmd/profile/nuts/profile.go
+++ b/orchestrator/cmd/profile/nuts/profile.go
@@ -96,7 +96,7 @@ func (d DutchNutsProfile) HttpClient(ctx context.Context, serverIdentity fhir.Id
 	var authzServerURL string
 	switch to.EmptyString(serverIdentity.System) {
 	case "https://build.fhir.org/http.html#root":
-		log.Ctx(ctx).Info().Msg("Using CSD lookup for OAuth2 token acquisition")
+		log.Ctx(ctx).Info().Msg("Using CapabilityStatement for OAuth2 token acquisition")
 		// FHIR base URL: need to look up CapabilityStatement
 		capabilityStatement, err := d.readCapabilityStatement(ctx, *serverIdentity.Value)
 		if err != nil {

--- a/orchestrator/cmd/profile/nuts/profile.go
+++ b/orchestrator/cmd/profile/nuts/profile.go
@@ -33,7 +33,7 @@ const nutsAuthorizationServerExtensionURL = "http://santeonnl.github.io/shared-c
 
 var uziOtherNameUraRegex = regexp.MustCompile("^[0-9.]+-\\d+-\\d+-S-(\\d+)-00\\.000-\\d+$")
 var oauthRestfulSecurityServiceCoding = fhir.Coding{
-	System: to.Ptr("http://terminology.hl7.org/CodeSystem/restful-security-service"),
+	System: to.Ptr("http://hl7.org/fhir/ValueSet/restful-security-service"),
 	Code:   to.Ptr("OAuth"),
 }
 

--- a/orchestrator/cmd/profile/nuts/profile_test.go
+++ b/orchestrator/cmd/profile/nuts/profile_test.go
@@ -383,12 +383,12 @@ func TestDutchNutsProfile_HttpClient(t *testing.T) {
 											Code:   to.Ptr("OAuth"),
 										},
 									},
-								},
-							},
-							Extension: []fhir.Extension{
-								{
-									Url:         "http://santeonnl.github.io/shared-care-planning/StructureDefinition/Nuts#AuthorizationServer",
-									ValueString: to.Ptr(fhirBaseURL + "/authz"),
+									Extension: []fhir.Extension{
+										{
+											Url:         "http://santeonnl.github.io/shared-care-planning/StructureDefinition/Nuts#AuthorizationServer",
+											ValueString: to.Ptr(fhirBaseURL + "/authz"),
+										},
+									},
 								},
 							},
 						},
@@ -465,7 +465,7 @@ func TestDutchNutsProfile_CapabilityStatement(t *testing.T) {
             ],
             "coding": [
               {
-                "system": "http://terminology.hl7.org/CodeSystem/restful-security-service",
+                "system": "http://hl7.org/fhir/ValueSet/restful-security-service",
                 "code": "OAuth"
               }
             ]

--- a/orchestrator/cmd/profile/nuts/profile_test.go
+++ b/orchestrator/cmd/profile/nuts/profile_test.go
@@ -438,7 +438,8 @@ func TestDutchNutsProfile_CapabilityStatement(t *testing.T) {
 	}
 	profile := DutchNutsProfile{
 		Config: Config{
-			Public: PublicConfig{URL: "https://example.com"},
+			Public:     PublicConfig{URL: "https://example.com"},
+			OwnSubject: "sub",
 		},
 	}
 	profile.CapabilityStatement(&md)
@@ -460,7 +461,7 @@ func TestDutchNutsProfile_CapabilityStatement(t *testing.T) {
             "extension": [
               {
                 "url": "http://santeonnl.github.io/shared-care-planning/StructureDefinition/Nuts#AuthorizationServer",
-                "valueString": "https://example.com"
+                "valueString": "https://example.com/oauth2/sub"
               }
             ],
             "coding": [

--- a/orchestrator/cmd/profile/nuts/profile_test.go
+++ b/orchestrator/cmd/profile/nuts/profile_test.go
@@ -427,3 +427,54 @@ func TestNew(t *testing.T) {
 		require.NotNil(t, profile.clientCert)
 	})
 }
+
+func TestDutchNutsProfile_CapabilityStatement(t *testing.T) {
+	md := fhir.CapabilityStatement{
+		Rest: []fhir.CapabilityStatementRest{
+			{
+				Mode: fhir.RestfulCapabilityModeServer,
+			},
+		},
+	}
+	profile := DutchNutsProfile{
+		Config: Config{
+			Public: PublicConfig{URL: "https://example.com"},
+		},
+	}
+	profile.CapabilityStatement(&md)
+	actual, err := json.Marshal(md)
+	require.NoError(t, err)
+	expected := `
+{
+  "status": "draft",
+  "date": "",
+  "kind": "instance",
+  "fhirVersion": "0.01",
+  "format": null,
+  "rest": [
+    {
+      "mode": "server",
+      "security": {
+        "service": [
+          {
+            "extension": [
+              {
+                "url": "http://santeonnl.github.io/shared-care-planning/StructureDefinition/Nuts#AuthorizationServer",
+                "valueString": "https://example.com"
+              }
+            ],
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/restful-security-service",
+                "code": "OAuth"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
+  "resourceType": "CapabilityStatement"
+}`
+	assert.JSONEq(t, expected, string(actual))
+}


### PR DESCRIPTION
The endpoint for the EHR (e.g. Viewer Demo app) to exchange with the CPS only worked with the local CPS. But, in case of Zorg bij jou, the CPS is remote (e.g. Faux Care, SAZ or ZPF).
Currently (broken), it always requests an access token at the local Nuts node to talk with the (assumed local) CPS, but this is wrong; it should look up the authorization server using the CapabilityStatement of the CPS.

This was broken by the earlier INT-568 change.

In the future, this should be optimized by the endpoint knowing whether it's the local CPS (then it can dispatch internally and doesn't need to go through the Nuts access token flow) or a remote one.