### PR TITLE
INT-646: Retry unauthorized requests with a fresh access token

### DIFF
--- a/orchestrator/go.mod
+++ b/orchestrator/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jellydator/ttlcache/v3 v3.3.0
 	github.com/knadh/koanf/providers/env v1.0.0
 	github.com/knadh/koanf/v2 v2.1.2
-	github.com/nuts-foundation/go-nuts-client v0.1.8
+	github.com/nuts-foundation/go-nuts-client v0.1.9
 	github.com/rs/zerolog v1.33.0
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.35.0

--- a/orchestrator/go.mod
+++ b/orchestrator/go.mod
@@ -10,14 +10,14 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus v1.8.0
 	github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azcertificates v1.3.1
 	github.com/SanteonNL/go-fhir-client v0.3.0
-	github.com/SanteonNL/nuts-policy-enforcement-point v0.0.0-20240805130644-8b92f1cbf865
+	github.com/SanteonNL/nuts-policy-enforcement-point v0.1.0
 	github.com/beevik/etree v1.5.0
 	github.com/braineet/saml v0.4.15
 	github.com/google/uuid v1.6.0
 	github.com/jellydator/ttlcache/v3 v3.3.0
 	github.com/knadh/koanf/providers/env v1.0.0
 	github.com/knadh/koanf/v2 v2.1.2
-	github.com/nuts-foundation/go-nuts-client v0.1.8-0.20250131065931-7e2bd8fd5976
+	github.com/nuts-foundation/go-nuts-client v0.1.8
 	github.com/rs/zerolog v1.33.0
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.35.0

--- a/orchestrator/go.sum
+++ b/orchestrator/go.sum
@@ -31,8 +31,8 @@ github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/SanteonNL/go-fhir-client v0.3.0 h1:7w82+W2BmOLFBLm1iPZnFuL9/XMMsqbbxARZf1nrrxk=
 github.com/SanteonNL/go-fhir-client v0.3.0/go.mod h1:CcU6J3vgxsdjTWry0s2BAJcV6SvdaRTsry9ixR7zqc4=
-github.com/SanteonNL/nuts-policy-enforcement-point v0.0.0-20240805130644-8b92f1cbf865 h1:luArkUx6tzRw/t6bI0kB1FdUJIqukSEanJeEIP9613I=
-github.com/SanteonNL/nuts-policy-enforcement-point v0.0.0-20240805130644-8b92f1cbf865/go.mod h1:mLVFlPbfU6lbrE/TeUQOpDC53aTC/PyOGYgPIR0S1Yw=
+github.com/SanteonNL/nuts-policy-enforcement-point v0.1.0 h1:tbkd8PvQC6+3VeNgq6HiBrdj81PFDAwiIbCbyFfdX9U=
+github.com/SanteonNL/nuts-policy-enforcement-point v0.1.0/go.mod h1:mLVFlPbfU6lbrE/TeUQOpDC53aTC/PyOGYgPIR0S1Yw=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62wh+A=
@@ -231,8 +231,8 @@ github.com/multiformats/go-multibase v0.2.0 h1:isdYCVLvksgWlMW9OZRYJEa9pZETFivnc
 github.com/multiformats/go-multibase v0.2.0/go.mod h1:bFBZX4lKCA/2lyOFSAoKH5SS6oPyjtnzK/XTFDPkNuk=
 github.com/nuts-foundation/go-did v0.15.0 h1:aNl6KC8jiyRJGl9PPKFBboLLC0wUm5h+tjE1UBDQEPw=
 github.com/nuts-foundation/go-did v0.15.0/go.mod h1:swjCJvcRxc+i1nyieIERWEb3vFb4N7iYC+qen2OIbNg=
-github.com/nuts-foundation/go-nuts-client v0.1.8-0.20250131065931-7e2bd8fd5976 h1:okPfjaMRJWAkMMU5iowwivxf1V1XsOPsEBsh2GfWkzg=
-github.com/nuts-foundation/go-nuts-client v0.1.8-0.20250131065931-7e2bd8fd5976/go.mod h1:/apCT1jOnplzvbAsP0GvTgMyUA0fPtesUDwi7VGEi5U=
+github.com/nuts-foundation/go-nuts-client v0.1.8 h1:sBzq6A20cda2bFhHG6x/+TtVtyV9Tm3IlzL8gkMTF00=
+github.com/nuts-foundation/go-nuts-client v0.1.8/go.mod h1:/apCT1jOnplzvbAsP0GvTgMyUA0fPtesUDwi7VGEi5U=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=

--- a/orchestrator/go.sum
+++ b/orchestrator/go.sum
@@ -233,6 +233,8 @@ github.com/nuts-foundation/go-did v0.15.0 h1:aNl6KC8jiyRJGl9PPKFBboLLC0wUm5h+tjE
 github.com/nuts-foundation/go-did v0.15.0/go.mod h1:swjCJvcRxc+i1nyieIERWEb3vFb4N7iYC+qen2OIbNg=
 github.com/nuts-foundation/go-nuts-client v0.1.8 h1:sBzq6A20cda2bFhHG6x/+TtVtyV9Tm3IlzL8gkMTF00=
 github.com/nuts-foundation/go-nuts-client v0.1.8/go.mod h1:/apCT1jOnplzvbAsP0GvTgMyUA0fPtesUDwi7VGEi5U=
+github.com/nuts-foundation/go-nuts-client v0.1.9 h1:008GwYhBieMGlwyrf/lZ+NkqBlHkXTuIKiv43MXlJeU=
+github.com/nuts-foundation/go-nuts-client v0.1.9/go.mod h1:/apCT1jOnplzvbAsP0GvTgMyUA0fPtesUDwi7VGEi5U=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=


### PR DESCRIPTION
The updated go-nuts-client retries the HTTP request with a fresh access token, acquired from the Nuts node with `Cache-Control: no-cache`.

Also see https://github.com/nuts-foundation/go-nuts-client/pull/3