### PR TITLE
INT-337 | Create audit events in CPS

### DIFF
--- a/orchestrator/careplanservice/careteamservice/careteam_test.go
+++ b/orchestrator/careplanservice/careteamservice/careteam_test.go
@@ -1,8 +1,10 @@
 package careteamservice
 
 import (
+	"context"
 	"encoding/json"
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor/mock"
+	"github.com/SanteonNL/orca/orchestrator/lib/auth"
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
 	"github.com/stretchr/testify/require"
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
@@ -86,7 +88,7 @@ func TestUpdate(t *testing.T) {
 
 			// Perform
 			tx := coolfhir.Transaction()
-			updated, err := Update(fhirClient, "1", *tc.UpdatedTask(), tx)
+			updated, err := Update(auth.WithPrincipal(context.Background(), *auth.TestPrincipal1), fhirClient, "1", *tc.UpdatedTask(), tx)
 			require.NoError(t, err)
 
 			// Assert

--- a/orchestrator/careplanservice/handle_createtask_test.go
+++ b/orchestrator/careplanservice/handle_createtask_test.go
@@ -147,6 +147,24 @@ func Test_handleCreateTask_NoExistingCarePlan(t *testing.T) {
 					Status:   "201 Created",
 				},
 			},
+			{
+				Response: &fhir.BundleEntryResponse{
+					Location: to.Ptr("AuditEvent/4"),
+					Status:   "201 Created",
+				},
+			},
+			{
+				Response: &fhir.BundleEntryResponse{
+					Location: to.Ptr("AuditEvent/5"),
+					Status:   "201 Created",
+				},
+			},
+			{
+				Response: &fhir.BundleEntryResponse{
+					Location: to.Ptr("AuditEvent/6"),
+					Status:   "201 Created",
+				},
+			},
 		},
 	}
 	defaultTask := fhir.Task{

--- a/orchestrator/careplanservice/handle_updatetask.go
+++ b/orchestrator/careplanservice/handle_updatetask.go
@@ -5,29 +5,33 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
+
 	fhirclient "github.com/SanteonNL/go-fhir-client"
 	"github.com/SanteonNL/orca/orchestrator/careplanservice/careteamservice"
+	"github.com/SanteonNL/orca/orchestrator/lib/audit"
 	"github.com/SanteonNL/orca/orchestrator/lib/auth"
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
 	"github.com/SanteonNL/orca/orchestrator/lib/deep"
+	"github.com/SanteonNL/orca/orchestrator/lib/to"
 	"github.com/rs/zerolog/log"
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
-	"strings"
 )
 
 func (s *Service) handleUpdateTask(ctx context.Context, request FHIRHandlerRequest, tx *coolfhir.BundleBuilder) (FHIRHandlerResult, error) {
 	log.Ctx(ctx).Info().Msgf("Updating Task: %s", request.RequestUrl)
 	var task fhir.Task
-	if err := json.Unmarshal(request.ResourceData, &task); err != nil {
+	var err error
+	if err = json.Unmarshal(request.ResourceData, &task); err != nil {
 		return nil, fmt.Errorf("invalid %T: %w", task, coolfhir.BadRequestError(err))
 	}
 	// Check we're only allowing secure external literal references
-	if err := s.validateLiteralReferences(ctx, &task); err != nil {
+	if err = s.validateLiteralReferences(ctx, &task); err != nil {
 		return nil, err
 	}
 
 	// Validate fields on updated Task
-	err := coolfhir.ValidateTaskRequiredFields(task)
+	err = coolfhir.ValidateTaskRequiredFields(task)
 	if err != nil {
 		return nil, fmt.Errorf("invalid Task: %w", err)
 	}
@@ -74,12 +78,12 @@ func (s *Service) handleUpdateTask(ctx context.Context, request FHIRHandlerReque
 		return s.handleCreateTask(ctx, request, tx)
 	}
 
+	principal, err := auth.PrincipalFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
 	if task.Status != taskExisting.Status {
 		// If the status is changing, validate the transition
-		principal, err := auth.PrincipalFromContext(ctx)
-		if err != nil {
-			return nil, err
-		}
 		isOwner, isRequester := coolfhir.IsIdentifierTaskOwnerAndRequester(&taskExisting, principal.Organization.Identifier)
 		isScpSubTask := coolfhir.IsScpSubTask(&task)
 		if !isValidTransition(taskExisting.Status, task.Status, isOwner, isRequester, isScpSubTask) {
@@ -118,11 +122,22 @@ func (s *Service) handleUpdateTask(ctx context.Context, request FHIRHandlerReque
 	}
 	carePlanId := strings.TrimPrefix(*carePlanRef, "CarePlan/")
 
+	taskUpdateAuditEvent, err := audit.AuditEvent(ctx, fhir.AuditEventActionU, &fhir.Reference{
+		Reference: to.Ptr("Task/" + *task.Id)},
+		&fhir.Reference{
+			Identifier: &principal.Organization.Identifier[0],
+			Type:       to.Ptr("Organization"),
+		})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create audit event: %w", err)
+	}
+
 	taskBundleEntry := request.bundleEntryWithResource(task)
 	tx = tx.AppendEntry(taskBundleEntry)
 	idx := len(tx.Entry) - 1
+	tx = tx.Create(taskUpdateAuditEvent)
 	// Update care team
-	_, err = careteamservice.Update(s.fhirClient, carePlanId, task, tx)
+	_, err = careteamservice.Update(ctx, s.fhirClient, carePlanId, task, tx)
 	if err != nil {
 		return nil, fmt.Errorf("update CareTeam: %w", err)
 	}

--- a/orchestrator/careplanservice/handle_updatetask_test.go
+++ b/orchestrator/careplanservice/handle_updatetask_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/SanteonNL/orca/orchestrator/cmd/profile"
-	"github.com/SanteonNL/orca/orchestrator/lib/deep"
 	"net/url"
 	"os"
 	"reflect"
 	"testing"
+
+	"github.com/SanteonNL/orca/orchestrator/cmd/profile"
+	"github.com/SanteonNL/orca/orchestrator/lib/audit"
+	"github.com/SanteonNL/orca/orchestrator/lib/deep"
 
 	fhirclient "github.com/SanteonNL/go-fhir-client"
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor/mock"
@@ -458,6 +460,10 @@ func Test_handleUpdateTask(t *testing.T) {
 	carePlanBundleData, _ := os.ReadFile("./careteamservice/testdata/001-input.json")
 	require.NoError(t, json.Unmarshal(carePlanBundleData, &carePlanBundle))
 
+	var carePlan fhir.CarePlan
+	err := json.Unmarshal(carePlanBundle.Entry[0].Resource, &carePlan)
+	require.NoError(t, err)
+
 	ctrl := gomock.NewController(t)
 	fhirClient := mock.NewMockClient(ctrl)
 	service := &Service{
@@ -510,9 +516,11 @@ func Test_handleUpdateTask(t *testing.T) {
 		_, err := service.handleUpdateTask(ctx, request, tx)
 
 		require.NoError(t, err)
-		require.Len(t, tx.Entry, 2)
+		require.Len(t, tx.Entry, 4)
 		require.Equal(t, "Task?_id=1", tx.Entry[0].Request.Url)
 		require.Equal(t, fhir.HTTPVerbPUT, tx.Entry[0].Request.Method)
+		require.True(t, audit.VerifyAuditEvent(t, &tx.Entry[1], "Task/"+*task.Id, fhir.AuditEventActionU))
+		require.True(t, audit.VerifyAuditEvent(t, &tx.Entry[3], *carePlan.CareTeam[0].Reference, fhir.AuditEventActionU))
 	})
 	t.Run("task status isn't updated", func(t *testing.T) {
 		request := updateRequest(func(task *fhir.Task) {
@@ -523,8 +531,10 @@ func Test_handleUpdateTask(t *testing.T) {
 		_, err := service.handleUpdateTask(ctx, request, tx)
 
 		require.NoError(t, err)
-		require.Len(t, tx.Entry, 2)
+		require.Len(t, tx.Entry, 4)
 		require.Equal(t, fhir.HTTPVerbPUT, tx.Entry[0].Request.Method)
+		require.True(t, audit.VerifyAuditEvent(t, &tx.Entry[1], "Task/"+*task.Id, fhir.AuditEventActionU))
+		require.True(t, audit.VerifyAuditEvent(t, &tx.Entry[3], *carePlan.CareTeam[0].Reference, fhir.AuditEventActionU))
 	})
 	t.Run("original FHIR request headers are passed to outgoing Bundle entry", func(t *testing.T) {
 		request := updateRequest()

--- a/orchestrator/careplanservice/subscriptions/manager.go
+++ b/orchestrator/careplanservice/subscriptions/manager.go
@@ -119,6 +119,7 @@ func (r DerivingManager) notifyAll(ctx context.Context, instant time.Time, focus
 				Reference: to.Ptr("Subscription/" + uuid.NewString()),
 			}
 			// TODO: Read event number from store
+			// TODO: Do we need an audit event for subscription notifications?
 			notification := coolfhir.CreateSubscriptionNotification(r.FhirBaseURL, instant, subscription, 0, focus)
 			if err = channel.Notify(ctx, notification); err != nil {
 				errs <- fmt.Errorf("notify subscriber %s: %w", coolfhir.ToString(subscriber), err)

--- a/orchestrator/lib/audit/audit.go
+++ b/orchestrator/lib/audit/audit.go
@@ -1,0 +1,68 @@
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/SanteonNL/orca/orchestrator/lib/auth"
+	"github.com/SanteonNL/orca/orchestrator/lib/to"
+
+	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
+)
+
+var TimeNow = time.Now
+
+func AuditEvent(ctx context.Context, action fhir.AuditEventAction, resourceReference *fhir.Reference, actingAgentRef *fhir.Reference) (*fhir.AuditEvent, error) {
+	principal, err := auth.PrincipalFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	auditEvent := fhir.AuditEvent{
+		Agent: []fhir.AuditEventAgent{
+			{
+				Who: actingAgentRef,
+			},
+		},
+		Entity: []fhir.AuditEventEntity{
+			{
+				What: resourceReference,
+			},
+		},
+		Recorded: TimeNow().Format(time.RFC3339),
+		Action:   to.Ptr(fhir.AuditEventAction(action)),
+		Source: fhir.AuditEventSource{
+			// Local organisation i.e. orchestrator
+			Observer: fhir.Reference{
+				Identifier: &principal.Organization.Identifier[0],
+				Type:       to.Ptr("Organization"),
+			},
+		},
+	}
+
+	return &auditEvent, nil
+}
+
+// Helper method for testing/validation
+func VerifyAuditEvent(t *testing.T, entry *fhir.BundleEntry, resourceReference string, action fhir.AuditEventAction) bool {
+	var auditEvent fhir.AuditEvent
+	err := json.Unmarshal(entry.Resource, &auditEvent)
+	if err != nil {
+		return false
+	}
+
+	if auditEvent.Action == nil || *auditEvent.Action != action {
+		return false
+	}
+
+	foundAuditEvent := false
+	for _, event := range auditEvent.Entity {
+		if *event.What.Reference == resourceReference {
+			foundAuditEvent = true
+			break
+		}
+	}
+	return foundAuditEvent
+}

--- a/orchestrator/lib/audit/audit_test.go
+++ b/orchestrator/lib/audit/audit_test.go
@@ -1,0 +1,142 @@
+package audit
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/SanteonNL/orca/orchestrator/lib/auth"
+	"github.com/SanteonNL/orca/orchestrator/lib/to"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
+)
+
+func TestAuditEvent(t *testing.T) {
+	// Setup
+	fixedTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	TimeNow = func() time.Time { return fixedTime }
+	defer func() { TimeNow = time.Now }()
+
+	ctx := auth.WithPrincipal(context.Background(), *auth.TestPrincipal1)
+
+	tests := []struct {
+		name           string
+		action         fhir.AuditEventAction
+		resourceRef    *fhir.Reference
+		actingAgentRef *fhir.Reference
+		wantErr        bool
+	}{
+		{
+			name:   "valid audit event creation",
+			action: fhir.AuditEventActionC,
+			resourceRef: &fhir.Reference{
+				Reference: to.Ptr("Task/123"),
+				Type:      to.Ptr("Task"),
+			},
+			actingAgentRef: &fhir.Reference{
+				Identifier: &auth.TestPrincipal1.Organization.Identifier[0],
+				Type:       to.Ptr("Organization"),
+			},
+			wantErr: false,
+		},
+		{
+			name:   "missing principal in context",
+			action: fhir.AuditEventActionC,
+			resourceRef: &fhir.Reference{
+				Reference: to.Ptr("Task/123"),
+			},
+			actingAgentRef: &fhir.Reference{},
+			wantErr:        true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var testCtx context.Context
+			if tt.name == "missing principal in context" {
+				testCtx = context.Background()
+			} else {
+				testCtx = ctx
+			}
+
+			got, err := AuditEvent(testCtx, tt.action, tt.resourceRef, tt.actingAgentRef)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, fixedTime.Format(time.RFC3339), got.Recorded)
+			assert.Equal(t, tt.action, *got.Action)
+			assert.Equal(t, tt.resourceRef, got.Entity[0].What)
+			assert.Equal(t, tt.actingAgentRef, got.Agent[0].Who)
+		})
+	}
+}
+
+func TestVerifyAuditEvent(t *testing.T) {
+	tests := []struct {
+		name           string
+		entry          *fhir.BundleEntry
+		resourceRef    string
+		action         fhir.AuditEventAction
+		expectedResult bool
+	}{
+		{
+			name: "matching audit event",
+			entry: &fhir.BundleEntry{
+				Resource: []byte(`{
+					"resourceType": "AuditEvent",
+					"action": "C",
+					"entity": [{"what": {"reference": "Task/123"}}]
+				}`),
+			},
+			resourceRef:    "Task/123",
+			action:         fhir.AuditEventActionC,
+			expectedResult: true,
+		},
+		{
+			name: "non-matching action",
+			entry: &fhir.BundleEntry{
+				Resource: []byte(`{
+					"resourceType": "AuditEvent",
+					"action": "R",
+					"entity": [{"what": {"reference": "Task/123"}}]
+				}`),
+			},
+			resourceRef:    "Task/123",
+			action:         fhir.AuditEventActionC,
+			expectedResult: false,
+		},
+		{
+			name: "non-matching reference",
+			entry: &fhir.BundleEntry{
+				Resource: []byte(`{
+					"resourceType": "AuditEvent",
+					"action": "C",
+					"entity": [{"what": {"reference": "Task/456"}}]
+				}`),
+			},
+			resourceRef:    "Task/123",
+			action:         fhir.AuditEventActionC,
+			expectedResult: false,
+		},
+		{
+			name: "invalid json",
+			entry: &fhir.BundleEntry{
+				Resource: []byte(`invalid json`),
+			},
+			resourceRef:    "Task/123",
+			action:         fhir.AuditEventActionC,
+			expectedResult: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := VerifyAuditEvent(t, tt.entry, tt.resourceRef, tt.action)
+			assert.Equal(t, tt.expectedResult, result)
+		})
+	}
+}


### PR DESCRIPTION
Audit events are created for CRUD methods, these will be used in the future to validate resource access as well as for compliance on resource access