### PR TITLE
INT-698: Set `Task.meta.source` on SSE push

### DIFF
--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -691,6 +691,18 @@ func (s Service) handleNotification(ctx context.Context, resource any) error {
 			return err
 		}
 		focusResource = task
+
+		//insert the meta.source - can be used to determine the X-Scp-Context
+		if task.Meta == nil {
+			task.Meta = &fhir.Meta{}
+		}
+
+		if task.Meta.Source != nil && task.Meta.Source != &resourceUrl {
+			log.Ctx(ctx).Warn().Msgf("Task (id=%s) already has a source (%s), overwriting it to (%s)", *task.Id, *task.Meta.Source, resourceUrl)
+		}
+
+		task.Meta.Source = &resourceUrl
+
 		// TODO: How to differentiate between create and update? (Currently we only use Create in CPS. There is code for Update but nothing calls it)
 		// TODO: Move this to a event.Handler implementation
 		err = s.publishTaskToSse(ctx, &task)

--- a/orchestrator/careplancontributor/sse/service.go
+++ b/orchestrator/careplancontributor/sse/service.go
@@ -97,7 +97,7 @@ func (s *Service) Publish(ctx context.Context, topic string, msg string) {
 		select {
 		case ch <- msg:
 		default:
-			log.Ctx(ctx).Info().Msgf("client channel full, dropping message on topic %s", topic)
+			log.Ctx(ctx).Warn().Msgf("client channel full, dropping message on topic %s", topic)
 		}
 	}
 }


### PR DESCRIPTION
**Why**

The `Task.meta.source` is used to determine the `X-Scp-Context` header

**What**

This allows the viewer to `/aggregate` all resources right after a `Task` update is pushed

Also changed the log level on a full publish channel, forgot to change this PR feedback  in the INT-691 PR