### PR TITLE
Fix: start.sh failing if tunnel file does not exist

### DIFF
--- a/deployments/dev/start.sh
+++ b/deployments/dev/start.sh
@@ -6,7 +6,7 @@ set -e
 # It takes a port to forward to the tunnel, and returns the tunnel URL
 # It kills the tunnel when this bash script exits
 function createTunnel() {
-  rm $1/data/tunnel.*
+  rm -f $1/data/tunnel.*
   local tunnelFile=$1/data/tunnel.id
   local tunnelPidFile=$1/data/tunnel.pid
   local tunnelPort=$2


### PR DESCRIPTION
This prevents the start.sh script from failing if it can't remove tunnel files that don't exist