### PR TITLE
INT-573: Added a styled error page for uncaught exceptions. 

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,1 +1,2 @@
 TERMINOLOGY_SERVER_BASE_URL=https://terminologieserver.nl/fhir
+SUPPORT_CONTACT_LINK=mailto:support@fauxcare.zorgbijjou.com #This link will be shown at the bottom of the error.tsx page if configured

--- a/frontend/app/actions.ts
+++ b/frontend/app/actions.ts
@@ -1,0 +1,4 @@
+"use server"
+export async function getSupportContactLink() {
+    return process.env.SUPPORT_CONTACT_LINK
+}

--- a/frontend/app/error.tsx
+++ b/frontend/app/error.tsx
@@ -1,0 +1,72 @@
+'use client' // Error boundaries must be Client Components
+
+import { Button } from '@/components/ui/button'
+import { RefreshCw, AlertTriangle } from 'lucide-react'
+import { getSupportContactLink } from './actions'
+import { useEffect, useState } from 'react'
+
+export default function Error({
+    error,
+    reset,
+}: {
+    error: Error & { digest?: string }
+    reset: () => void
+}) {
+    const [supportContactLink, setSupportContactLink] = useState<string>()
+
+    useEffect(() => {
+
+        const fetchSupportContactLink = async () => {
+            const link = await getSupportContactLink()
+            setSupportContactLink(link)
+        }
+
+        if (!supportContactLink) fetchSupportContactLink()
+    }, [])
+
+    return (
+        <div className="min-h-screen flex flex-col justify-center items-center bg-gray-50">
+            <div className="max-w-3xl bg-white shadow-md rounded-xl p-8 space-y-6">
+                <div className="flex items-center space-x-3">
+                    <AlertTriangle className="text-primary" size={30} />
+                    <h2 className="text-2xl font-semibold text-gray-800">
+                        Oeps, er ging iets mis!
+                    </h2>
+                </div>
+
+                <p className="text-gray-600">
+                    {error.message || 'Er is een onverwachte fout opgetreden. Probeer het later opnieuw.'}
+                </p>
+
+                <h3 className="text-lg font-semibold text-gray-800">
+                    Tijdelijke fout?
+                </h3>
+                <p className="text-gray-600">
+                    Tijdelijke fouten kunnen soms opgelost worden door ze opnieuw te proberen. Gebruik de onderstaande knop om het opnieuw te proberen.
+                </p>
+                <Button onClick={reset}>
+                    <RefreshCw /> Opnieuw proberen
+                </Button>
+
+                <h3 className="text-xl font-semibold text-gray-800">
+                    Aanhoudende fout?
+                </h3>
+                <p className="text-gray-600">
+                    Indien de fout aanhoudt, neem dan contact op met support. Vermeld hierbij code
+                    <code className='bg-gray-100 text-gray-800 rounded px-2 py-1 ml-1'>
+                        {error.digest || '000000000'}
+                    </code> en tijdstip
+                    <code className='bg-gray-100 text-gray-800 rounded px-2 py-1 ml-1'>
+                        {new Date().toISOString() /* Print in UTC to avoid timezone issues */}
+                    </code>
+                    . Deze informatie helpt bij het gericht zoeken naar de oorzaak.
+                </p>
+                {supportContactLink && (
+                    <p className="text-sm text-gray-500">
+                        Neem <a href={supportContactLink} className="text-blue-600 hover:underline">contact</a> op.
+                    </p>
+                )}
+            </div>
+        </div>
+    )
+}


### PR DESCRIPTION
This error page contains a retry button and reports the `digest` and UTC timestamp of the error. The page instructs the user to send this information to support if the issue persists. The digest can be used to correlate to the error in the logs.

``` GET /enrollment/new 200 in 116ms
 ⨯ Error: Not implemented
    at ConfirmDataPreEnrollment (app/enrollment/new/page.tsx:8:8)
   6 | export default function ConfirmDataPreEnrollment() {
   7 |
>  8 |   throw new Error('Not implemented')
     |        ^
   9 |
  10 |   return (
  11 |     <Card className="border-0 shadow-none px-0"> {
  digest: '4196643865'
```

### Additional configuration
Added the `SUPPORT_CONTACT_LINK` env var to the frontend. When this is set, the "Neem contact op" subtext appears at the bottom, the the value is set as the anchor href. This can be a website, but also a `mailto:` of `tel:` link etc.

## Style
<img width="1047" alt="Screenshot 2025-02-20 at 20 38 30" src="https://github.com/user-attachments/assets/ad3a4d12-4b97-43b8-a98c-da37da7a61c8" />

