### PR TITLE
Allow disable notification bundle for viewer in production

### DIFF
--- a/viewer_simulator/.env.local.example
+++ b/viewer_simulator/.env.local.example
@@ -1,3 +1,4 @@
 FHIR_BASE_URL=http://localhost:3030/cpc/cps/fhir
 FHIR_HOSPITAL_URL=http://localhost:3030/cpc/aggregate/fhir
 FHIR_AUTHORIZATION_TOKEN=
+DISABLE_NOTIFICATION_BUNDLE=true

--- a/viewer_simulator/app/api/delivery/orca-enroll-patient/storage.ts
+++ b/viewer_simulator/app/api/delivery/orca-enroll-patient/storage.ts
@@ -9,8 +9,8 @@ export function storeNotificationBundle(bundle: Bundle) {
 export async function getNotificationBundles(): Promise<Bundle[]> {
 
     //fetch all data when developing on the dev server, so we don't have to constantly create new resources in the hospital simulator
-    if (!notificationBundles?.length && process.env.NODE_ENV === 'development') {
-        console.info('[NODE_ENV === "development"] No notification bundles found - Fetching resources from FHIR server');
+    if (process.env.DISABLE_NOTIFICATION_BUNDLE === 'true') {
+        console.info('[DISABLE_NOTIFICATION_BUNDLE === "true"] No notification bundles found - Fetching resources from FHIR server');
         await fetchAllResources()
     }
 


### PR DESCRIPTION
Changes `getNotificationBundles` in the viewer to fetch resources instead of listening to notification bundles (only) based on the `DISABLE_NOTIFICATION_BUNDLE` environment variable instead of relying on `NODE_ENV`.

This makes the feature explicit and allows production deployments to use it.