### PR TITLE
INT-386 | Disable requirement for CPS URL in CPC

### DIFF
--- a/orchestrator/careplancontributor/config.go
+++ b/orchestrator/careplancontributor/config.go
@@ -42,9 +42,6 @@ func (c Config) Validate() error {
 	if !c.Enabled {
 		return nil
 	}
-	if c.CarePlanService.URL == "" {
-		return errors.New("careplancontributor.careplanservice.url is not configured")
-	}
 	return nil
 }
 

--- a/orchestrator/careplancontributor/config_test.go
+++ b/orchestrator/careplancontributor/config_test.go
@@ -11,12 +11,6 @@ func TestConfig_Validate(t *testing.T) {
 		err := Config{}.Validate()
 		require.NoError(t, err)
 	})
-	t.Run("missing care plan service URL", func(t *testing.T) {
-		err := Config{
-			Enabled: true,
-		}.Validate()
-		require.EqualError(t, err, "careplancontributor.careplanservice.url is not configured")
-	})
 }
 
 func TestDefaultConfig(t *testing.T) {


### PR DESCRIPTION
CPS is not required in CPC as we add support for multiple CPS's, if the CPS URL is not set then the proxy method will fail