### PR TITLE
Viewer: ignore FHIR_BASE_URL for showing accepted Tasks or BgZ

### DIFF
--- a/viewer_simulator/app/(DashboardLayout)/components/bgz/bgz-overview.tsx
+++ b/viewer_simulator/app/(DashboardLayout)/components/bgz/bgz-overview.tsx
@@ -7,11 +7,6 @@ import { getNotificationBundles } from '@/app/api/delivery/orca-enroll-patient/s
 
 export default async function BgzOverview() {
 
-    if (!process.env.FHIR_BASE_URL) {
-        console.error('FHIR_BASE_URL is not defined');
-        return <>FHIR_BASE_URL is not defined</>;
-    }
-
     // prevent ssr from pre-rendering the page, as it won't be able to fetch resources from process.env.FHIR_BASE_URL
     const headersList = headers()
 

--- a/viewer_simulator/app/(DashboardLayout)/components/onboarding/accepted-task-overview.tsx
+++ b/viewer_simulator/app/(DashboardLayout)/components/onboarding/accepted-task-overview.tsx
@@ -6,11 +6,6 @@ import { getNotificationBundles } from "@/app/api/delivery/orca-enroll-patient/s
 
 export default async function AcceptedTaskOverview() {
 
-    if (!process.env.FHIR_BASE_URL) {
-        console.error('FHIR_BASE_URL is not defined');
-        return <>FHIR_BASE_URL is not defined</>;
-    }
-
     // prevent ssr from pre-rendering the page, as it won't be able to fetch resources from process.env.FHIR_BASE_URL
     const headersList = headers()
 


### PR DESCRIPTION
- Accepted Task overview is sourced primarily from received notifications and _may_ query FHIR_BASE_URL when running in dev mode
- The same applies to BgZ view, and it then uses the FHIR_AGGREGATE_URL to query the BgZ data

I'm removing the check, as I'll be removing the `FHIR_BASE_URL` from the configuration on test/acceptance (since it's not used).