### PR TITLE
INT-626: Hospital Simulator | BUG, mock BSN is not 9 digits

### DIFF
--- a/hospital_simulator/app/(DashboardLayout)/components/service-requests/create-service-request-dialog.tsx
+++ b/hospital_simulator/app/(DashboardLayout)/components/service-requests/create-service-request-dialog.tsx
@@ -174,7 +174,8 @@ function createServiceRequestBundle(firstName: string, lastName: string, conditi
     }
     const performerIdentifier = performer.identifier[0]
 
-    const patientBsn = Date.now();
+    let patientBsn = "" + Date.now()
+    patientBsn = patientBsn.substring(patientBsn.length - 9, patientBsn.length)
 
     return {
         "resourceType": "Bundle",


### PR DESCRIPTION
The BSN is defined as a 9 digit number. Using something different breaks stuff on the other side of the integration.

Fix: Limit patient BSN to 9 characters in service request. Updated the logic for generating patient BSN to ensure it is a 9-character string. 