### PR TITLE
INT-667: Have FHIR proxy set meta.source when querying remote FHIR APIs

### DIFF
--- a/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
@@ -213,7 +213,7 @@ func (s *Service) EhrFhirProxy() coolfhir.HttpProxy {
 		cpsFhirClient:      s.cpsFhirClient,
 		secureTokenService: s.secureTokenService,
 		accessTokenCache:   s.accessTokenCache,
-	}, true)
+	}, true, false)
 	// Zorgplatform's FHIR API only allows GET-based FHIR searches, while ORCA only allows POST-based FHIR searches.
 	// If the request is a POST-based search, we need to rewrite the request to a GET-based search.
 	result.HTTPRequestModifier = func(req *http.Request) (*http.Request, error) {

--- a/orchestrator/careplancontributor/integration_test.go
+++ b/orchestrator/careplancontributor/integration_test.go
@@ -178,7 +178,7 @@ func Test_Integration_CPCFHIRProxy(t *testing.T) {
 	}
 	t.Log("CPC client without CPS URL, returns error")
 	{
-		cpsProxy := coolfhir.NewProxy("CPS->CPC", fhirBaseURL, "/cpc/fhir", orcaPublicURL, httpService.Client().Transport, true)
+		cpsProxy := coolfhir.NewProxy("CPS->CPC", fhirBaseURL, "/cpc/fhir", orcaPublicURL, httpService.Client().Transport, true, false)
 
 		messageBroker, err := messaging.New(messaging.Config{}, nil)
 		require.NoError(t, err)
@@ -231,7 +231,7 @@ func setupIntegrationTest(t *testing.T, notificationEndpoint *url.URL) (*url.URL
 	sessionManager, _ := createTestSession()
 
 	// TODO: Tests using the Zorgplatform service
-	cpsProxy := coolfhir.NewProxy("CPS->CPC", fhirBaseURL, "/cpc/fhir", orcaPublicURL, httpService.Client().Transport, true)
+	cpsProxy := coolfhir.NewProxy("CPS->CPC", fhirBaseURL, "/cpc/fhir", orcaPublicURL, httpService.Client().Transport, true, false)
 
 	cpcConfig := DefaultConfig()
 	cpcConfig.Enabled = true

--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -245,7 +245,7 @@ func (s *Service) RegisterHandlers(mux *http.ServeMux) {
 			return
 		}
 		carePlanServiceProxy := coolfhir.NewProxy("App->CPS FHIR proxy", s.localCarePlanServiceUrl,
-			proxyBasePath, s.orcaPublicURL.JoinPath(proxyBasePath), httpClient.Transport, false)
+			proxyBasePath, s.orcaPublicURL.JoinPath(proxyBasePath), httpClient.Transport, false, true)
 		carePlanServiceProxy.ServeHTTP(writer, request)
 	}))
 
@@ -281,7 +281,7 @@ func (s Service) handleProxyAppRequestToEHR(writer http.ResponseWriter, request 
 	clientFactory := clients.Factories[session.FHIRLauncher](session.StringValues)
 	proxyBasePath := basePath + "/ehr/fhir"
 	proxy := coolfhir.NewProxy("App->EHR FHIR proxy", clientFactory.BaseURL, proxyBasePath,
-		s.orcaPublicURL.JoinPath(proxyBasePath), clientFactory.Client, false)
+		s.orcaPublicURL.JoinPath(proxyBasePath), clientFactory.Client, false, false)
 
 	resourcePath := request.PathValue("rest")
 	// If the requested resource is cached in the session, directly return it. This is used to support resources that are required (e.g. by Frontend), but not provided by the EHR.
@@ -402,7 +402,7 @@ func (s *Service) proxyToAllCareTeamMembers(writer http.ResponseWriter, request 
 	}
 	const proxyBasePath = basePath + "/aggregate/fhir/"
 	for _, target := range queryTargets {
-		fhirProxy := coolfhir.NewProxy("EHR(local)->EHR(external) FHIR proxy", target.fhirBaseURL, proxyBasePath, s.orcaPublicURL.JoinPath(proxyBasePath), target.httpClient.Transport, true)
+		fhirProxy := coolfhir.NewProxy("EHR(local)->EHR(external) FHIR proxy", target.fhirBaseURL, proxyBasePath, s.orcaPublicURL.JoinPath(proxyBasePath), target.httpClient.Transport, true, true)
 		fhirProxy.ServeHTTP(writer, request)
 	}
 	return nil

