### PR TITLE
INT-701: Fix the Task accepted notification

### DIFF
--- a/orchestrator/careplancontributor/handle_taskfiller.go
+++ b/orchestrator/careplancontributor/handle_taskfiller.go
@@ -128,6 +128,7 @@ func (s *Service) handleSubtaskNotification(ctx context.Context, cpsClient fhirc
 }
 
 func (s *Service) acceptPrimaryTask(ctx context.Context, cpsClient fhirclient.Client, primaryTask *fhir.Task) error {
+	log.Ctx(ctx).Debug().Msgf("Started function acceptPrimaryTask() for Task (task=%s)", *primaryTask.Id)
 	if primaryTask.Status != fhir.TaskStatusRequested && primaryTask.Status != fhir.TaskStatusReceived {
 		log.Ctx(ctx).Debug().Msg("primary Task.status != requested||received (workflow already started) - not processing in handleTaskNotification")
 		return nil

--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -126,6 +126,7 @@ func New(
 		if err != nil {
 			return nil, fmt.Errorf("TaskEngine: failed to create EHR notifier: %w", err)
 		}
+		log.Ctx(ctx).Info().Msgf("TaskEngine: created EHR notifier for topic %s", config.TaskFiller.TaskAcceptedBundleTopic)
 	}
 	pubsub.DefaultSubscribers.FhirSubscriptionNotify = result.handleNotification
 	return result, nil

--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -120,6 +120,7 @@ func New(
 		eventManager:                  eventManager,
 		sseService:                    sse.New(),
 	}
+	result.createFHIRClientForURL = result.defaultCreateFHIRClientForURL
 	if config.TaskFiller.TaskAcceptedBundleTopic != "" {
 		result.notifier, err = ehr.NewNotifier(eventManager, messageBroker, messaging.Entity{Name: config.TaskFiller.TaskAcceptedBundleTopic}, result.createFHIRClientForURL)
 		if err != nil {
@@ -127,7 +128,6 @@ func New(
 		}
 	}
 	pubsub.DefaultSubscribers.FhirSubscriptionNotify = result.handleNotification
-	result.createFHIRClientForURL = result.defaultCreateFHIRClientForURL
 	return result, nil
 }
 

--- a/orchestrator/careplanservice/subscriptions/channels.go
+++ b/orchestrator/careplanservice/subscriptions/channels.go
@@ -7,14 +7,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+
 	fhirclient "github.com/SanteonNL/go-fhir-client"
 	"github.com/SanteonNL/orca/orchestrator/cmd/profile"
 	"github.com/SanteonNL/orca/orchestrator/lib/auth"
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
 	"github.com/SanteonNL/orca/orchestrator/lib/pubsub"
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
-	"io"
-	"net/http"
 )
 
 // ChannelFactory defines an interface for creating Subscription Notification Channels (e.g. rest-hook).
@@ -106,7 +107,7 @@ func (r RestHookChannel) Notify(ctx context.Context, notification coolfhir.Subsc
 	// Be a good client and read the response, even if we don't actually do anything with it.
 	_, _ = io.ReadAll(io.LimitReader(httpResponse.Body, 1024))
 	if httpResponse.StatusCode < 200 || httpResponse.StatusCode >= 300 {
-		return errors.Join(ReceiverFailure, fmt.Errorf("non-OK HTTP response status: %v", httpResponse.Status))
+		return errors.Join(ReceiverFailure, fmt.Errorf("non-OK HTTP response from %s status: %v", r.Endpoint, httpResponse.Status))
 	}
 	return nil
 }

--- a/orchestrator/careplanservice/subscriptions/channels_test.go
+++ b/orchestrator/careplanservice/subscriptions/channels_test.go
@@ -3,6 +3,13 @@ package subscriptions
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
 	fhirclient "github.com/SanteonNL/go-fhir-client"
 	"github.com/SanteonNL/orca/orchestrator/cmd/profile"
 	"github.com/SanteonNL/orca/orchestrator/lib/auth"
@@ -11,12 +18,6 @@ import (
 	"github.com/SanteonNL/orca/orchestrator/lib/to"
 	"github.com/stretchr/testify/require"
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
-	"io"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
-	"testing"
-	"time"
 )
 
 func TestRestHookChannel_Notify(t *testing.T) {
@@ -60,7 +61,7 @@ func TestRestHookChannel_Notify(t *testing.T) {
 		err := channel.Notify(context.Background(), notification)
 
 		require.ErrorIs(t, err, ReceiverFailure)
-		require.EqualError(t, err, "FHIR subscription could not be delivered to receiver\nnon-OK HTTP response status: 404 Not Found")
+		require.EqualError(t, err, "FHIR subscription could not be delivered to receiver\nnon-OK HTTP response from "+subscriberServer.URL+" status: 404 Not Found")
 	})
 	t.Run("subscriber endpoint unreachable", func(t *testing.T) {
 		subscriberServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {

--- a/orchestrator/messaging/http.go
+++ b/orchestrator/messaging/http.go
@@ -10,6 +10,8 @@ import (
 	"slices"
 	"strings"
 	"time"
+
+	"github.com/rs/zerolog/log"
 )
 
 var _ Broker = &HTTPBroker{}
@@ -24,6 +26,7 @@ func NewHTTPBroker(config HTTPBrokerConfig, underlyingBroker Broker) Broker {
 	return HTTPBroker{
 		underlyingBroker: underlyingBroker,
 		endpoint:         config.Endpoint,
+		topicFilter:      config.TopicFilter,
 	}
 }
 
@@ -48,9 +51,9 @@ func (h HTTPBroker) Close(ctx context.Context) error {
 }
 
 func (h HTTPBroker) SendMessage(ctx context.Context, topic Entity, message *Message) error {
-	if len(h.topicFilter) != 0 && !slices.Contains(h.topicFilter, topic.Name) {
-		return nil
-	}
+
+	log.Ctx(ctx).Debug().Msgf("Sending message to topic %s. ", topic.Name)
+
 	var errs []error
 	if err := h.doSend(ctx, topic, message); err != nil {
 		errs = append(errs, fmt.Errorf("failed to send message over HTTP: %w", err))
@@ -60,10 +63,19 @@ func (h HTTPBroker) SendMessage(ctx context.Context, topic Entity, message *Mess
 			errs = append(errs, err)
 		}
 	}
+	if len(errs) == 0 {
+		log.Ctx(ctx).Debug().Msgf("Sent message to topic %s", topic.Name)
+	}
 	return errors.Join(errs...)
 }
 
 func (h HTTPBroker) doSend(ctx context.Context, topic Entity, message *Message) error {
+
+	if len(h.topicFilter) != 0 && !slices.Contains(h.topicFilter, topic.Name) {
+		log.Ctx(ctx).Debug().Msgf("Skipping message for topic %s", topic.Name)
+		return nil
+	}
+
 	// unmarshall and marshall the value to remove extra whitespace
 	var v interface{}
 	err := json.Unmarshal(message.Body, &v)
@@ -86,6 +98,7 @@ func (h HTTPBroker) doSend(ctx context.Context, topic Entity, message *Message) 
 		return err
 	}
 	req.Header.Set("Content-Type", message.ContentType)
+	log.Ctx(ctx).Debug().Msgf("Sending message to %s", req.URL.String())
 	client := &http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {

--- a/orchestrator/messaging/http.go
+++ b/orchestrator/messaging/http.go
@@ -52,7 +52,7 @@ func (h HTTPBroker) Close(ctx context.Context) error {
 
 func (h HTTPBroker) SendMessage(ctx context.Context, topic Entity, message *Message) error {
 
-	log.Ctx(ctx).Debug().Msgf("Sending message to topic %s. ", topic.Name)
+	log.Ctx(ctx).Debug().Msgf("SendMessage invoked for topic %s. ", topic.Name)
 
 	var errs []error
 	if err := h.doSend(ctx, topic, message); err != nil {


### PR DESCRIPTION
On the local dev server, the MSC viewer doesn't receive updates on the accepted Task anymore. The Task isn't pushed to the viewer, and is never listed any more.