### PR TITLE
INT-589 | Always send bundle to demo endpoint if set

### DIFF
--- a/orchestrator/careplancontributor/ehr/servicebus_client_test.go
+++ b/orchestrator/careplancontributor/ehr/servicebus_client_test.go
@@ -86,6 +86,16 @@ func TestNewClient(t *testing.T) {
 			expectType: &ServiceBusClientImpl{},
 			expectErr:  false,
 		},
+		{
+			name: "ServiceBusClientImpl with valid config and demo endpoint set",
+			config: ServiceBusConfig{
+				Enabled:      true,
+				DebugOnly:    false,
+				DemoEndpoint: "http://localhost:8080",
+			},
+			expectType: &ServiceBusClientImpl{},
+			expectErr:  false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Creates a demo messenger client if the demo viewer endpoint is set, and the app is not running in strict mode. This way, bundles are delivered to the configured viewer over HTTP for demo purposes, and the existing serrvicebus client still runs, allowing us to test both