--- a/orchestrator/careplanservice/service.go
+++ b/orchestrator/careplanservice/service.go
@@ -144,7 +144,7 @@ type FHIRHandlerResult func(txResult *fhir.Bundle) (*fhir.BundleEntry, []any, er
 
 func (s *Service) RegisterHandlers(mux *http.ServeMux) {
 	s.proxy = coolfhir.NewProxy("CPS->FHIR proxy", s.fhirURL, basePath,
-		s.orcaPublicURL.JoinPath(basePath), s.transport, true)
+		s.orcaPublicURL.JoinPath(basePath), s.transport, true, false)
 	baseUrl := s.baseUrl()
 
 	// Binding to actual routing

--- a/orchestrator/lib/coolfhir/pipeline/rewriting.go
+++ b/orchestrator/lib/coolfhir/pipeline/rewriting.go
@@ -2,9 +2,43 @@ package pipeline
 
 import (
 	"bytes"
+	"encoding/json"
+	"github.com/rs/zerolog/log"
 	"net/http"
 	"strings"
 )
+
+var _ HttpResponseTransformer = &MetaSourceSetter{}
+
+// MetaSourceSetter is a transformer that sets (or overwrites) the meta.source field in a FHIR resource.
+type MetaSourceSetter struct {
+	URI string
+}
+
+func (m MetaSourceSetter) Transform(_ *int, responseBody *[]byte, _ map[string][]string) {
+	if err := m.do(responseBody); err != nil {
+		log.Error().Err(err).Msg("MetaSourceSetter: failed to set meta.source")
+	}
+}
+
+func (m MetaSourceSetter) do(responseBody *[]byte) error {
+	resource := make(map[string]interface{})
+	if err := json.Unmarshal(*responseBody, &resource); err != nil {
+		return err
+	}
+	meta, ok := resource["meta"].(map[string]interface{})
+	if !ok {
+		meta = make(map[string]interface{})
+		resource["meta"] = meta
+	}
+	meta["source"] = m.URI
+	newBody, err := json.Marshal(resource)
+	if err != nil {
+		return err
+	}
+	*responseBody = newBody
+	return nil
+}
 
 var _ HttpResponseTransformer = &ResponseBodyRewriter{}
 

--- a/orchestrator/lib/coolfhir/pipeline/rewriting_test.go
+++ b/orchestrator/lib/coolfhir/pipeline/rewriting_test.go
@@ -38,3 +38,28 @@ func TestResponseBodyRewriter_Transform(t *testing.T) {
 		assert.Equal(t, expected, input)
 	})
 }
+
+func TestMetaSourceSetter_do(t *testing.T) {
+	t.Run("sets meta.source", func(t *testing.T) {
+		expected := `{"meta":{"source":"http://example.com"}}`
+		input := []byte(`{}`)
+		transformer := MetaSourceSetter{URI: "http://example.com"}
+		err := transformer.do(&input)
+		assert.NoError(t, err)
+		assert.JSONEq(t, expected, string(input))
+	})
+	t.Run("overwrites existing meta.source", func(t *testing.T) {
+		expected := `{"meta":{"source":"http://example.com"}}`
+		input := []byte(`{"meta":{"source":"http://localhost:8080"}}`)
+		transformer := MetaSourceSetter{URI: "http://example.com"}
+		err := transformer.do(&input)
+		assert.NoError(t, err)
+		assert.JSONEq(t, expected, string(input))
+	})
+	t.Run("invalid resource", func(t *testing.T) {
+		input := []byte(`invalid`)
+		transformer := MetaSourceSetter{URI: "http://example.com"}
+		err := transformer.do(&input)
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
Helps with determining X-SCP-Context, if a proxy reports where it got the resource from. Only do for GET requests for now, only for top-level resources (nested resources not supported).