### PR TITLE
INT-665: The creation of the Observation didn't keep the basePath in mind

### DIFF
--- a/viewer_simulator/app/(DashboardLayout)/components/onboarding/create-task-observation.tsx
+++ b/viewer_simulator/app/(DashboardLayout)/components/onboarding/create-task-observation.tsx
@@ -332,7 +332,7 @@ export default function CreateTaskObservation({ task }: { task: Task }) {
         observation.encounter = createExternalReference(task.encounter)
       }
 
-      const resp = await fetch("/api/fhir/Observation", {
+      const resp = await fetch(`${process.env.NEXT_PUBLIC_BASE_PATH || ""}/api/fhir/Observation`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",


### PR DESCRIPTION
This resulted in default routing to nuts instead of itself - causing a 404.