### PR TITLE
Set careplan author on creation

### DIFF
--- a/orchestrator/careplanservice/handle_createtask.go
+++ b/orchestrator/careplanservice/handle_createtask.go
@@ -137,6 +137,7 @@ func (s *Service) handleCreateTask(ctx context.Context, request FHIRHandlerReque
 		}
 		carePlan.Subject = *task.For
 		carePlan.Status = fhir.RequestStatusActive
+		carePlan.Author = task.Requester
 
 		task.BasedOn = []fhir.Reference{
 			{


### PR DESCRIPTION
According to the [SCP specification](https://santeonnl.github.io/shared-care-planning/overview.html#careplan) the author should be set for a CarePlan. However, whenever a new CarePlan is created (based on a Task), it doesn't set the author.