### PR TITLE
INT-700: Remove scrollToTop logic

### DIFF
--- a/frontend/app/enrollment/components/questionnaire-renderer.tsx
+++ b/frontend/app/enrollment/components/questionnaire-renderer.tsx
@@ -31,20 +31,12 @@ function QuestionnaireRenderer(props: QuestionnaireRendererPageProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [prePopulated, setPrePopulated] = useState(false);
   const [initialized, setInitialized] = useState(false)
-  const [shouldScroll, setShouldScroll] = useState(false)
 
   const [, setPrevQuestionnaireResponse] = useState<QuestionnaireResponse>()
 
   const cpsClient = useCpsClient()
   const { task } = useTaskProgressStore()
   const router = useRouter()
-
-  useEffect(() => {
-    if (shouldScroll) {
-      window.scrollTo({ top: 0, behavior: 'smooth' })
-      setShouldScroll(false);
-    }
-  }, [shouldScroll]);
 
   useEffect(() => {
 
@@ -81,8 +73,6 @@ function QuestionnaireRenderer(props: QuestionnaireRendererPageProps) {
     }
 
     setIsSubmitting(true)
-
-    setShouldScroll(true)
 
     const outputTask = { ...inputTask }
     const questionnaireResponse = await findQuestionnaireResponse(inputTask, questionnaire)


### PR DESCRIPTION
Was used before when there were multiple Questionnaires. Now simply goes to the Task status page, so it'll be at the top after a new Task is received. 

If needed, this logic can be performed on Task updates, which is cleaner anyway.