### PR TITLE
INT-596 | Implement webhook handler

### DIFF
--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -6,12 +6,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	events "github.com/SanteonNL/orca/orchestrator/careplancontributor/event"
-	"github.com/SanteonNL/orca/orchestrator/careplancontributor/webhook"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
+
+	events "github.com/SanteonNL/orca/orchestrator/careplancontributor/event"
+	"github.com/SanteonNL/orca/orchestrator/careplancontributor/webhook"
 
 	"github.com/SanteonNL/orca/orchestrator/careplanservice"
 
@@ -96,9 +97,7 @@ func New(
 	// Register event handlers
 	eventManager := events.NewInMemoryManager()
 	for _, handler := range config.Events.WebHooks {
-		err := eventManager.Subscribe(handler.ResourceType, handler.Name, webhook.EventHandler{
-			URL: handler.URL,
-		}.Handle)
+		err := eventManager.Subscribe(handler.ResourceType, handler.Name, webhook.NewEventHandler(handler.URL).Handle)
 		if err != nil {
 			return nil, fmt.Errorf("failed to subscribe to event %s: %w", handler.Name, err)
 		}

--- a/orchestrator/careplancontributor/webhook/eventhandler.go
+++ b/orchestrator/careplancontributor/webhook/eventhandler.go
@@ -1,16 +1,62 @@
 package webhook
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
 	events "github.com/SanteonNL/orca/orchestrator/careplancontributor/event"
+	"github.com/rs/zerolog/log"
 )
+
+// See: https://go.googlesource.com/go/+/refs/tags/go1.20.4/src/net/http/server.go#1098
+const maxPostHandlerReadBytes = 256 << 10
 
 var _ events.Handler = EventHandler{}
 
+func disposeResponseBody(r io.ReadCloser) {
+	if _, err := io.CopyN(io.Discard, r, maxPostHandlerReadBytes); err != nil {
+		log.Error().Err(err).Msg("failed to read request body")
+	}
+}
+
 type EventHandler struct {
-	URL string
+	client *http.Client
+	URL    string
+}
+
+func NewEventHandler(url string) EventHandler {
+	return EventHandler{URL: url, client: &http.Client{}}
 }
 
 func (w EventHandler) Handle(ctx context.Context, event events.Instance) error {
-	panic("implement me")
+	data, err := json.Marshal(event.FHIRResource)
+	if err != nil {
+		return fmt.Errorf("failed to serialize event: %w", err)
+	}
+
+	request, err := http.NewRequestWithContext(ctx, "POST", w.URL, bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	request.Header.Add("Content-Type", "application/json")
+
+	response, err := w.client.Do(request)
+	if err != nil {
+		return fmt.Errorf("failed to send request: %w", err)
+	}
+
+	defer disposeResponseBody(response.Body)
+
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code: %d", response.StatusCode)
+	}
+
+	log.Ctx(ctx).Info().Msgf("Successfully sent event to webhook: %s", w.URL)
+
+	return nil
 }

--- a/orchestrator/careplancontributor/webhook/eventhandler_test.go
+++ b/orchestrator/careplancontributor/webhook/eventhandler_test.go
@@ -1,0 +1,103 @@
+package webhook
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	events "github.com/SanteonNL/orca/orchestrator/careplancontributor/event"
+	"github.com/stretchr/testify/require"
+)
+
+type unmarshallable struct{}
+
+func (u unmarshallable) MarshalJSON() ([]byte, error) {
+	return nil, errors.New("fail")
+}
+
+func TestEventHandler_Handle(t *testing.T) {
+	cancelled, cancel := context.WithCancel(context.TODO())
+	cancel()
+
+	tests := map[string]struct {
+		event         events.Instance
+		expectedError string
+		context       context.Context
+		handlerFunc   http.HandlerFunc
+	}{
+		"happy path": {
+			event:   events.Instance{FHIRResource: "noop"},
+			context: context.TODO(),
+			handlerFunc: func(w http.ResponseWriter, r *http.Request) {
+				defer r.Body.Close()
+
+				data, err := io.ReadAll(r.Body)
+				require.NoError(t, err)
+
+				require.Equal(t, "\"noop\"", string(data))
+				require.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+				w.WriteHeader(http.StatusOK)
+			},
+		},
+		"context canceled": {
+			event:         events.Instance{FHIRResource: "noop"},
+			context:       cancelled,
+			expectedError: "context canceled",
+			handlerFunc: func(w http.ResponseWriter, r *http.Request) {
+			},
+		},
+		"failed to marshal": {
+			event:         events.Instance{FHIRResource: unmarshallable{}},
+			context:       context.TODO(),
+			expectedError: "failed to serialize event",
+			handlerFunc:   func(w http.ResponseWriter, r *http.Request) {},
+		},
+		"failed to create request": {
+			event:         events.Instance{FHIRResource: "noop"},
+			context:       nil,
+			expectedError: "failed to create request",
+			handlerFunc: func(w http.ResponseWriter, r *http.Request) {
+			},
+		},
+		"failed to send request": {
+			event:         events.Instance{FHIRResource: "noop"},
+			context:       context.TODO(),
+			expectedError: "failed to send request",
+			handlerFunc: func(w http.ResponseWriter, r *http.Request) {
+				panic("stop")
+			},
+		},
+		"unexpected HTTP status": {
+			event:         events.Instance{FHIRResource: "noop"},
+			context:       context.TODO(),
+			expectedError: "unexpected status code: 500",
+			handlerFunc: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(tt.handlerFunc))
+			defer server.Close()
+
+			handler := EventHandler{
+				client: server.Client(),
+				URL:    server.URL,
+			}
+
+			err := handler.Handle(tt.context, tt.event)
+
+			if tt.expectedError == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, tt.expectedError)
+			}
+		})
+	}
+}

--- a/orchestrator/cmd/profile/nuts/csd.go
+++ b/orchestrator/cmd/profile/nuts/csd.go
@@ -4,14 +4,15 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
 	"github.com/SanteonNL/orca/orchestrator/lib/csd"
 	"github.com/SanteonNL/orca/orchestrator/lib/to"
 	"github.com/nuts-foundation/go-nuts-client/nuts/discovery"
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
-	"net/http"
-	"sync"
-	"time"
 )
 
 var _ csd.Directory = &CsdDirectory{}


### PR DESCRIPTION
Basic webhook handler implementation. Sends a POST request containing the full resource encoded in JSON. Expects a HTTP 200 to succeed. Also tested manually.