### PR TITLE
INT-691: Added Server-Sent Events (SSE) to the CPC. 

### DIFF
--- a/frontend/app/enrollment/components/questionnaire-renderer.tsx
+++ b/frontend/app/enrollment/components/questionnaire-renderer.tsx
@@ -5,7 +5,7 @@ import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import useCpsClient from '@/hooks/use-cps-client';
 import useTaskProgressStore from '@/lib/store/task-progress-store';
-import {findQuestionnaireResponse, getPatientIdentifier} from '@/lib/fhirUtils';
+import { findQuestionnaireResponse, getPatientIdentifier } from '@/lib/fhirUtils';
 import { Spinner } from '@/components/spinner';
 import { v4 } from 'uuid';
 import { populateQuestionnaire } from '../../utils/populate';
@@ -36,7 +36,7 @@ function QuestionnaireRenderer(props: QuestionnaireRendererPageProps) {
   const [, setPrevQuestionnaireResponse] = useState<QuestionnaireResponse>()
 
   const cpsClient = useCpsClient()
-  const { onSubTaskSubmit, task } = useTaskProgressStore()
+  const { task } = useTaskProgressStore()
   const router = useRouter()
 
   useEffect(() => {
@@ -144,8 +144,6 @@ function QuestionnaireRenderer(props: QuestionnaireRendererPageProps) {
     await cpsClient?.transaction({
       body: bundle
     });
-
-    onSubTaskSubmit(router.push(`/enrollment/task/${task!.id}`))
   }
 
   useEffect(() => {

--- a/frontend/app/enrollment/components/sse-connection-status.tsx
+++ b/frontend/app/enrollment/components/sse-connection-status.tsx
@@ -1,0 +1,42 @@
+"use client"
+import { HoverCard, HoverCardContent, HoverCardTrigger } from '@/components/ui/hover-card'
+import useTaskProgressStore from '@/lib/store/task-progress-store'
+import { AlertCircle, CheckCircle2 } from 'lucide-react'
+import React from 'react'
+
+export default function TaskSseConnectionStatus() {
+
+    const { eventSourceConnected } = useTaskProgressStore()
+
+    return (
+        <HoverCard>
+            <HoverCardTrigger asChild>
+                <div className={`fixed bottom-5 right-5 h-3 w-3 rounded-full ${eventSourceConnected ? "bg-green-500" : "bg-red-500"}`} />
+            </HoverCardTrigger>
+            <HoverCardContent className="w-120">
+                <div className="flex flex-col space-y-2 p-4">
+                    <div className="flex items-center justify-between">
+                        <h3 className="text-lg font-medium">Real-time updates</h3>
+                        <div className="flex items-center space-x-2">
+                            <div className={`h-3 w-3 rounded-full ${eventSourceConnected ? "bg-green-500" : "bg-red-500"}`} />
+                            <span className="text-sm font-medium capitalize">{eventSourceConnected ? 'Verbonden' : 'Verbinding verbroken'}</span>
+                        </div>
+                    </div>
+
+                    <div className="flex items-center text-sm text-muted-foreground">
+                        {eventSourceConnected ? (
+                            <CheckCircle2 className="mr-2 h-4 w-4 text-green-500" />
+                        ) : (
+                            <AlertCircle className="mr-2 h-4 w-4 text-red-500" />
+                        )}
+                        <span>
+                            {eventSourceConnected
+                                ? "Successvol verbonden - U ontvangt real-time updates"
+                                : "Verbinding verbroken - U ontvangt geen real-time updates"}
+                        </span>
+                    </div>
+                </div>
+            </HoverCardContent>
+        </HoverCard>
+    )
+}

--- a/frontend/app/enrollment/task/[taskId]/page.tsx
+++ b/frontend/app/enrollment/task/[taskId]/page.tsx
@@ -8,6 +8,7 @@ import useEnrollmentStore from "@/lib/store/enrollment-store";
 import { patientName, organizationName } from "@/lib/fhirRender";
 import DataViewer from '@/components/data-viewer'
 import { viewerFeatureIsEnabled } from '@/app/actions'
+import TaskSseConnectionStatus from '../../components/sse-connection-status'
 
 export default function EnrollmentTaskPage() {
     const { taskId } = useParams()
@@ -51,10 +52,13 @@ export default function EnrollmentTaskPage() {
         if (!taskToQuestionnaireMap || !subTasks?.[0]?.id || !taskToQuestionnaireMap[subTasks[0].id]) {
             return <>Task is ontvangen, maar er ontbreekt informatie.</>
         }
-        return <QuestionnaireRenderer
-            questionnaire={taskToQuestionnaireMap[subTasks[0].id]}
-            inputTask={subTasks[0]}
-        />
+        return <>
+            <QuestionnaireRenderer
+                questionnaire={taskToQuestionnaireMap[subTasks[0].id]}
+                inputTask={subTasks[0]}
+            />
+            <TaskSseConnectionStatus />
+        </>
     } else {
         return <div className='w-full flex flex-col auto-cols-max'>
             {
@@ -75,6 +79,7 @@ export default function EnrollmentTaskPage() {
                 }
             </div>
             {showViewer && <DataViewer task={task} />}
+            <TaskSseConnectionStatus />
         </div>
     }
 }

--- a/frontend/app/enrollment/task/[taskId]/page.tsx
+++ b/frontend/app/enrollment/task/[taskId]/page.tsx
@@ -11,19 +11,10 @@ import { viewerFeatureIsEnabled } from '@/app/actions'
 
 export default function EnrollmentTaskPage() {
     const { taskId } = useParams()
-    const { task, loading, initialized, setSelectedTaskId, subTasks, taskToQuestionnaireMap, refetchTasks } = useTaskProgressStore()
+    const { task, loading, initialized, setSelectedTaskId, subTasks, taskToQuestionnaireMap } = useTaskProgressStore()
     const { patient } = useEnrollmentStore()
     const [viewerFeatureEnabled, setViewerFeatureEnabled] = useState(false)
     const [showViewer, setShowViewer] = useState(false)
-
-    useEffect(() => {
-        console.warn("Enabling TMP polling")
-        const interval = setInterval(() => {
-            refetchTasks()
-        }, 2000)
-        return () => clearInterval(interval)
-    }, [refetchTasks])
-
 
     useEffect(() => {
         if (taskId) {

--- a/frontend/components/ui/hover-card.tsx
+++ b/frontend/components/ui/hover-card.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import * as React from "react"
+import * as HoverCardPrimitive from "@radix-ui/react-hover-card"
+
+import { cn } from "@/lib/utils"
+
+const HoverCard = HoverCardPrimitive.Root
+
+const HoverCardTrigger = HoverCardPrimitive.Trigger
+
+const HoverCardContent = React.forwardRef<
+  React.ElementRef<typeof HoverCardPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <HoverCardPrimitive.Content
+    ref={ref}
+    align={align}
+    sideOffset={sideOffset}
+    className={cn(
+      "z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-hover-card-content-transform-origin]",
+      className
+    )}
+    {...props}
+  />
+))
+HoverCardContent.displayName = HoverCardPrimitive.Content.displayName
+
+export { HoverCard, HoverCardTrigger, HoverCardContent }

--- a/frontend/lib/store/task-progress-store.ts
+++ b/frontend/lib/store/task-progress-store.ts
@@ -124,7 +124,7 @@ const useTaskProgressStore = () => {
                 // Detect if it's the primary Task or a subtask.
                 if (task.id === selectedTaskId) {
                     taskProgressStore.setState({ task });
-                } else {
+                } else if (task.partOf?.some(ref => ref.reference === `Task/${selectedTaskId}`)) {
                     taskProgressStore.setState((state) => {
                         const currentSubTasks = state.subTasks || [];
                         const index = currentSubTasks.findIndex(subTask => subTask.id === task.id);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@mui/material": "^6.4.8",
     "@radix-ui/react-collapsible": "^1.1.1",
     "@radix-ui/react-dialog": "^1.1.2",
+    "@radix-ui/react-hover-card": "^1.1.6",
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/react-label": "^2.1.2",
     "@radix-ui/react-popover": "^1.1.5",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 2.3.1(@types/hapi@18.0.14)(@types/node@22.13.4)(expo@52.0.11(@babel/core@7.26.0)(@babel/preset-env@7.26.7(@babel/core@7.26.0))(graphql@16.9.0)(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.7(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.1.2)(@types/react@18.3.16)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.7(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.1.2)(@types/react@18.3.16)(react@18.3.1))
       '@aehrc/smart-forms-renderer':
         specifier: ^0.45.1
-        version: 0.45.1(bmtepm2k46srxc6g3eff36vocm)
+        version: 0.45.1(364826f32fd73075c094632ef8897b16)
       '@babel/core':
         specifier: ^7.26.0
         version: 7.26.0
@@ -29,6 +29,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@18.3.5(@types/react@18.3.16))(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-hover-card':
+        specifier: ^1.1.6
+        version: 1.1.6(@types/react-dom@18.3.5(@types/react@18.3.16))(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-icons':
         specifier: ^1.3.2
         version: 1.3.2(react@18.3.1)
@@ -1364,7 +1367,6 @@ packages:
   '@mui/base@5.0.0-beta.62':
     resolution: {integrity: sha512-TzJLCNlrMkSU4bTCdTT+TVUiGx4sjZLhH673UV6YN+rNNP8wJpkWfRSvjDB5HcbH2T0lUamnz643ZnV+8IiMjw==}
     engines: {node: '>=14.0.0'}
-    deprecated: This package has been replaced by @base-ui-components/react
     peerDependencies:
       '@types/react': ^17.0.0 || ^18.0.0
       react: ^17.0.0 || ^18.0.0
@@ -1639,6 +1641,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-arrow@1.1.2':
+    resolution: {integrity: sha512-G+KcpzXHq24iH0uGG/pF8LyzpFJYGD4RfLjCIBfGdSLXvjLHST31RUiRVrupIBMvIppMgSzQ6l66iAxl03tdlg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-collapsible@1.1.1':
     resolution: {integrity: sha512-1///SnrfQHJEofLokyczERxQbWfCGQlQ2XsCZMucVs6it+lq9iw4vXy+uDn1edlb58cOZOWSldnfPAYcT4O/Yg==}
     peerDependencies:
@@ -1740,6 +1755,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dismissable-layer@1.1.5':
+    resolution: {integrity: sha512-E4TywXY6UsXNRhFrECa5HAvE5/4BFcGyfTyK36gP+pAW1ed7UTK4vKwdr53gAJYwqbfCWC6ATvJa3J3R/9+Qrg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-focus-guards@1.1.1':
     resolution: {integrity: sha512-pSIwfrT1a6sIoDASCSpFwOasEwKTZWDw/iBdtnqKO7v6FeOzYJ7U53cPzYFVR3geGGXgVHaH+CdngrrAzqUGxg==}
     peerDependencies:
@@ -1764,6 +1792,19 @@ packages:
 
   '@radix-ui/react-focus-scope@1.1.1':
     resolution: {integrity: sha512-01omzJAYRxXdG2/he/+xy+c8a8gCydoQ1yOxnWNcRhrrBW5W+RQJ22EK1SaO8tb3WoUsuEw7mJjBozPzihDFjA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-hover-card@1.1.6':
+    resolution: {integrity: sha512-E4ozl35jq0VRlrdc4dhHrNSV0JqBb4Jy73WAhBEK7JoYnQ83ED5r0Rb/XdVKw89ReAJN38N492BAPBZQ57VmqQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -1828,6 +1869,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-popper@1.2.2':
+    resolution: {integrity: sha512-Rvqc3nOpwseCyj/rgjlJDYAgyfw7OC1tTkKn2ivhaMGcYt8FSBlahHOZak2i3QwkRXUXgGgzeEe2RuqeEHuHgA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-portal@1.1.2':
     resolution: {integrity: sha512-WeDYLGPxJb/5EGBoedyJbT0MpoULmwnIPMJMSldkuiMsBAv7N1cRdsTWZWht9vpPOiN3qyiGAtbK2is47/uMFg==}
     peerDependencies:
@@ -1843,6 +1897,19 @@ packages:
 
   '@radix-ui/react-portal@1.1.3':
     resolution: {integrity: sha512-NciRqhXnGojhT93RPyDaMPfLH3ZSl4jjIFbZQ1b/vxvZEdHsBZ49wP9w8L3HzUQwep01LcWtkUvm0OVB5JAHTw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.4':
+    resolution: {integrity: sha512-sn2O9k1rPFYVyKd5LAJfo96JlSGVFpa1fS6UuBJfrZadudiw5tAmru+n1x7aMRQ84qDM71Zh1+SzK5QwU0tJfA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -6442,7 +6509,7 @@ snapshots:
       - react-native
       - supports-color
 
-  '@aehrc/smart-forms-renderer@0.45.1(bmtepm2k46srxc6g3eff36vocm)':
+  '@aehrc/smart-forms-renderer@0.45.1(364826f32fd73075c094632ef8897b16)':
     dependencies:
       '@aehrc/sdc-populate': 2.3.1(@types/hapi@18.0.14)(@types/node@22.13.4)(expo@52.0.11(@babel/core@7.26.0)(@babel/preset-env@7.26.7(@babel/core@7.26.0))(graphql@16.9.0)(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.7(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.1.2)(@types/react@18.3.16)(react@18.3.1))(react@18.3.1))(react-native@0.76.3(@babel/core@7.26.0)(@babel/preset-env@7.26.7(@babel/core@7.26.0))(@react-native-community/cli-server-api@15.1.2)(@types/react@18.3.16)(react@18.3.1))
       '@emotion/react': 11.13.5(@types/react@18.3.16)(react@18.3.1)
@@ -8601,6 +8668,15 @@ snapshots:
       '@types/react': 18.3.16
       '@types/react-dom': 18.3.5(@types/react@18.3.16)
 
+  '@radix-ui/react-arrow@1.1.2(@types/react-dom@18.3.5(@types/react@18.3.16))(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.5(@types/react@18.3.16))(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.16
+      '@types/react-dom': 18.3.5(@types/react@18.3.16)
+
   '@radix-ui/react-collapsible@1.1.1(@types/react-dom@18.3.5(@types/react@18.3.16))(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.0
@@ -8701,6 +8777,19 @@ snapshots:
       '@types/react': 18.3.16
       '@types/react-dom': 18.3.5(@types/react@18.3.16)
 
+  '@radix-ui/react-dismissable-layer@1.1.5(@types/react-dom@18.3.5(@types/react@18.3.16))(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.16)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.5(@types/react@18.3.16))(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.16)(react@18.3.1)
+      '@radix-ui/react-use-escape-keydown': 1.1.0(@types/react@18.3.16)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.16
+      '@types/react-dom': 18.3.5(@types/react@18.3.16)
+
   '@radix-ui/react-focus-guards@1.1.1(@types/react@18.3.16)(react@18.3.1)':
     dependencies:
       react: 18.3.1
@@ -8723,6 +8812,23 @@ snapshots:
       '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.16)(react@18.3.1)
       '@radix-ui/react-primitive': 2.0.1(@types/react-dom@18.3.5(@types/react@18.3.16))(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.16)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.16
+      '@types/react-dom': 18.3.5(@types/react@18.3.16)
+
+  '@radix-ui/react-hover-card@1.1.6(@types/react-dom@18.3.5(@types/react@18.3.16))(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.1
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.16)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.16)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.5(@types/react-dom@18.3.5(@types/react@18.3.16))(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.2(@types/react-dom@18.3.5(@types/react@18.3.16))(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.4(@types/react-dom@18.3.5(@types/react@18.3.16))(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.2(@types/react-dom@18.3.5(@types/react@18.3.16))(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.5(@types/react@18.3.16))(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.16)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -8790,6 +8896,24 @@ snapshots:
       '@types/react': 18.3.16
       '@types/react-dom': 18.3.5(@types/react@18.3.16)
 
+  '@radix-ui/react-popper@1.2.2(@types/react-dom@18.3.5(@types/react@18.3.16))(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-arrow': 1.1.2(@types/react-dom@18.3.5(@types/react@18.3.16))(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.3.16)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.16)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.5(@types/react@18.3.16))(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.16)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.16)(react@18.3.1)
+      '@radix-ui/react-use-rect': 1.1.0(@types/react@18.3.16)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.0(@types/react@18.3.16)(react@18.3.1)
+      '@radix-ui/rect': 1.1.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.16
+      '@types/react-dom': 18.3.5(@types/react@18.3.16)
+
   '@radix-ui/react-portal@1.1.2(@types/react-dom@18.3.5(@types/react@18.3.16))(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.5(@types/react@18.3.16))(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -8803,6 +8927,16 @@ snapshots:
   '@radix-ui/react-portal@1.1.3(@types/react-dom@18.3.5(@types/react@18.3.16))(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.0.1(@types/react-dom@18.3.5(@types/react@18.3.16))(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.16)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.16
+      '@types/react-dom': 18.3.5(@types/react@18.3.16)
+
+  '@radix-ui/react-portal@1.1.4(@types/react-dom@18.3.5(@types/react@18.3.16))(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.2(@types/react-dom@18.3.5(@types/react@18.3.16))(@types/react@18.3.16)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.16)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)

--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -615,7 +615,7 @@ func (s Service) handleNotification(ctx context.Context, resource any) error {
 	}
 	// TODO: for now, we assume the resource URL is always in the form of <FHIR base url>/<resource type>/<resource id>
 	//       Then, we can deduce the FHIR base URL from the resource URL
-	fhirBaseURL, _, err := coolfhir.ParseExternalLiteralReference(resourceUrl, *focusReference.Type)
+	fhirBaseURL, relativeReference, err := coolfhir.ParseExternalLiteralReference(resourceUrl, *focusReference.Type)
 	if err != nil {
 		return err
 	}
@@ -665,7 +665,7 @@ func (s Service) handleNotification(ctx context.Context, resource any) error {
 			if parentTaskReference != "" {
 				s.sseService.Publish(parentTaskReference, string(data))
 			} else {
-				s.sseService.Publish(fmt.Sprintf("Task/%s", *task.Id), string(data))
+				s.sseService.Publish(relativeReference, string(data))
 			}
 		}
 	case "CarePlan":

--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -693,7 +693,7 @@ func (s Service) handleNotification(ctx context.Context, resource any) error {
 		focusResource = task
 		// TODO: How to differentiate between create and update? (Currently we only use Create in CPS. There is code for Update but nothing calls it)
 		// TODO: Move this to a event.Handler implementation
-		err = s.publishTaskToSse(&task)
+		err = s.publishTaskToSse(ctx, &task)
 		if err != nil {
 			//gracefully log the error, but continue processing the notification
 			log.Ctx(ctx).Err(err).Msgf("Failed to publish task (id=%s) to SSE", *task.Id)
@@ -726,7 +726,7 @@ func (s Service) handleNotification(ctx context.Context, resource any) error {
 	})
 }
 
-func (s Service) publishTaskToSse(task *fhir.Task) error {
+func (s Service) publishTaskToSse(ctx context.Context, task *fhir.Task) error {
 	data, err := json.Marshal(task)
 	if err != nil {
 		return err
@@ -744,9 +744,9 @@ func (s Service) publishTaskToSse(task *fhir.Task) error {
 	}
 
 	if parentTaskReference != "" {
-		s.sseService.Publish(parentTaskReference, string(data))
+		s.sseService.Publish(ctx, parentTaskReference, string(data))
 	} else {
-		s.sseService.Publish(fmt.Sprintf("Task/%s", *task.Id), string(data))
+		s.sseService.Publish(ctx, fmt.Sprintf("Task/%s", *task.Id), string(data))
 	}
 
 	return nil

--- a/orchestrator/careplancontributor/sse/service.go
+++ b/orchestrator/careplancontributor/sse/service.go
@@ -1,0 +1,88 @@
+package sse
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+)
+
+// This service maps a topic to a set of clients that are interested in receiving
+// messages for that topic. Clients can subscribe to a topic by connecting to the
+// server-sent events (SSE) endpoint for that topic. The server can then publish
+// messages to all clients subscribed to a topic.
+type Service struct {
+	mu      sync.RWMutex
+	clients map[string]map[chan string]struct{} // topic -> clients
+}
+
+func New() *Service {
+	return &Service{
+		clients: make(map[string]map[chan string]struct{}),
+	}
+}
+
+func (s *Service) ServeHTTP(topic string, writer http.ResponseWriter, request *http.Request) {
+	// Set headers for server-sent events (SSE)
+	writer.Header().Set("Content-Type", "text/event-stream")
+	writer.Header().Set("Cache-Control", "no-cache")
+	writer.Header().Set("Connection", "keep-alive")
+	writer.Header().Set("X-Accel-Buffering", "no")
+
+	// Check if the ResponseWriter supports the Flusher interface
+	flusher, ok := writer.(http.Flusher)
+	if !ok {
+		http.Error(writer, "Streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	// Create a channel for the client and register it
+	msgCh := make(chan string, 10)
+	s.registerClient(topic, msgCh)
+	defer s.unregisterClient(topic, msgCh)
+
+	// Send messages to the client
+	ctx := request.Context()
+	for {
+		select {
+		case msg := <-msgCh:
+			fmt.Fprintf(writer, "data: %s\n\n", msg)
+			flusher.Flush()
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (s *Service) registerClient(topic string, ch chan string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.clients[topic]; !exists {
+		s.clients[topic] = make(map[chan string]struct{})
+	}
+	s.clients[topic][ch] = struct{}{}
+}
+
+func (s *Service) unregisterClient(topic string, ch chan string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.clients[topic]; exists {
+		delete(s.clients[topic], ch)
+		close(ch)
+	}
+}
+
+func (s *Service) Publish(topic string, msg string) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for ch := range s.clients[topic] {
+		select {
+		case ch <- msg:
+		default:
+			log.Printf("client channel full, dropping message on topic %s", topic)
+		}
+	}
+}

--- a/orchestrator/careplancontributor/sse/service.go
+++ b/orchestrator/careplancontributor/sse/service.go
@@ -41,6 +41,10 @@ func (s *Service) ServeHTTP(topic string, writer http.ResponseWriter, request *h
 	s.registerClient(topic, msgCh)
 	defer s.unregisterClient(topic, msgCh)
 
+	// A comment/ping as per SSE spec - marks the start of the stream
+	fmt.Fprintf(writer, ": ping\n\n")
+	flusher.Flush()
+
 	// Send messages to the client
 	ctx := request.Context()
 	for {

--- a/orchestrator/careplancontributor/sse/service.go
+++ b/orchestrator/careplancontributor/sse/service.go
@@ -72,9 +72,12 @@ func (s *Service) unregisterClient(topic string, ch chan string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if _, exists := s.clients[topic]; exists {
-		delete(s.clients[topic], ch)
+	if clients, exists := s.clients[topic]; exists {
+		delete(clients, ch)
 		close(ch)
+		if len(clients) == 0 {
+			delete(s.clients, topic)
+		}
 	}
 }
 

--- a/orchestrator/careplancontributor/sse/service.go
+++ b/orchestrator/careplancontributor/sse/service.go
@@ -45,7 +45,7 @@ func (s *Service) ServeHTTP(topic string, writer http.ResponseWriter, request *h
 	fmt.Fprintf(writer, ": ping\n\n")
 	flusher.Flush()
 
-	// Send messages to the client
+	// Keep listening for messages to send to the client - keeps the connection open
 	ctx := request.Context()
 	for {
 		select {

--- a/orchestrator/careplancontributor/sse/service_test.go
+++ b/orchestrator/careplancontributor/sse/service_test.go
@@ -126,7 +126,7 @@ func TestPublish_ChannelFull(t *testing.T) {
 	s.registerClient("full", ch)
 
 	// Fill the channel.
-	ch <- "first"
+	s.Publish("full", "first")
 	// At this point, the channel is full (buffer size is 1).
 	// Publish a message which should be dropped.
 	s.Publish("full", "dropped")

--- a/orchestrator/careplancontributor/sse/service_test.go
+++ b/orchestrator/careplancontributor/sse/service_test.go
@@ -73,7 +73,14 @@ func TestServeHTTP_Publishes(t *testing.T) {
 	}()
 
 	// Give the ServeHTTP loop time to start and register the client.
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(10 * time.Millisecond)
+
+	// Check that the initial ping is sent
+	output := frw.readOutput()
+	expected := "ping\n\n"
+	if !strings.Contains(output, expected) {
+		t.Errorf("expected output to contain %q, got %q", expected, output)
+	}
 
 	// Publish a message.
 	msg := "hello world"
@@ -87,9 +94,12 @@ func TestServeHTTP_Publishes(t *testing.T) {
 		t.Fatal("timed out waiting for flush")
 	}
 
+	// Give the ServeHTTP loop time to send the async message.
+	time.Sleep(10 * time.Millisecond)
+
 	// Check that the output contains our published message.
-	output := frw.readOutput()
-	expected := "data: " + msg + "\n\n"
+	output = frw.readOutput()
+	expected = "data: " + msg + "\n\n"
 	if !strings.Contains(output, expected) {
 		t.Errorf("expected output to contain %q, got %q", expected, output)
 	}

--- a/orchestrator/careplancontributor/sse/service_test.go
+++ b/orchestrator/careplancontributor/sse/service_test.go
@@ -84,7 +84,7 @@ func TestServeHTTP_Publishes(t *testing.T) {
 
 	// Publish a message.
 	msg := "hello world"
-	s.Publish("test", msg)
+	s.Publish(ctx, "test", msg)
 
 	// Wait for a flush to occur (i.e. message has been written).
 	select {
@@ -119,6 +119,8 @@ func TestServeHTTP_Publishes(t *testing.T) {
 // The message is dropped in this case.
 func TestPublish_ChannelFull(t *testing.T) {
 	s := New()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
 	// Create a dummy client channel with a small buffer.
 	ch := make(chan string, 1)
@@ -126,10 +128,10 @@ func TestPublish_ChannelFull(t *testing.T) {
 	s.registerClient("full", ch)
 
 	// Fill the channel.
-	s.Publish("full", "first")
+	s.Publish(ctx, "full", "first")
 	// At this point, the channel is full (buffer size is 1).
 	// Publish a message which should be dropped.
-	s.Publish("full", "dropped")
+	s.Publish(ctx, "full", "dropped")
 
 	// Read from channel: should only receive the first message.
 	select {

--- a/orchestrator/careplancontributor/sse/service_test.go
+++ b/orchestrator/careplancontributor/sse/service_test.go
@@ -1,0 +1,189 @@
+package sse
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeResponseWriter is a custom ResponseWriter that supports http.Flusher.
+type fakeResponseWriter struct {
+	header  http.Header
+	mu      sync.Mutex
+	buf     bytes.Buffer
+	flushed chan struct{}
+}
+
+func newFakeResponseWriter() *fakeResponseWriter {
+	return &fakeResponseWriter{
+		header:  make(http.Header),
+		flushed: make(chan struct{}, 100),
+	}
+}
+
+func (w *fakeResponseWriter) Header() http.Header {
+	return w.header
+}
+
+func (w *fakeResponseWriter) Write(b []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.Write(b)
+}
+
+func (w *fakeResponseWriter) WriteHeader(statusCode int) {
+	// For testing we ignore the status code.
+}
+
+func (w *fakeResponseWriter) Flush() {
+	// Signal that a flush has occurred.
+	w.flushed <- struct{}{}
+}
+
+// readOutput returns the current written output.
+func (w *fakeResponseWriter) readOutput() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String()
+}
+
+// TestServeHTTP_Publishes tests that messages published on a topic
+// are received by a connected SSE client.
+func TestServeHTTP_Publishes(t *testing.T) {
+	s := New()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// create a fake request with our cancellable context.
+	req := httptest.NewRequest("GET", "/subscribe/test", nil)
+	req = req.WithContext(ctx)
+	// Create our fake response writer.
+	frw := newFakeResponseWriter()
+
+	// Run ServeHTTP in a goroutine.
+	done := make(chan struct{})
+	go func() {
+		s.ServeHTTP("test", frw, req)
+		close(done)
+	}()
+
+	// Give the ServeHTTP loop time to start and register the client.
+	time.Sleep(100 * time.Millisecond)
+
+	// Publish a message.
+	msg := "hello world"
+	s.Publish("test", msg)
+
+	// Wait for a flush to occur (i.e. message has been written).
+	select {
+	case <-frw.flushed:
+		// message flushed.
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("timed out waiting for flush")
+	}
+
+	// Check that the output contains our published message.
+	output := frw.readOutput()
+	expected := "data: " + msg + "\n\n"
+	if !strings.Contains(output, expected) {
+		t.Errorf("expected output to contain %q, got %q", expected, output)
+	}
+
+	// Cancel the request context so that ServeHTTP loop ends.
+	cancel()
+
+	// Wait for ServeHTTP to return.
+	select {
+	case <-done:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("ServeHTTP did not exit after context cancellation")
+	}
+}
+
+// TestPublish_ChannelFull tests the Publish method when client channel buffer is full.
+// The message is dropped in this case.
+func TestPublish_ChannelFull(t *testing.T) {
+	s := New()
+
+	// Create a dummy client channel with a small buffer.
+	ch := make(chan string, 1)
+	// Register the client under topic "full".
+	s.registerClient("full", ch)
+
+	// Fill the channel.
+	ch <- "first"
+	// At this point, the channel is full (buffer size is 1).
+	// Publish a message which should be dropped.
+	s.Publish("full", "dropped")
+
+	// Read from channel: should only receive the first message.
+	select {
+	case msg := <-ch:
+		if msg != "first" {
+			t.Errorf("expected message 'first', got %q", msg)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected to receive a message")
+	}
+
+	// There should be no second message.
+	select {
+	case msg := <-ch:
+		t.Errorf("unexpected message received: %q", msg)
+	case <-time.After(100 * time.Millisecond):
+		// expected no message.
+	}
+
+	// Clean up.
+	s.unregisterClient("full", ch)
+}
+
+// TestRegisterAndUnregisterClient tests that registerClient and unregisterClient add and remove clients appropriately.
+func TestRegisterAndUnregisterClient(t *testing.T) {
+	s := New()
+	topic := "testTopic"
+	ch := make(chan string, 10)
+
+	// Initially, topic should not exist.
+	s.mu.RLock()
+	if _, exists := s.clients[topic]; exists {
+		t.Errorf("expected topic %q not to exist", topic)
+	}
+	s.mu.RUnlock()
+
+	// Register client.
+	s.registerClient(topic, ch)
+
+	s.mu.RLock()
+	clients, exists := s.clients[topic]
+	s.mu.RUnlock()
+	if !exists {
+		t.Fatalf("expected topic %q to exist after registration", topic)
+	}
+	if _, exists = clients[ch]; !exists {
+		t.Errorf("expected channel to be registered under topic %q", topic)
+	}
+
+	// Unregister client.
+	s.unregisterClient(topic, ch)
+
+	s.mu.RLock()
+	clients, exists = s.clients[topic]
+	s.mu.RUnlock()
+	// Channel should be removed.
+	if exists {
+		if _, exists := clients[ch]; exists {
+			t.Errorf("expected channel to be removed from topic %q", topic)
+		}
+	}
+	// Also, channel should be closed.
+	_, open := <-ch
+	if open {
+		t.Errorf("expected channel to be closed upon unregistration")
+	}
+}

--- a/orchestrator/careplancontributor/testdata/task-3.json
+++ b/orchestrator/careplancontributor/testdata/task-3.json
@@ -6,6 +6,12 @@
       "type": "CarePlan"
     }
   ],
+  "identifier": [
+    {
+      "system": "http://fhir.nl/fhir/NamingSystem/task-workflow-identifier",
+      "value": "12345"
+    }
+  ],
   "status": "requested",
   "intent": "order",
   "requester": {


### PR DESCRIPTION
The frontend can now subscribe to changes of a specific Task (with a valid session). Changes to that Task (or subtasks related to) are pushed to the browser. This is done via a generic "SSE" service. This service is injected into the CPC. It can be re-used for other topics as well. Currently only used for Task topics.

Removed the short-term polling solution, and the existing polling solution after a QuestionnaireResponse is created, and the application awaits the other party to process it.

The `EventSource` will automatically reconnect when the connection is lost. The bottom-right of the screen contains a "connected"-indicator of the SSE stream with the Go backend:
<img width="958" alt="Screenshot 2025-03-26 at 13 12 38" src="https://github.com/user-attachments/assets/9a0afb06-4bf6-4dd2-bc74-edb74e854d03" />

And on hover:
<img width="958" alt="Screenshot 2025-03-26 at 13 12 53" src="https://github.com/user-attachments/assets/308cc21d-c2f8-4e02-af6d-6d976e2f21b0" />