### PR TITLE
INT-572: Added 3 retries in the ZPF handleLaunch when the `getSession…

### DIFF
--- a/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
@@ -173,6 +173,8 @@ func newWithClients(ctx context.Context, sessionManager *user.SessionManager, co
 
 	result.secureTokenService = result
 	result.registerFhirClientFactory(config)
+	result.getSessionData = result.defaultGetSessionData
+
 	return result, nil
 }
 
@@ -189,6 +191,7 @@ type Service struct {
 	zorgplatformCert       *x509.Certificate
 	profile                profile.Provider
 	secureTokenService     SecureTokenService
+	getSessionData         func(ctx context.Context, accessToken string, launchContext LaunchContext) (*user.SessionData, error)
 	// accessTokenCache stores the Zorgplatform access tokens a given CarePlan (from X-SCP-Context)
 	// Requesting an access token involves an, chained lookup, so we cache the result for some time.
 	accessTokenCache *ttlcache.Cache[string, string]
@@ -328,11 +331,21 @@ func (s *Service) handleLaunch(response http.ResponseWriter, request *http.Reque
 
 	log.Ctx(request.Context()).Info().Msgf("Successfully requested access token for HCP ProfessionalService, access_token=%s...", accessToken[:min(len(accessToken), 16)])
 
-	sessionData, err := s.getSessionData(request.Context(), accessToken, launchContext)
-	if err != nil {
-		log.Ctx(request.Context()).Err(err).Msg("unable to create session data")
-		http.Error(response, "Application launch failed.", http.StatusInternalServerError)
-		return
+	var sessionData *user.SessionData
+	// INT-572: Adding a retry mechanism, as in some cases the Patient returns a 404 when a new workflow is created and directly launched in HiX
+	for i := 1; i <= 3; i++ {
+		sessionData, err = s.getSessionData(request.Context(), accessToken, launchContext)
+		if err == nil {
+			break
+		}
+		if i < 3 {
+			log.Ctx(request.Context()).Warn().Msg("unable to create session data, retrying")
+			time.Sleep(200 * time.Duration(i) * time.Millisecond)
+		} else {
+			log.Ctx(request.Context()).Err(err).Msg("unable to create session data - retry limit reached")
+			http.Error(response, "Application launch failed.", http.StatusInternalServerError)
+			return
+		}
 	}
 
 	s.sessionManager.Create(response, *sessionData)
@@ -434,7 +447,7 @@ func (s *Service) createZorgplatformApiClient(accessToken string) *http.Client {
 	}
 }
 
-func (s *Service) getSessionData(ctx context.Context, accessToken string, launchContext LaunchContext) (*user.SessionData, error) {
+func (s *Service) defaultGetSessionData(ctx context.Context, accessToken string, launchContext LaunchContext) (*user.SessionData, error) {
 	// New client that uses the access token
 	apiUrl, err := url.Parse(s.config.ApiUrl)
 	if err != nil {

--- a/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
@@ -40,6 +40,8 @@ const zorgplatformWorkflowIdSystem = "http://sts.zorgplatform.online/ws/claims/2
 // They expire after ca. 12 minutes, so this value is on the safe side.
 const accessTokenCacheTTL = time.Minute * 5
 
+var sleep = time.Sleep
+
 type workflowContext struct {
 	workflowId string
 	patientBsn string
@@ -333,14 +335,14 @@ func (s *Service) handleLaunch(response http.ResponseWriter, request *http.Reque
 
 	var sessionData *user.SessionData
 	// INT-572: Adding a retry mechanism, as in some cases the Patient returns a 404 when a new workflow is created and directly launched in HiX
-	for i := 1; i <= 3; i++ {
+	for i := 1; i <= 4; i++ {
 		sessionData, err = s.getSessionData(request.Context(), accessToken, launchContext)
 		if err == nil {
 			break
 		}
-		if i < 3 {
+		if i < 4 {
 			log.Ctx(request.Context()).Warn().Msg("unable to create session data, retrying")
-			time.Sleep(200 * time.Duration(i) * time.Millisecond)
+			sleep(200 * time.Duration(i) * time.Millisecond)
 		} else {
 			log.Ctx(request.Context()).Err(err).Msg("unable to create session data - retry limit reached")
 			http.Error(response, "Application launch failed.", http.StatusInternalServerError)

--- a/orchestrator/careplancontributor/applaunch/zorgplatform/service_test.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/service_test.go
@@ -12,11 +12,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	fhirclient "github.com/SanteonNL/go-fhir-client"
-	"github.com/SanteonNL/orca/orchestrator/globals"
-	"github.com/SanteonNL/orca/orchestrator/lib/must"
-	"github.com/SanteonNL/orca/orchestrator/lib/test"
-	"github.com/jellydator/ttlcache/v3"
 	"hash"
 	"net/http"
 	"net/http/httptest"
@@ -25,6 +20,12 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	fhirclient "github.com/SanteonNL/go-fhir-client"
+	"github.com/SanteonNL/orca/orchestrator/globals"
+	"github.com/SanteonNL/orca/orchestrator/lib/must"
+	"github.com/SanteonNL/orca/orchestrator/lib/test"
+	"github.com/jellydator/ttlcache/v3"
 
 	"github.com/stretchr/testify/assert"
 
@@ -271,6 +272,46 @@ func TestService(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, http.StatusBadRequest, launchHttpResponse.StatusCode)
 	})
+
+	t.Run("retry getSessionData 3 times - should work", func(t *testing.T) {
+		globals.CarePlanServiceFhirClient = &test.StubFHIRClient{}
+
+		// Mock getSessionData to fail twice before succeeding
+		callCount := 0
+		service.getSessionData = func(ctx context.Context, accessToken string, launchContext LaunchContext) (*user.SessionData, error) {
+			callCount++
+			if callCount < 3 {
+				return nil, errors.New("temporary error")
+			}
+			return service.defaultGetSessionData(ctx, accessToken, launchContext)
+		}
+
+		launchHttpResponse, err := client.PostForm(httpServer.URL+"/zorgplatform-app-launch", url.Values{
+			"SAMLResponse": {createSAMLResponse(t, certificate.Leaf)},
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, http.StatusFound, launchHttpResponse.StatusCode)
+		require.Equal(t, 3, callCount, "expected getSessionData to be called 3 times")
+	})
+
+	t.Run("Consistent error - should fail after 3 retries", func(t *testing.T) {
+		globals.CarePlanServiceFhirClient = &test.StubFHIRClient{}
+
+		callCount := 0
+		service.getSessionData = func(ctx context.Context, accessToken string, launchContext LaunchContext) (*user.SessionData, error) {
+			callCount++
+			return nil, errors.New("temporary error") //always throw an error
+		}
+
+		launchHttpResponse, _ := client.PostForm(httpServer.URL+"/zorgplatform-app-launch", url.Values{
+			"SAMLResponse": {createSAMLResponse(t, certificate.Leaf)},
+		})
+
+		require.Equal(t, http.StatusInternalServerError, launchHttpResponse.StatusCode)
+		require.Equal(t, 3, callCount, "expected getSessionData to be called 3 times")
+	})
+
 }
 
 func createSAMLResponse(t *testing.T, encryptionKey *x509.Certificate) string {


### PR DESCRIPTION
…Data() returns an error. During testing moments with ChipSoft, we seemed to sometiems get a 404 when a newly created workflow was quickly launched and the code tried to query the `Patient` bound to that workflow.