### PR TITLE
INT-642 > INT-655: Create Observations from the MSC viewer

### DIFF
--- a/viewer_simulator/app/(DashboardLayout)/components/bgz/bgz-overview.tsx
+++ b/viewer_simulator/app/(DashboardLayout)/components/bgz/bgz-overview.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Bundle, BundleEntry, CarePlan, Task } from 'fhir/r4';
+import { BundleEntry, CarePlan } from 'fhir/r4';
 import CarePlanTable from './bgz-careplan-table';
 import { getBsn } from '@/utils/fhirUtils';
 import { headers } from 'next/headers'
@@ -19,7 +19,7 @@ export default async function BgzOverview() {
 
     try {
         // Get bundles from internal storage, join all entries
-        const notificationBundles = getNotificationBundles();
+        const notificationBundles = await getNotificationBundles();
         let entries = notificationBundles.flatMap(bundle => bundle.entry || []);
 
         //map all the resources to their reference as it contains CarePlans, Patients, Tasks and CareTeams
@@ -33,21 +33,25 @@ export default async function BgzOverview() {
         rows = entries?.filter((entries) => entries.resource?.resourceType === "CarePlan")
             .map((entry: any) => entry.resource as CarePlan)
             .map((carePlan: CarePlan) => {
-                const careTeam = carePlan.careTeam?.[0]?.reference ? resourceMap?.get(carePlan.careTeam[0].reference) : undefined;
+
+                // Find the careteam, first as a contained resource, otherwise as a referenced resource that has been notified
+                const careTeam =
+                    carePlan.contained?.find((resource: any) => resource.resourceType === "CareTeam") ??
+                    (carePlan.careTeam?.[0]?.reference ? resourceMap?.get(carePlan.careTeam[0].reference) : undefined);
 
                 if (!careTeam) {
                     console.warn(`No CareTeam found for CarePlan/${carePlan.id}`);
                 }
 
                 return {
-                    id: careTeam.id,
+                    id: careTeam?.id || "Uknown",
                     bsn: getBsn(carePlan),
                     category: carePlan.category?.[0]?.coding?.map(coding => coding.display).join(', ') ?? "Unknown",
                     carePlan,
                     careTeam,
                     status: carePlan.status,
                     lastUpdated: carePlan.meta?.lastUpdated ? new Date(carePlan.meta.lastUpdated) : new Date(),
-                    careTeamMembers: careTeam.participant?.map((participant: any) => {
+                    careTeamMembers: careTeam?.participant?.map((participant: any) => {
                         const display = participant.member.display ? participant.member.display + ' ' : '';
                         const ura = `(URA ${participant.member.identifier?.value || 'Unknown'})`;
                         return display + ura;

--- a/viewer_simulator/app/(DashboardLayout)/components/onboarding/accepted-task-overview.tsx
+++ b/viewer_simulator/app/(DashboardLayout)/components/onboarding/accepted-task-overview.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import EnrolledTaskTable from './enrolled-task-table';
-import {Bundle, BundleEntry, FhirResource, PractitionerRole, Task} from 'fhir/r4';
+import { BundleEntry, FhirResource, PractitionerRole, Task } from 'fhir/r4';
 import { headers } from 'next/headers'
-import {getNotificationBundles} from "@/app/api/delivery/storage";
+import { getNotificationBundles } from "@/app/api/delivery/storage";
 
 export default async function AcceptedTaskOverview() {
 
@@ -19,42 +19,42 @@ export default async function AcceptedTaskOverview() {
 
     try {
         // Get bundles from internal storage, join all entries
-        const notificationBundles = getNotificationBundles();
+        const notificationBundles = await getNotificationBundles();
         entries = notificationBundles.flatMap(bundle => bundle.entry || []);
         console.log(`Found [${entries?.length}] bundle resources`);
 
         if (entries?.length) {
             rows = entries.
-            filter((entries) => entries.resource?.resourceType === "Task").
-            map((entry: any) => {
-                const task = entry.resource as Task;
-                const bsn = task.for?.identifier?.value || "Unknown";
+                filter((entries) => entries.resource?.resourceType === "Task").
+                map((entry: any) => {
+                    const task = entry.resource as Task;
+                    const bsn = task.for?.identifier?.value || "Unknown";
 
-                const practitionerRole = task.contained?.find((resource: any) => resource.resourceType === "PractitionerRole") as PractitionerRole | undefined;
-                let practitionerRoleIdentifiers
-                if (practitionerRole) {
-                    practitionerRoleIdentifiers = practitionerRole.identifier
-                        ?.map((identifier: any) => `${identifier.system}|${identifier.value}`)
-                        .join(', ') || "Unknown";
-                }
+                    const practitionerRole = task.contained?.find((resource: any) => resource.resourceType === "PractitionerRole") as PractitionerRole | undefined;
+                    let practitionerRoleIdentifiers
+                    if (practitionerRole) {
+                        practitionerRoleIdentifiers = practitionerRole.identifier
+                            ?.map((identifier: any) => `${identifier.system}|${identifier.value}`)
+                            .join(', ') || "Unknown";
+                    }
 
-                //TODO: An optional improvement would be to fetch & cache the task.requester by identifier if the display is not set
-                return {
-                    id: task.id,
-                    requesterUra: task.requester?.identifier?.value ?? "Unknown",
-                    requesterName: task.requester?.display ?? "Unknown",
-                    practitionerRoleIdentifiers,
-                    performerUra: task.owner?.identifier?.value ?? "Unknown",
-                    performerName: task.owner?.display ?? "Unknown",
-                    isSubtask: !!task.partOf,
-                    patientBsn: bsn,
-                    serviceRequest: task.focus?.display ?? "Unknown",
-                    condition: task?.reasonCode?.text ?? task?.reasonCode?.coding?.[0].display ?? "",
-                    status: task.status,
-                    lastUpdated: task.meta?.lastUpdated ? new Date(task.meta.lastUpdated) : new Date(),
-                    task: task
-                };
-            });
+                    //TODO: An optional improvement would be to fetch & cache the task.requester by identifier if the display is not set
+                    return {
+                        id: task.id,
+                        requesterUra: task.requester?.identifier?.value ?? "Unknown",
+                        requesterName: task.requester?.display ?? "Unknown",
+                        practitionerRoleIdentifiers,
+                        performerUra: task.owner?.identifier?.value ?? "Unknown",
+                        performerName: task.owner?.display ?? "Unknown",
+                        isSubtask: !!task.partOf,
+                        patientBsn: bsn,
+                        serviceRequest: task.focus?.display ?? "Unknown",
+                        condition: task?.reasonCode?.text ?? task?.reasonCode?.coding?.[0].display ?? "",
+                        status: task.status,
+                        lastUpdated: task.meta?.lastUpdated ? new Date(task.meta.lastUpdated) : new Date(),
+                        task: task
+                    };
+                });
         }
     } catch (error) {
         console.error('Error occurred while fetching tasks:', error);

--- a/viewer_simulator/app/(DashboardLayout)/components/onboarding/create-task-observation.tsx
+++ b/viewer_simulator/app/(DashboardLayout)/components/onboarding/create-task-observation.tsx
@@ -1,0 +1,571 @@
+"use client"
+import React, { useState, useEffect } from "react"
+import { IconPencilPlus } from "@tabler/icons-react"
+import type { Observation, Task, Reference, Identifier } from "fhir/r4"
+import Dialog from "@mui/material/Dialog"
+import AppBar from "@mui/material/AppBar"
+import Toolbar from "@mui/material/Toolbar"
+import Typography from "@mui/material/Typography"
+import CloseIcon from "@mui/icons-material/Close"
+import Slide from "@mui/material/Slide"
+import type { TransitionProps } from "@mui/material/transitions"
+import {
+  Box,
+  IconButton,
+  TextField,
+  MenuItem,
+  Select,
+  FormControl,
+  InputLabel,
+  Button,
+  Grid,
+  FormHelperText,
+  Snackbar,
+  Alert,
+  CircularProgress,
+  Chip,
+  Portal,
+} from "@mui/material"
+import { DateTimePicker, LocalizationProvider } from "@mui/x-date-pickers"
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs"
+import dayjs from "dayjs"
+import "dayjs/locale/nl"
+
+const Transition = React.forwardRef(function Transition(
+  props: TransitionProps & {
+    children: React.ReactElement
+  },
+  ref: React.Ref<unknown>,
+) {
+  return <Slide direction="up" ref={ref} {...props} />
+})
+
+// Common observation categories in FHIR
+const observationCategories = [
+  { display: "Vital Signs", code: "vital-signs", system: "http://terminology.hl7.org/CodeSystem/observation-category" },
+  { display: "Laboratory", code: "laboratory", system: "http://terminology.hl7.org/CodeSystem/observation-category" },
+  { display: "Exam", code: "exam", system: "http://terminology.hl7.org/CodeSystem/observation-category" },
+  {
+    display: "Social History", code: "social-history", system: "http://terminology.hl7.org/CodeSystem/observation-category",
+  },
+  { display: "Imaging", code: "imaging", system: "http://terminology.hl7.org/CodeSystem/observation-category" },
+]
+
+// Common observation codes (LOINC)
+const observationCodes = [
+  { display: "Body Weight", code: "29463-7", system: "http://loinc.org" },
+  { display: "Body Height", code: "8302-2", system: "http://loinc.org" },
+  { display: "Heart rate", code: "8867-4", system: "http://loinc.org" },
+  { display: "Blood Pressure", code: "85354-9", system: "http://loinc.org" },
+  { display: "Body Temperature", code: "8310-5", system: "http://loinc.org" },
+  { display: "Respiratory Rate", code: "9279-1", system: "http://loinc.org" },
+  { display: "Oxygen Saturation", code: "59408-5", system: "http://loinc.org" },
+  { display: "Blood Glucose", code: "15074-8", system: "http://loinc.org" },
+]
+
+// Observation status options
+const statusOptions: Observation["status"][] = [
+  "registered",
+  "preliminary",
+  "final",
+  "amended",
+  "corrected",
+  "cancelled",
+  "entered-in-error",
+  "unknown",
+]
+
+const getUnitSuggestions = (code: string): string[] => {
+  // Return appropriate units based on the selected observation code
+  switch (code) {
+    case "29463-7": // Body Weight
+      return ["kg", "g", "lb"]
+    case "8302-2": // Body Height
+      return ["cm", "m", "in"]
+    case "8867-4": // Heart rate
+      return ["beats/min"]
+    case "85354-9": // Blood Pressure
+      return ["mmHg"]
+    case "8310-5": // Body Temperature
+      return ["°C", "°F"]
+    case "9279-1": // Respiratory Rate
+      return ["breaths/min"]
+    case "59408-5": // Oxygen Saturation
+      return ["%"]
+    case "15074-8": // Blood Glucose
+      return ["mg/dL", "mmol/L"]
+    default:
+      return []
+  }
+}
+
+/**
+ * Creates a reference if an identifier and/or absolute reference is present for cross-system compatibility.
+ * If only a relative reference is present, returns undefined.
+ */
+function createExternalReference(reference: Reference | undefined): Reference | undefined {
+  if (!reference) return undefined
+
+  const externalRef = { ...reference }
+
+  // If there is an absolute reference, return a basic reference
+  if (externalRef.reference && !externalRef.reference.startsWith("http")) {
+    externalRef.reference = undefined
+  }
+
+  // If the reference only contained a relative ref and no identifier, return undefined
+  if (!externalRef.reference && !externalRef.identifier?.value) {
+    return undefined
+  }
+
+  return externalRef
+}
+
+/**
+ * Extracts a display name from a reference or identifier
+ */
+function getDisplayFromReference(reference: Reference | undefined): string {
+  if (!reference) return "Unknown"
+
+  if (reference.display) {
+    return reference.display
+  }
+
+  if (reference.identifier?.value) {
+    return `${reference.type || "Resource"} (${reference.identifier.system?.split("/").pop() || "ID"}: ${reference.identifier.value})`
+  }
+
+  if (reference.reference) {
+    return reference.reference
+  }
+
+  return "Unknown"
+}
+
+/**
+ * Creates a task identifier that can be used for cross-system references
+ */
+function createTaskIdentifier(task: Task): Identifier | undefined {
+  // If task already has an identifier, use it
+  if (task.identifier && task.identifier.length > 0) {
+    return task.identifier[0]
+  }
+
+  // If task has a meta.source, use it to create an identifier
+  if (task.meta?.source) {
+    return {
+      system: `urn:source:${task.meta.source.replace(/^#/, "")}`,
+      value: task.id || "unknown",
+    }
+  }
+
+  // If task has an id but no other identifiers, create a basic one
+  if (task.id) {
+    return {
+      system: "urn:uuid:task",
+      value: task.id,
+    }
+  }
+
+  return undefined
+}
+
+export default function CreateTaskObservation({ task }: { task: Task }) {
+  const [open, setOpen] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [showSuccess, setShowSuccess] = useState(false)
+  const [patientDisplay, setPatientDisplay] = useState<string>("")
+  const [loading, setLoading] = useState(false)
+  const [taskIdentifier, setTaskIdentifier] = useState<Identifier | undefined>()
+
+  // Form state
+  const [status, setStatus] = useState<string>("preliminary")
+  const [category, setCategory] = useState<string>("vital-signs")
+  const [code, setCode] = useState<string>("")
+  const [effectiveDateTime, setEffectiveDateTime] = useState<dayjs.Dayjs | null>(dayjs())
+  const [valueQuantity, setValueQuantity] = useState<string>("")
+  const [valueUnit, setValueUnit] = useState<string>("")
+  const [note, setNote] = useState<string>("")
+
+  // Form validation
+  const [errors, setErrors] = useState<Record<string, string>>({})
+
+  // Extract patient information and task identifier when component mounts
+  useEffect(() => {
+    if (task) {
+      // Set patient display name
+      if (task.for) {
+        setPatientDisplay(getDisplayFromReference(task.for))
+      }
+
+      // Create task identifier for cross-system references
+      setTaskIdentifier(createTaskIdentifier(task))
+    }
+  }, [task])
+
+  const handleClickOpen = () => {
+    setOpen(true)
+
+    // Pre-populate form based on task if needed
+    if (task.status === "completed") {
+      setStatus("final")
+    } else if (task.status === "in-progress") {
+      setStatus("preliminary")
+    } else {
+      setStatus("registered")
+    }
+  }
+
+  const handleClose = () => {
+    setOpen(false)
+    resetForm()
+  }
+
+  const resetForm = () => {
+    setStatus("preliminary")
+    setCategory("vital-signs")
+    setCode("")
+    setEffectiveDateTime(dayjs())
+    setValueQuantity("")
+    setValueUnit("")
+    setNote("")
+    setErrors({})
+  }
+
+  const validateForm = (): boolean => {
+    const newErrors: Record<string, string> = {}
+
+    if (!code) newErrors.code = "Observation code is required"
+    if (!effectiveDateTime) newErrors.effectiveDateTime = "Date and time are required"
+    if (!valueQuantity) newErrors.valueQuantity = "Value is required"
+
+    setErrors(newErrors)
+    return Object.keys(newErrors).length === 0
+  }
+
+  const handleSave = async () => {
+    if (!validateForm()) return
+
+    setSaving(true)
+
+    try {
+      // Create the FHIR Observation resource
+      const selectedCategory = observationCategories.find((c) => c.code === category)
+      const selectedCode = observationCodes.find((c) => c.code === code)
+
+      const observation: Observation = {
+        resourceType: "Observation",
+        status: status as Observation["status"],
+        category: [
+          {
+            coding: [
+              {
+                system: selectedCategory?.system,
+                code: selectedCategory?.code,
+                display: selectedCategory?.display,
+              },
+            ],
+          },
+        ],
+        code: {
+          coding: [
+            {
+              system: selectedCode?.system,
+              code: selectedCode?.code,
+              display: selectedCode?.display,
+            },
+          ],
+        },
+        // Use subject with identifier when possible for cross-system compatibility
+        subject: createExternalReference(task.for),
+        effectiveDateTime: effectiveDateTime?.toISOString(),
+        valueQuantity: {
+          value: Number.parseFloat(valueQuantity),
+          unit: valueUnit,
+          system: "http://unitsofmeasure.org",
+          code: valueUnit,
+        },
+      }
+
+      // Add note if provided
+      if (note) {
+        observation.note = [
+          {
+            text: note,
+          },
+        ]
+      }
+
+      // Link to task using basedOn with identifier when possible
+      if (taskIdentifier) {
+        observation.basedOn = [
+          {
+            type: "Task",
+            identifier: taskIdentifier,
+            display: `Task ${task.id}`,
+          },
+        ]
+      } else if (task.id) {
+        observation.basedOn = [
+          {
+            reference: `Task/${task.id}`,
+            type: "Task",
+          },
+        ]
+      }
+
+      // Add focus reference if task has one, using identifier when possible
+      if (task.focus) {
+        const ref = createExternalReference(task.focus)
+        if (ref) observation.focus = [ref]
+      }
+
+      // Add partOf references if task is part of other tasks
+      if (task.partOf && task.partOf.length > 0) {
+        observation.partOf = task.partOf
+          .map((ref) => createExternalReference(ref))
+          .filter((ref) => ref !== undefined) as Reference[]
+      }
+
+      // Add context from task's encounter or episode if available
+      if (task.encounter) {
+        observation.encounter = createExternalReference(task.encounter)
+      }
+
+      const resp = await fetch("/api/fhir/Observation", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(observation),
+      })
+
+      if (!resp.ok) {
+        const errorMsg = JSON.stringify(await resp.json(), undefined, 2)
+        throw new Error(`Failed to save observation: [${resp.status}] ${errorMsg || resp.statusText || "No server message"}`)
+      }
+
+      setShowSuccess(true)
+      handleClose()
+    } catch (error) {
+      console.error("Error saving observation:", error)
+      if (error instanceof Error) {
+        setErrors({ submit: error.message || "Failed to save observation. Please try again." })
+      } else {
+        setErrors({ submit: "Failed to save observation. Please try again." })
+      }
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale="nl">
+      <IconButton edge="start" color="inherit" onClick={handleClickOpen} aria-label="register observation">
+        <IconPencilPlus />
+      </IconButton>
+
+      <Dialog open={open} fullScreen TransitionComponent={Transition}>
+        <AppBar sx={{ position: "fixed", backgroundColor: "#121212" }}>
+          <Toolbar>
+            <IconButton edge="start" color="inherit" onClick={handleClose} aria-label="close" disabled={saving}>
+              <CloseIcon />
+            </IconButton>
+            <Typography sx={{ ml: 2, flex: 1 }} variant="h6" component="div">
+              Register New Observation for {patientDisplay}
+            </Typography>
+            <Button color="inherit" onClick={handleSave} disabled={saving}>
+              {saving ? "Saving..." : "Save"}
+            </Button>
+          </Toolbar>
+        </AppBar>
+
+        <Box sx={{ mt: "80px", p: 3 }}>
+          {loading ? (
+            <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", height: "50vh" }}>
+              <CircularProgress />
+            </Box>
+          ) : (
+            <Grid container spacing={3}>
+              {/* Task Information */}
+              <Grid item xs={12}>
+                <Box sx={{ p: 2, bgcolor: "background.paper", borderRadius: 1, mb: 2 }}>
+                  <Typography variant="subtitle2" color="text.secondary">
+                    Task ID: {task.id}
+                    {taskIdentifier && (
+                      <Chip
+                        color="primary"
+                        size="small"
+                        label={`${taskIdentifier.system?.split("/").pop()}: ${taskIdentifier.value}`}
+                        sx={{ ml: 1 }}
+                      />
+                    )}
+                  </Typography>
+                  {task.focus && (
+                    <Typography variant="subtitle2" color="text.secondary">
+                      Focus: {getDisplayFromReference(task.focus)}
+                    </Typography>
+                  )}
+                  <Typography variant="subtitle2" color="text.secondary">
+                    Task Status: {task.status}
+                  </Typography>
+                  {task.for?.identifier && (
+                    <Typography variant="subtitle2" color="text.secondary">
+                      Patient Identifier: {task.for.identifier.system?.split("/").pop()}: {task.for.identifier.value}
+                    </Typography>
+                  )}
+                </Box>
+              </Grid>
+
+              {/* Status */}
+              <Grid item xs={12} md={6}>
+                <FormControl fullWidth error={!!errors.status}>
+                  <InputLabel id="status-label">Status</InputLabel>
+                  <Select
+                    labelId="status-label"
+                    value={status}
+                    label="Status"
+                    onChange={(e) => setStatus(e.target.value)}
+                  >
+                    {statusOptions.map((option) => (
+                      <MenuItem key={option} value={option}>
+                        {option.charAt(0).toUpperCase() + option.slice(1).replace(/-/g, " ")}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                  {errors.status && <FormHelperText>{errors.status}</FormHelperText>}
+                </FormControl>
+              </Grid>
+
+              {/* Category */}
+              <Grid item xs={12} md={6}>
+                <FormControl fullWidth error={!!errors.category}>
+                  <InputLabel id="category-label">Category</InputLabel>
+                  <Select
+                    labelId="category-label"
+                    value={category}
+                    label="Category"
+                    onChange={(e) => setCategory(e.target.value)}
+                  >
+                    {observationCategories.map((category) => (
+                      <MenuItem key={category.code} value={category.code}>
+                        {category.display}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                  {errors.category && <FormHelperText>{errors.category}</FormHelperText>}
+                </FormControl>
+              </Grid>
+
+              {/* Observation Code */}
+              <Grid item xs={12}>
+                <FormControl fullWidth error={!!errors.code}>
+                  <InputLabel id="code-label">Observation Type</InputLabel>
+                  <Select
+                    labelId="code-label"
+                    value={code}
+                    label="Observation Type"
+                    onChange={(e) => {
+                      setCode(e.target.value)
+                      // Reset unit when code changes
+                      setValueUnit("")
+                    }}
+                  >
+                    {observationCodes.map((code) => (
+                      <MenuItem key={code.code} value={code.code}>
+                        {code.display}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                  {errors.code && <FormHelperText>{errors.code}</FormHelperText>}
+                </FormControl>
+              </Grid>
+
+              {/* Effective Date Time */}
+              <Grid item xs={12}>
+                <DateTimePicker
+                  maxDate={dayjs()}
+                  label="Date and Time"
+                  value={effectiveDateTime}
+                  onChange={(newValue) => setEffectiveDateTime(newValue)}
+                  slotProps={{
+                    textField: {
+                      fullWidth: true,
+                      error: !!errors.effectiveDateTime,
+                      helperText: errors.effectiveDateTime,
+                    },
+                  }}
+                />
+              </Grid>
+              {/* Value */}
+              <Grid item xs={12} md={6}>
+                <TextField
+                  fullWidth
+                  label="Value"
+                  type="number"
+                  value={valueQuantity}
+                  onChange={(e) => setValueQuantity(e.target.value)}
+                  error={!!errors.valueQuantity}
+                  helperText={errors.valueQuantity}
+                />
+              </Grid>
+
+              {/* Unit */}
+              <Grid item xs={12} md={6}>
+                <FormControl fullWidth error={!!errors.valueUnit}>
+                  <InputLabel id="unit-label">Unit</InputLabel>
+                  <Select
+                    labelId="unit-label"
+                    value={valueUnit}
+                    label="Unit"
+                    onChange={(e) => setValueUnit(e.target.value)}
+                  >
+                    {getUnitSuggestions(code).map((unit) => (
+                      <MenuItem key={unit} value={unit}>
+                        {unit}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                  {errors.valueUnit && <FormHelperText>{errors.valueUnit}</FormHelperText>}
+                </FormControl>
+              </Grid>
+
+              {/* Notes */}
+              <Grid item xs={12}>
+                <TextField
+                  fullWidth
+                  label="Notes"
+                  multiline
+                  rows={4}
+                  value={note}
+                  onChange={(e) => setNote(e.target.value)}
+                />
+              </Grid>
+
+              {/* General error message */}
+              {errors.submit && (
+                <Grid item xs={12}>
+                  <Alert severity="error">{errors.submit}</Alert>
+                </Grid>
+              )}
+            </Grid>
+          )}
+        </Box>
+      </Dialog>
+
+      <Portal>
+
+        <Snackbar
+          open={showSuccess}
+          autoHideDuration={4000}
+          onClose={() => setShowSuccess(false)}
+          anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+        >
+          <Alert onClose={() => setShowSuccess(false)} severity="success">
+            Observation successfully registered
+          </Alert>
+        </Snackbar>
+      </Portal>
+    </LocalizationProvider>
+  )
+}

--- a/viewer_simulator/app/(DashboardLayout)/components/onboarding/enrolled-task-table.tsx
+++ b/viewer_simulator/app/(DashboardLayout)/components/onboarding/enrolled-task-table.tsx
@@ -1,10 +1,11 @@
 "use client"
-import React, { useState } from 'react';
+import React from 'react';
 import { DataGrid, GridColDef, GridToolbar } from '@mui/x-data-grid';
-import { Button, Tooltip } from '@mui/material';
+import { Tooltip } from '@mui/material';
 import { IconEye, IconProgressBolt, IconProgressCheck, IconProgressHelp, IconProgressX } from '@tabler/icons-react';
 import ViewTaskOutput from './view-task-output';
-import {Bundle, BundleEntry, FhirResource} from "fhir/r4";
+import { BundleEntry, FhirResource } from "fhir/r4";
+import CreateTaskObservation from './create-task-observation';
 
 interface Props {
     rows: any[]
@@ -45,7 +46,7 @@ const EnrolledTaskTable: React.FC<Props> = ({ rows, notificationBundles }) => {
             flex: 1,
             renderCell: (params) => {
 
-                if (!params.row.isSubtask) return <></>
+                if (!params.row.isSubtask) return <CreateTaskObservation task={params.row.task} />
 
                 return <ViewTaskOutput task={params.row.task} notificationBundles={notificationBundles} />
             }

--- a/viewer_simulator/app/api/delivery/storage.ts
+++ b/viewer_simulator/app/api/delivery/storage.ts
@@ -6,6 +6,31 @@ export function storeNotificationBundle(bundle: Bundle) {
     notificationBundles.push(bundle);
 }
 
-export function getNotificationBundles(): Bundle[] {
+export async function getNotificationBundles(): Promise<Bundle[]> {
+
+    //fetch all data when developing on the dev server, so we don't have to constantly create new resources in the hospital simulator
+    if (!notificationBundles?.length && process.env.NODE_ENV === 'development') {
+        console.info('[NODE_ENV === "development"] No notification bundles found - Fetching resources from FHIR server');
+        await fetchAllResources()
+    }
+
     return notificationBundles;
+}
+
+async function fetchAllResources() {
+
+    const everythingResponses = await fetch(`${process.env.FHIR_BASE_URL}/Patient/$everything?_count=500`, {
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${process.env.FHIR_AUTHORIZATION_TOKEN || 'unconfigured'}`
+        }
+    })
+
+    if (everythingResponses.ok) {
+        notificationBundles = [await everythingResponses.json()]
+        console.log(`Fetched all resources from FHIR server - found ${notificationBundles[0].total} resource(s)`);
+    } else {
+        console.error(`Failed to fetch resources from FHIR server for any patients`);
+    }
+
 }

--- a/viewer_simulator/app/api/fhir/[...fhirPath]/route.tsx
+++ b/viewer_simulator/app/api/fhir/[...fhirPath]/route.tsx
@@ -1,31 +1,177 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { OperationOutcome, Bundle, Resource, SearchParameter, BundleEntry, FhirResource } from 'fhir/r4';
+import { v4 } from 'uuid';
+import { JSONPath } from 'jsonpath-plus';
 
-type Params = Promise<{ fhirPath: string }>
+/*
+ * A very lightweight in-memory FHIR server that supports creating and reading resources of configured types.
+ * It does not support updating or deleting resources. It also ONLY allows searching on SearchParameters
+ * added directly into the code. 
+ * 
+ * Does NOT support vread, history, or any other FHIR operations.
+ */
+const supportedResourceTypes = ['Task', 'Condition', 'Observation'];
+const resources: { [key: string]: Resource[] } = {
+    Task: [],
+    Condition: [],
+    Observation: []
+};
 
-//Proxies all GET requests to the configured FHIR_BASE_URL
-export async function GET(req: Request, { params }: { params: Params }) {
+//expression MUST be json path
+const searchParameters: SearchParameter[] = [{
+    resourceType: 'SearchParameter',
+    id: 'based-on',
+    name: 'based-on',
+    code: 'basedOn',
+    type: 'reference',
+    expression: '$.basedOn[*].identifier',
+    base: [],
+    description: '',
+    status: 'active',
+    url: ''
+}];
 
+export async function GET(req: NextRequest, { params }: { params: Promise<{ fhirPath: string }> }) {
     try {
         const { fhirPath } = await params;
         const fhirPathUrlSegment = Array.isArray(fhirPath) ? fhirPath.join('/') : fhirPath;
+        const [resourceType, resourceId] = fhirPathUrlSegment.split('/');
 
-        let requestHeaders = new Headers(req.headers)
-        if (process.env.FHIR_AUTHORIZATION_TOKEN) {
-            requestHeaders.set('Authorization', "Bearer " + process.env.FHIR_AUTHORIZATION_TOKEN);
+        if (!supportedResourceTypes.includes(resourceType)) {
+            const error: OperationOutcome = {
+                resourceType: 'OperationOutcome',
+                issue: [{
+                    severity: 'error',
+                    code: 'not-supported',
+                    diagnostics: `Resource type ${resourceType} is not supported by this server. Supported resource types: ${supportedResourceTypes.join(', ')}`
+                }]
+            };
+            return NextResponse.json(error, { status: 400 });
         }
-        const response = await fetch(`${process.env.FHIR_BASE_URL}/${fhirPathUrlSegment}`, {
-            method: req.method,
-            headers: requestHeaders,
-        });
 
-        if (!response.ok) {
-            throw new Error("Failed to proxy FHIR request: " + response.statusText)
-        }
+        const searchParams = req.nextUrl.searchParams;
 
-        return NextResponse.json(await response.json(), { status: response.status });
+        const errorResponse = validateSearchParamKeys(searchParams);
+        if (errorResponse) return errorResponse;
+
+        const filteredResources = filterParams(resources[resourceType], searchParams);
+
+        if (resourceId) return getResourceById(filteredResources, resourceId);
+
+        const bundleEntries = filteredResources.map(resource => ({
+            fullUrl: `${req.url}/${resource.id}`,
+            resource: resource as FhirResource
+        })) as BundleEntry<FhirResource>[];
+
+        const result: Bundle = {
+            resourceType: 'Bundle',
+            type: 'searchset',
+            total: filteredResources.length,
+            entry: bundleEntries
+        };
+
+        return NextResponse.json(result, { status: 200 });
     } catch (error) {
         const errorMessage = error instanceof Error ? error.message : 'Unknown error';
         return NextResponse.json({ error: errorMessage }, { status: 500 });
-
     }
+}
+
+export async function POST(req: NextRequest) {
+    try {
+        const resource: Resource = await req.json();
+        if (!supportedResourceTypes.includes(resource.resourceType)) {
+            const error: OperationOutcome = {
+                resourceType: 'OperationOutcome',
+                issue: [{
+                    severity: 'error',
+                    code: 'not-supported',
+                    diagnostics: `Resource type ${resource.resourceType} is not supported by this server. Supported resource types: ${supportedResourceTypes.join(', ')}`
+                }]
+            };
+            return NextResponse.json(error, { status: 400 });
+        }
+
+        resource.id = v4();
+        resources[resource.resourceType].push(resource);
+        return NextResponse.json(resource, { status: 201 });
+    } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+        return NextResponse.json({ error: errorMessage }, { status: 500 });
+    }
+}
+
+function validateSearchParamKeys(params: URLSearchParams) {
+
+    for (const param of Array.from(params.keys())) {
+        if (!searchParameters.some(sp => sp.code === param)) {
+            const error: OperationOutcome = {
+                resourceType: 'OperationOutcome',
+                issue: [{
+                    severity: 'error',
+                    code: 'not-supported',
+                    diagnostics: `Search parameter ${param} is not supported by this server. Supported search parameters: ${searchParameters.map(sp => sp.code).join(', ')}`
+                }]
+            };
+            return NextResponse.json(error, { status: 400 });
+        }
+    }
+}
+
+/*
+* Filter resources based on search parameters. This is a VERY basic implementation of search parameters.
+* It only does an exact match on a JSON expression, or a system|code match on a coding. 
+*/
+function filterParams(resources: Resource[], searchParams: URLSearchParams) {
+
+    if (!searchParams.size) return resources;
+
+    for (const paramKey of Array.from(searchParams.keys())) {
+        const paramValue = searchParams.get(paramKey);
+        const searchParam = searchParameters.find(sp => sp.code === paramKey);
+
+        if (searchParam && searchParam.expression) {
+            return resources.filter(resource => {
+                const result = JSONPath({ path: searchParam.expression!, json: resource });
+                if (result.length > 0) {
+
+                    //check for a coding
+                    if (result[0].system && result[0].value) {
+                        if (!paramValue) return false;
+                        const [system, code] = paramValue.includes('|') ? paramValue.split('|') : [undefined, paramValue];
+
+                        return result.some((item: any) => {
+                            if (system) {
+                                return item.system === system && item.value === code;
+                            }
+                            return item.value === code;
+                        });
+
+                    } else {
+                        return result.some((item: any) => item.code === paramValue);
+                    }
+                }
+                return false;
+            });
+        }
+    }
+
+    return [];
+}
+
+function getResourceById(resources: Resource[], resourceId: string) {
+    const resource = resources.find(r => r.id === resourceId);
+    if (!resource) {
+        const error: OperationOutcome = {
+            resourceType: 'OperationOutcome',
+            issue: [{
+                severity: 'error',
+                code: 'not-found',
+                diagnostics: `Resource with id ${resourceId} not found`
+            }]
+        };
+        return NextResponse.json(error, { status: 404 });
+    }
+
+    return NextResponse.json(resource, { status: 200 });
 }

--- a/viewer_simulator/eslint.config.mjs
+++ b/viewer_simulator/eslint.config.mjs
@@ -1,0 +1,13 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import js from "@eslint/js";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const compat = new FlatCompat({
+    baseDirectory: __dirname,
+    recommendedConfig: js.configs.recommended,
+    allConfig: js.configs.all
+});
+export default [...compat.extends("next/core-web-vitals")];

--- a/viewer_simulator/package-lock.json
+++ b/viewer_simulator/package-lock.json
@@ -17,6 +17,7 @@
         "@mui/lab": "^5.0.0-alpha.174",
         "@mui/material": "^5.16.14",
         "@mui/x-data-grid": "^5.17.26",
+        "@mui/x-date-pickers": "^6.20.2",
         "@tabler/icons-react": "3.24.0",
         "@types/fhir": "^0.0.41",
         "@types/node": "22.13.4",
@@ -25,6 +26,7 @@
         "apexcharts": "4.2.0",
         "fhir": "^4.12.0",
         "fhir-kit-client": "^1.9.2",
+        "jsonpath-plus": "^10.3.0",
         "lodash": "4.17.21",
         "next": "^15.1.6",
         "react": "^18.3.1",
@@ -32,9 +34,12 @@
         "react-dom": "^18.3.1",
         "react-helmet-async": "2.0.5",
         "typescript": "5.7.2",
+        "uuid": "^11.1.0",
         "zustand": "^5.0.2"
       },
       "devDependencies": {
+        "@eslint/eslintrc": "^3.3.0",
+        "@eslint/js": "^9.21.0",
         "@types/lodash": "4.17.13",
         "eslint": "^9.19.0",
         "eslint-config-next": "^15.1.0"
@@ -2663,10 +2668,11 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
-      "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.0.tgz",
+      "integrity": "sha512-yaVPAiNAalnCZedKLdR21GOGILMLKPyqSLWaAjQFvYA2i/ciDi8ArYVr69Anohb6cH2Ukhqti4aFnYyPm8wdwQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
         "debug": "^4.3.2",
@@ -2698,9 +2704,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.19.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.19.0.tgz",
-      "integrity": "sha512-rbq9/g38qjfqFLOVPvwjIvFFdNziEC5S65jmjPw5r6A//QH+W91akh9irMwjDN8zKUTak6W9EsAv4m/7Wnw0UQ==",
+      "version": "9.21.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.21.0.tgz",
+      "integrity": "sha512-BqStZ3HX8Yz6LvsF5ByXYrtigrV5AXADWLAGc7PH/1SxOb7/FIYYMszZZWiUou/GB9P2lXWk2SV4d+Z8h0nknw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2741,6 +2747,17 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@expo/bunyan/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@expo/cli": {
@@ -3413,6 +3430,17 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@expo/rudder-sdk-node/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@expo/sdk-runtime-versions": {
@@ -4334,6 +4362,30 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsep-plugin/assignment": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
+      "integrity": "sha512-VVgV+CXrhbMI3aSusQyclHkenWSAm95WaiKrMxRFam3JSUiIaQjoMIw2sEs/OX4XifnqeQUN4DYbJjlA8EfktQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@jsep-plugin/regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jsep-plugin/regex/-/regex-1.0.4.tgz",
+      "integrity": "sha512-q7qL4Mgjs1vByCaTnDFcBnV9HS7GVPJX5vyVoCgZHNSC9rjwIlmbXG5sUuorR5ndfHAIlJ8pVStxvjXHbNvtUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "peerDependencies": {
+        "jsep": "^0.4.0||^1.0.0"
+      }
+    },
     "node_modules/@lhncbc/ucum-lhc": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@lhncbc/ucum-lhc/-/ucum-lhc-5.0.4.tgz",
@@ -4352,30 +4404,31 @@
       }
     },
     "node_modules/@mui/base": {
-      "version": "5.0.0-beta.66",
-      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.66.tgz",
-      "integrity": "sha512-1SzcNbtIms0o/Dx+599B6QbvR5qUMBUjwc2Gs47h1HsF7RcEFXxqaq7zrWkIWbvGctIIPx0j330oGx/SkF+UmA==",
-      "peer": true,
+      "version": "5.0.0-dev.20240529-082515-213b5e33ab",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-dev.20240529-082515-213b5e33ab.tgz",
+      "integrity": "sha512-3ic6fc6BHstgM+MGqJEVx3zt9g5THxVXm3VVFUfdeplPqAWWgW2QoKfZDLT10s+pi+MAkpgEBP0kgRidf81Rsw==",
+      "deprecated": "This package has been replaced by @base-ui-components/react",
+      "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.26.0",
-        "@floating-ui/react-dom": "^2.1.1",
-        "@mui/types": "^7.2.19",
-        "@mui/utils": "^6.2.0",
+        "@babel/runtime": "^7.24.6",
+        "@floating-ui/react-dom": "^2.0.8",
+        "@mui/types": "^7.2.14-dev.20240529-082515-213b5e33ab",
+        "@mui/utils": "^6.0.0-dev.20240529-082515-213b5e33ab",
         "@popperjs/core": "^2.11.8",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=12.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
       },
       "peerDependencies": {
-        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -4384,13 +4437,13 @@
       }
     },
     "node_modules/@mui/base/node_modules/@mui/utils": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.2.0.tgz",
-      "integrity": "sha512-77CaFJi+OIi2SjbPwCis8z5DXvE0dfx9hBz5FguZHt1VYFlWEPCWTHcMsQCahSErnfik5ebLsYK8+D+nsjGVfw==",
-      "peer": true,
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-6.4.6.tgz",
+      "integrity": "sha512-43nZeE1pJF2anGafNydUcYFPtHwAqiBiauRtaMvurdrZI3YrUjHkAu43RBsxef7OFtJMXGiHFvq43kb7lig0sA==",
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.26.0",
-        "@mui/types": "^7.2.19",
+        "@mui/types": "^7.2.21",
         "@types/prop-types": "^15.7.14",
         "clsx": "^2.1.1",
         "prop-types": "^15.8.1",
@@ -4417,7 +4470,7 @@
       "version": "19.0.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.0.0.tgz",
       "integrity": "sha512-H91OHcwjZsbq3ClIDHMzBShc1rotbfACdWENsmEf0IFvZ3FgGPtdHMcsv45bQ1hAbgdfiA8SnxTKfDS+x/8m2g==",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@mui/core-downloads-tracker": {
       "version": "5.16.14",
@@ -4670,9 +4723,10 @@
       }
     },
     "node_modules/@mui/types": {
-      "version": "7.2.19",
-      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.19.tgz",
-      "integrity": "sha512-6XpZEM/Q3epK9RN8ENoXuygnqUQxE+siN/6rGRi2iwJPgBUR25mphYQ9ZI87plGh58YoZ5pp40bFvKYOCDJ3tA==",
+      "version": "7.2.21",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.21.tgz",
+      "integrity": "sha512-6HstngiUxNqLU+/DPqlUJDIPbzUBxIVHb1MmXP0eTWDIROiCR2viugXpEif0PPe2mLqqakPzzRClWAnK+8UJww==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0"
       },
@@ -4753,7 +4807,7 @@
       "version": "6.20.2",
       "resolved": "https://registry.npmjs.org/@mui/x-date-pickers/-/x-date-pickers-6.20.2.tgz",
       "integrity": "sha512-x1jLg8R+WhvkmUETRfX2wC+xJreMii78EXKLl6r3G+ggcAZlPyt0myID1Amf6hvJb9CtR7CgUo8BwR+1Vx9Ggw==",
-      "peer": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.2",
         "@mui/base": "^5.0.0-beta.22",
@@ -9177,6 +9231,16 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "9.19.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.19.0.tgz",
+      "integrity": "sha512-rbq9/g38qjfqFLOVPvwjIvFFdNziEC5S65jmjPw5r6A//QH+W91akh9irMwjDN8zKUTak6W9EsAv4m/7Wnw0UQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/eslint/node_modules/eslint-visitor-keys": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
@@ -11818,6 +11882,15 @@
         "@babel/preset-env": "^7.1.6"
       }
     },
+    "node_modules/jsep": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
+      "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.16.0"
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
@@ -11883,6 +11956,24 @@
       "integrity": "sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==",
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/jsonpath-plus": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-10.3.0.tgz",
+      "integrity": "sha512-8TNmfeTCk2Le33A3vRRwtuworG/L5RrgMvdjhKZxvyShO+mBu2fP50OWUjRLNtvw344DdDarFh9buFAZs5ujeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsep-plugin/assignment": "^1.3.0",
+        "@jsep-plugin/regex": "^1.0.4",
+        "jsep": "^1.4.0"
+      },
+      "bin": {
+        "jsonpath": "bin/jsonpath-cli.js",
+        "jsonpath-plus": "bin/jsonpath-cli.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -17986,13 +18077,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "optional": true,
-      "peer": true,
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/uvu": {

--- a/viewer_simulator/package.json
+++ b/viewer_simulator/package.json
@@ -18,6 +18,7 @@
     "@mui/lab": "^5.0.0-alpha.174",
     "@mui/material": "^5.16.14",
     "@mui/x-data-grid": "^5.17.26",
+    "@mui/x-date-pickers": "^6.20.2",
     "@tabler/icons-react": "3.24.0",
     "@types/fhir": "^0.0.41",
     "@types/node": "22.13.4",
@@ -26,6 +27,7 @@
     "apexcharts": "4.2.0",
     "fhir": "^4.12.0",
     "fhir-kit-client": "^1.9.2",
+    "jsonpath-plus": "^10.3.0",
     "lodash": "4.17.21",
     "next": "^15.1.6",
     "react": "^18.3.1",
@@ -33,9 +35,12 @@
     "react-dom": "^18.3.1",
     "react-helmet-async": "2.0.5",
     "typescript": "5.7.2",
+    "uuid": "^11.1.0",
     "zustand": "^5.0.2"
   },
   "devDependencies": {
+    "@eslint/eslintrc": "^3.3.0",
+    "@eslint/js": "^9.21.0",
     "@types/lodash": "4.17.13",
     "eslint": "^9.19.0",
     "eslint-config-next": "^15.1.0"

--- a/viewer_simulator/utils/theme/DefaultColors.tsx
+++ b/viewer_simulator/utils/theme/DefaultColors.tsx
@@ -170,10 +170,45 @@ const darkTheme = createTheme({
         },
       },
     },
+    MuiAlert: {
+      styleOverrides: {
+        root: {
+          backgroundColor: "#2e2e2e",
+          '& .MuiAlert-message': {
+            color: "#ffffff",
+          },
+        },
+      },
+    },
     MuiSvgIcon: {
       styleOverrides: {
         root: {
           color: "#ffffff",
+        },
+      },
+    },
+    MuiInputBase: {
+      styleOverrides: {
+        root: {
+          '& .MuiInputBase-input': {
+            borderColor: '#ffffff',
+          },
+          '& .MuiOutlinedInput-notchedOutline': {
+            borderColor: '#ffffff',
+          },
+          '&:hover .MuiOutlinedInput-notchedOutline': {
+            borderColor: '#ffffff',
+          },
+          '&.Mui-focused .MuiOutlinedInput-notchedOutline': {
+            borderColor: '#ffffff',
+          },
+        },
+      },
+    },
+    MuiSelect: {
+      styleOverrides: {
+        icon: {
+          color: '#ffffff',
         },
       },
     },


### PR DESCRIPTION
This PR adds the following:

1. The order Tasks that come from the hospitals now have a "pencil" icon in the "Onboarding Tasks" table.
<img width="1242" alt="Screenshot 2025-03-07 at 15 13 57" src="https://github.com/user-attachments/assets/f46ebce3-0c77-4d9a-965b-cea03a7e187c" />

2. When clicking this pencil, a popup is shown that allows for creation of a FHIR `Observation`
<img width="1905" alt="Screenshot 2025-03-07 at 15 14 42" src="https://github.com/user-attachments/assets/9a4b0108-a74f-4991-8b76-81b23a2e4c2f" />

3. Rewrote the FHIR endpoint, that used to proxy to become a light-weight in-memory FHIR server. This to keep the configuration simple, and to not re-introduce a second HAPI server like we used to have.
4. The Observation is stored in the new light-weight FHIR server. The Observation can be queried here as well.
<img width="1281" alt="Screenshot 2025-03-07 at 15 17 23" src="https://github.com/user-attachments/assets/949de148-277c-4089-9f67-532e32247fd0" />

5. Also added a "fetch resources when there are no notifications in-memory" logic when the viewer is started from the dev server (`process.env.NODE_ENV === 'development'`). As the dev server does many hot reloads, the in-memory data is often cleared. This would require devs to keep moving back to the EHR simulator and create new enrolments.
6. Fixed some small dark-theme issues
7. Fixed deprecated eslint config that doesn't work in eslint 9 anymore

The `Observation` will serve as a basis for INT-642. The CPC node of the hospital should be allowed to query this MSC Observation through the SCP standard.

