### PR TITLE
INT-630: Fix enrolment bundle building after making CareTeam contained within CarePlan

### DIFF
--- a/deployments/dev/clinic/docker-compose.yaml
+++ b/deployments/dev/clinic/docker-compose.yaml
@@ -30,10 +30,10 @@ services:
     ports:
       - "1305:1305"
   orchestrator:
-#    image: ghcr.io/santeonnl/orca_orchestrator:main
-    build:
-      context: ../../../orchestrator
-      dockerfile: Dockerfile
+    image: ghcr.io/santeonnl/orca_orchestrator:main
+    #build:
+    #  context: ../../../orchestrator
+    #  dockerfile: Dockerfile
     ports:
       - "3030:8080"
     environment:
@@ -44,13 +44,14 @@ services:
       - ORCA_PUBLIC_URL=${NUTS_URL}/orca
       - ORCA_STRICTMODE=false
       - ORCA_MESSAGING_HTTP_ENDPOINT=${NUTS_URL}/viewer/api/delivery
+      - ORCA_MESSAGING_HTTP_TOPICFILTER=orca-enroll-patient
       - ORCA_CAREPLANCONTRIBUTOR_CAREPLANSERVICE_URL=${CAREPLANCONTRIBUTOR_CAREPLANSERVICE_URL}
       - ORCA_CAREPLANCONTRIBUTOR_STATICBEARERTOKEN=valid
       - ORCA_CAREPLANCONTRIBUTOR_HEALTHDATAVIEWENDPOINTENABLED=true
       # Note: clinic re-uses the FHIR store of the Hospital, so we don't need to start a second one making things even slower
       - ORCA_CAREPLANCONTRIBUTOR_TASKFILLER_QUESTIONNAIREFHIR_URL=${HOSPITAL_URL}/fhir
       # If this value is set, the clinic will send task notifications over http to the provided endpoint. Cannot be used in conjunction with the strict mode
-      - ORCA_CAREPLANCONTRIBUTOR_TASKFILLER_TASKACCEPTEDBUNDLETOPIC=enrolment-accepted
+      - ORCA_CAREPLANCONTRIBUTOR_TASKFILLER_TASKACCEPTEDBUNDLETOPIC=orca-enroll-patient
       - ORCA_CAREPLANCONTRIBUTOR_TASKFILLER_QUESTIONNAIRESYNCURLS=file:///config/fhir/healthcareservices.json,file:///config/fhir/questionnaires.json
     volumes:
       # FHIR HealthcareService and Questionnaire resources that are loaded into the FHIR store on startup,

--- a/orchestrator/careplancontributor/ehr/notification_bundle.go
+++ b/orchestrator/careplancontributor/ehr/notification_bundle.go
@@ -213,10 +213,6 @@ func fetchRefs(ctx context.Context, cpsClient fhirclient.Client, refs []string) 
 		var bundle fhir.Bundle
 		values := url.Values{}
 		values.Set("_id", strings.Join(refIds, ","))
-		if refType == "CarePlan" {
-			values.Set("_include", "CarePlan:care-team")
-			expectedResourceCount++
-		}
 		err := cpsClient.SearchWithContext(ctx, refType, values, &bundle)
 		if err != nil {
 			return nil, err
@@ -247,10 +243,6 @@ func fetchRef(ctx context.Context, cpsClient fhirclient.Client, ref string) (*fh
 	var bundle fhir.Bundle
 	values := url.Values{}
 	values.Set("_id", refId)
-	if refType == "CarePlan" {
-		values.Set("_include", "CarePlan:care-team")
-		expectedResourceCount = 2
-	}
 	err := cpsClient.SearchWithContext(ctx, refType, values, &bundle)
 	if err != nil {
 		return nil, err

--- a/orchestrator/careplancontributor/ehr/notification_bundle_test.go
+++ b/orchestrator/careplancontributor/ehr/notification_bundle_test.go
@@ -26,7 +26,6 @@ func TestTaskNotificationBundleSet(t *testing.T) {
 			Reference: to.Ptr("Patient/1"),
 		},
 	})
-	careTeam1Raw, _ := json.Marshal(fhir.CareTeam{Id: to.Ptr("1")})
 	serviceRequest1Raw, _ := json.Marshal(fhir.ServiceRequest{Id: to.Ptr("1")})
 	questionnaire1Raw, _ := json.Marshal(fhir.Questionnaire{Id: to.Ptr("1")})
 	questionnaireResponse1Raw, _ := json.Marshal(fhir.QuestionnaireResponse{Id: to.Ptr("1")})
@@ -90,7 +89,6 @@ func TestTaskNotificationBundleSet(t *testing.T) {
 			*data = fhir.Bundle{
 				Entry: []fhir.BundleEntry{
 					{Resource: carePlan1Raw},
-					{Resource: careTeam1Raw},
 				},
 			}
 			return nil
@@ -132,7 +130,6 @@ func TestTaskNotificationBundleSet(t *testing.T) {
 		require.JSONEq(t, string(patient1Raw), string(result.Bundles[1].Entry[0].Resource))
 		require.JSONEq(t, string(serviceRequest1Raw), string(result.Bundles[2].Entry[0].Resource))
 		require.JSONEq(t, string(carePlan1Raw), string(result.Bundles[3].Entry[0].Resource))
-		require.JSONEq(t, string(careTeam1Raw), string(result.Bundles[3].Entry[1].Resource))
 		require.JSONEq(t, string(questionnaire1Raw), string(result.Bundles[4].Entry[0].Resource))
 		require.JSONEq(t, string(questionnaireResponse1Raw), string(result.Bundles[5].Entry[0].Resource))
 	})
@@ -178,7 +175,6 @@ func TestTaskNotificationBundleSet(t *testing.T) {
 			*data = fhir.Bundle{
 				Entry: []fhir.BundleEntry{
 					{Resource: carePlan1Raw},
-					{Resource: careTeam1Raw},
 				},
 			}
 			return nil
@@ -225,7 +221,6 @@ func TestTaskNotificationBundleSet(t *testing.T) {
 			*data = fhir.Bundle{
 				Entry: []fhir.BundleEntry{
 					{Resource: carePlan1Raw},
-					{Resource: careTeam1Raw},
 				},
 			}
 			return nil
@@ -258,7 +253,6 @@ func TestTaskNotificationBundleSet(t *testing.T) {
 			*data = fhir.Bundle{
 				Entry: []fhir.BundleEntry{
 					{Resource: carePlan1Raw},
-					{Resource: careTeam1Raw},
 				},
 			}
 			return nil


### PR DESCRIPTION
The enrolment bundle builder still worked under the assumption that CarePlan referenced CareTeam, and thus failed.

Also configured required messaging config.