### PR TITLE
FIX | Disable audit based authorisation

### DIFF
--- a/orchestrator/careplanservice/handle_getcondition_test.go
+++ b/orchestrator/careplanservice/handle_getcondition_test.go
@@ -170,73 +170,74 @@ func TestService_handleGetCondition(t *testing.T) {
 					})
 			},
 		},
-		"error: Condition exists, subject is patient, patient returned, incorrect principal": {
-			context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal3),
-			request: FHIRHandlerRequest{
-				Principal:   auth.TestPrincipal3,
-				ResourceId:  "1",
-				FhirHeaders: &fhirclient.Headers{},
-			},
-			expectedError: &coolfhir.ErrorWithCode{
-				Message:    "Participant does not have access to Condition",
-				StatusCode: http.StatusForbidden,
-			},
-			setup: func(ctx context.Context, client *mock.MockClient) {
-				client.EXPECT().ReadWithContext(ctx, "Condition/1", gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, target *fhir.Condition, _ ...fhirclient.Option) error {
-						*target = condition1
-						return nil
-					})
-				client.EXPECT().SearchWithContext(ctx, "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-						return nil
-					})
-				client.EXPECT().SearchWithContext(ctx, "Patient", gomock.Any(), gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-						*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: patient1Raw}}}
-						return nil
-					})
-				client.EXPECT().SearchWithContext(ctx, "CarePlan", gomock.Any(), gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-						*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: carePlan1Raw}}}
-						return nil
-					})
-			},
-		},
-		"ok: Condition exists, subject is patient, patient returned, incorrect principal, but AuditEvent is found": {
-			context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal3),
-			request: FHIRHandlerRequest{
-				Principal:   auth.TestPrincipal3,
-				ResourceId:  "1",
-				FhirHeaders: &fhirclient.Headers{},
-				LocalIdentity: &fhir.Identifier{
-					System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
-					Value:  to.Ptr("1"),
-				},
-			},
-			setup: func(ctx context.Context, client *mock.MockClient) {
-				client.EXPECT().ReadWithContext(ctx, "Condition/1", gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, target *fhir.Condition, _ ...fhirclient.Option) error {
-						*target = condition1
-						return nil
-					})
-				client.EXPECT().SearchWithContext(ctx, "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-						*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: auditEventRaw}}}
-						return nil
-					})
-				client.EXPECT().SearchWithContext(ctx, "Patient", gomock.Any(), gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-						*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: patient1Raw}}}
-						return nil
-					})
-				client.EXPECT().SearchWithContext(ctx, "CarePlan", gomock.Any(), gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-						*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: carePlan1Raw}}}
-						return nil
-					})
-			},
-		},
+		// TODO: Re-implement, test case is still valid but auth mechanism needs to change
+		//"error: Condition exists, subject is patient, patient returned, incorrect principal": {
+		//	context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal3),
+		//	request: FHIRHandlerRequest{
+		//		Principal:   auth.TestPrincipal3,
+		//		ResourceId:  "1",
+		//		FhirHeaders: &fhirclient.Headers{},
+		//	},
+		//	expectedError: &coolfhir.ErrorWithCode{
+		//		Message:    "Participant does not have access to Condition",
+		//		StatusCode: http.StatusForbidden,
+		//	},
+		//	setup: func(ctx context.Context, client *mock.MockClient) {
+		//		client.EXPECT().ReadWithContext(ctx, "Condition/1", gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, target *fhir.Condition, _ ...fhirclient.Option) error {
+		//				*target = condition1
+		//				return nil
+		//			})
+		//		client.EXPECT().SearchWithContext(ctx, "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+		//				return nil
+		//			})
+		//		client.EXPECT().SearchWithContext(ctx, "Patient", gomock.Any(), gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+		//				*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: patient1Raw}}}
+		//				return nil
+		//			})
+		//		client.EXPECT().SearchWithContext(ctx, "CarePlan", gomock.Any(), gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+		//				*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: carePlan1Raw}}}
+		//				return nil
+		//			})
+		//	},
+		//},
+		//"ok: Condition exists, subject is patient, patient returned, incorrect principal, but creator of resource": {
+		//	context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal3),
+		//	request: FHIRHandlerRequest{
+		//		Principal:   auth.TestPrincipal3,
+		//		ResourceId:  "1",
+		//		FhirHeaders: &fhirclient.Headers{},
+		//		LocalIdentity: &fhir.Identifier{
+		//			System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
+		//			Value:  to.Ptr("1"),
+		//		},
+		//	},
+		//	setup: func(ctx context.Context, client *mock.MockClient) {
+		//		client.EXPECT().ReadWithContext(ctx, "Condition/1", gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, target *fhir.Condition, _ ...fhirclient.Option) error {
+		//				*target = condition1
+		//				return nil
+		//			})
+		//		client.EXPECT().SearchWithContext(ctx, "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+		//				*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: auditEventRaw}}}
+		//				return nil
+		//			})
+		//		client.EXPECT().SearchWithContext(ctx, "Patient", gomock.Any(), gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+		//				*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: patient1Raw}}}
+		//				return nil
+		//			})
+		//		client.EXPECT().SearchWithContext(ctx, "CarePlan", gomock.Any(), gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+		//				*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: carePlan1Raw}}}
+		//				return nil
+		//			})
+		//	},
+		//},
 		"ok: Condition exists, subject is patient, patient returned, correct principal": {
 			context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal1),
 			request: FHIRHandlerRequest{

--- a/orchestrator/careplanservice/handle_getcondition_test.go
+++ b/orchestrator/careplanservice/handle_getcondition_test.go
@@ -69,6 +69,8 @@ func TestService_handleGetCondition(t *testing.T) {
 		request       FHIRHandlerRequest
 		expectedError error
 		setup         func(ctx context.Context, client *mock.MockClient)
+		// TODO: Temporarily disabling the audit-based auth tests, re-enable tests once auth has been re-implemented
+		shouldSkip bool
 	}{
 		"error: Condition does not exist": {
 			context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal1),
@@ -170,74 +172,66 @@ func TestService_handleGetCondition(t *testing.T) {
 					})
 			},
 		},
-		// TODO: Re-implement, test case is still valid but auth mechanism needs to change
-		//"error: Condition exists, subject is patient, patient returned, incorrect principal": {
-		//	context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal3),
-		//	request: FHIRHandlerRequest{
-		//		Principal:   auth.TestPrincipal3,
-		//		ResourceId:  "1",
-		//		FhirHeaders: &fhirclient.Headers{},
-		//	},
-		//	expectedError: &coolfhir.ErrorWithCode{
-		//		Message:    "Participant does not have access to Condition",
-		//		StatusCode: http.StatusForbidden,
-		//	},
-		//	setup: func(ctx context.Context, client *mock.MockClient) {
-		//		client.EXPECT().ReadWithContext(ctx, "Condition/1", gomock.Any(), gomock.Any()).
-		//			DoAndReturn(func(_ context.Context, _ string, target *fhir.Condition, _ ...fhirclient.Option) error {
-		//				*target = condition1
-		//				return nil
-		//			})
-		//		client.EXPECT().SearchWithContext(ctx, "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).
-		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-		//				return nil
-		//			})
-		//		client.EXPECT().SearchWithContext(ctx, "Patient", gomock.Any(), gomock.Any(), gomock.Any()).
-		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-		//				*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: patient1Raw}}}
-		//				return nil
-		//			})
-		//		client.EXPECT().SearchWithContext(ctx, "CarePlan", gomock.Any(), gomock.Any(), gomock.Any()).
-		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-		//				*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: carePlan1Raw}}}
-		//				return nil
-		//			})
-		//	},
-		//},
-		//"ok: Condition exists, subject is patient, patient returned, incorrect principal, but creator of resource": {
-		//	context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal3),
-		//	request: FHIRHandlerRequest{
-		//		Principal:   auth.TestPrincipal3,
-		//		ResourceId:  "1",
-		//		FhirHeaders: &fhirclient.Headers{},
-		//		LocalIdentity: &fhir.Identifier{
-		//			System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
-		//			Value:  to.Ptr("1"),
-		//		},
-		//	},
-		//	setup: func(ctx context.Context, client *mock.MockClient) {
-		//		client.EXPECT().ReadWithContext(ctx, "Condition/1", gomock.Any(), gomock.Any()).
-		//			DoAndReturn(func(_ context.Context, _ string, target *fhir.Condition, _ ...fhirclient.Option) error {
-		//				*target = condition1
-		//				return nil
-		//			})
-		//		client.EXPECT().SearchWithContext(ctx, "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).
-		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-		//				*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: auditEventRaw}}}
-		//				return nil
-		//			})
-		//		client.EXPECT().SearchWithContext(ctx, "Patient", gomock.Any(), gomock.Any(), gomock.Any()).
-		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-		//				*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: patient1Raw}}}
-		//				return nil
-		//			})
-		//		client.EXPECT().SearchWithContext(ctx, "CarePlan", gomock.Any(), gomock.Any(), gomock.Any()).
-		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-		//				*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: carePlan1Raw}}}
-		//				return nil
-		//			})
-		//	},
-		//},
+		"error: Condition exists, subject is patient, patient returned, incorrect principal": {
+			shouldSkip: true,
+			context:    auth.WithPrincipal(context.Background(), *auth.TestPrincipal3),
+			request: FHIRHandlerRequest{
+				Principal:   auth.TestPrincipal3,
+				ResourceId:  "1",
+				FhirHeaders: &fhirclient.Headers{},
+			},
+			expectedError: &coolfhir.ErrorWithCode{
+				Message:    "Participant does not have access to Condition",
+				StatusCode: http.StatusForbidden,
+			},
+			setup: func(ctx context.Context, client *mock.MockClient) {
+				client.EXPECT().ReadWithContext(ctx, "Condition/1", gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, target *fhir.Condition, _ ...fhirclient.Option) error {
+						*target = condition1
+						return nil
+					})
+				client.EXPECT().SearchWithContext(ctx, "Patient", gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+						*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: patient1Raw}}}
+						return nil
+					})
+				client.EXPECT().SearchWithContext(ctx, "CarePlan", gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+						*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: carePlan1Raw}}}
+						return nil
+					})
+			},
+		},
+		"ok: Condition exists, subject is patient, patient returned, incorrect principal, but creator of resource": {
+			shouldSkip: true,
+			context:    auth.WithPrincipal(context.Background(), *auth.TestPrincipal3),
+			request: FHIRHandlerRequest{
+				Principal:   auth.TestPrincipal3,
+				ResourceId:  "1",
+				FhirHeaders: &fhirclient.Headers{},
+				LocalIdentity: &fhir.Identifier{
+					System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
+					Value:  to.Ptr("1"),
+				},
+			},
+			setup: func(ctx context.Context, client *mock.MockClient) {
+				client.EXPECT().ReadWithContext(ctx, "Condition/1", gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, target *fhir.Condition, _ ...fhirclient.Option) error {
+						*target = condition1
+						return nil
+					})
+				client.EXPECT().SearchWithContext(ctx, "Patient", gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+						*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: patient1Raw}}}
+						return nil
+					})
+				client.EXPECT().SearchWithContext(ctx, "CarePlan", gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+						*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: carePlan1Raw}}}
+						return nil
+					})
+			},
+		},
 		"ok: Condition exists, subject is patient, patient returned, correct principal": {
 			context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal1),
 			request: FHIRHandlerRequest{
@@ -271,6 +265,10 @@ func TestService_handleGetCondition(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			if tt.shouldSkip {
+				t.Skip()
+			}
+
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 

--- a/orchestrator/careplanservice/handle_getpatient_test.go
+++ b/orchestrator/careplanservice/handle_getpatient_test.go
@@ -114,10 +114,6 @@ func TestService_handleGetPatient(t *testing.T) {
 						*target = patient1
 						return nil
 					})
-				client.EXPECT().SearchWithContext(ctx, "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-						return nil
-					})
 				client.EXPECT().SearchWithContext(ctx, "CarePlan", gomock.Any(), gomock.Any(), gomock.Any()).
 					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
 						*target = fhir.Bundle{Entry: []fhir.BundleEntry{}}
@@ -125,61 +121,62 @@ func TestService_handleGetPatient(t *testing.T) {
 					})
 			},
 		},
-		"error: Patient exists, auth, CarePlan returned, not a participant": {
-			context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal3),
-			request: FHIRHandlerRequest{
-				ResourceId:    "1",
-				Principal:     auth.TestPrincipal3,
-				LocalIdentity: &fhir.Identifier{},
-				FhirHeaders:   &fhirclient.Headers{},
-			},
-			expectedError: &coolfhir.ErrorWithCode{
-				Message:    "Participant does not have access to Patient",
-				StatusCode: http.StatusForbidden,
-			},
-			setup: func(ctx context.Context, client *mock.MockClient) {
-				client.EXPECT().ReadWithContext(ctx, "Patient/1", gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, target *fhir.Patient, _ ...fhirclient.Option) error {
-						*target = patient1
-						return nil
-					})
-				client.EXPECT().SearchWithContext(ctx, "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-						return nil
-					})
-				client.EXPECT().SearchWithContext(ctx, "CarePlan", gomock.Any(), gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-						*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: carePlan1Raw}}}
-						return nil
-					})
-			},
-		},
-		"ok: Patient exists, auth, CarePlan returned, not a participant, is creator": {
-			context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal3),
-			request: FHIRHandlerRequest{
-				ResourceId:    "1",
-				Principal:     auth.TestPrincipal3,
-				LocalIdentity: &fhir.Identifier{},
-				FhirHeaders:   &fhirclient.Headers{},
-			},
-			setup: func(ctx context.Context, client *mock.MockClient) {
-				client.EXPECT().ReadWithContext(ctx, "Patient/1", gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, target *fhir.Patient, _ ...fhirclient.Option) error {
-						*target = patient1
-						return nil
-					})
-				client.EXPECT().SearchWithContext(ctx, "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-						*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: auditEventRaw}}}
-						return nil
-					})
-				client.EXPECT().SearchWithContext(ctx, "CarePlan", gomock.Any(), gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-						*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: carePlan1Raw}}}
-						return nil
-					})
-			},
-		},
+		// TODO: Re-implement, test case is still valid but auth mechanism needs to change
+		//"error: Patient exists, auth, CarePlan returned, not a participant": {
+		//	context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal3),
+		//	request: FHIRHandlerRequest{
+		//		ResourceId:    "1",
+		//		Principal:     auth.TestPrincipal3,
+		//		LocalIdentity: &fhir.Identifier{},
+		//		FhirHeaders:   &fhirclient.Headers{},
+		//	},
+		//	expectedError: &coolfhir.ErrorWithCode{
+		//		Message:    "Participant does not have access to Patient",
+		//		StatusCode: http.StatusForbidden,
+		//	},
+		//	setup: func(ctx context.Context, client *mock.MockClient) {
+		//		client.EXPECT().ReadWithContext(ctx, "Patient/1", gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, target *fhir.Patient, _ ...fhirclient.Option) error {
+		//				*target = patient1
+		//				return nil
+		//			})
+		//		client.EXPECT().SearchWithContext(ctx, "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+		//				return nil
+		//			})
+		//		client.EXPECT().SearchWithContext(ctx, "CarePlan", gomock.Any(), gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+		//				*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: carePlan1Raw}}}
+		//				return nil
+		//			})
+		//	},
+		//},
+		//"ok: Patient exists, auth, CarePlan returned, not a participant, is creator": {
+		//	context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal3),
+		//	request: FHIRHandlerRequest{
+		//		ResourceId:    "1",
+		//		Principal:     auth.TestPrincipal3,
+		//		LocalIdentity: &fhir.Identifier{},
+		//		FhirHeaders:   &fhirclient.Headers{},
+		//	},
+		//	setup: func(ctx context.Context, client *mock.MockClient) {
+		//		client.EXPECT().ReadWithContext(ctx, "Patient/1", gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, target *fhir.Patient, _ ...fhirclient.Option) error {
+		//				*target = patient1
+		//				return nil
+		//			})
+		//		client.EXPECT().SearchWithContext(ctx, "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+		//				*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: auditEventRaw}}}
+		//				return nil
+		//			})
+		//		client.EXPECT().SearchWithContext(ctx, "CarePlan", gomock.Any(), gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+		//				*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: carePlan1Raw}}}
+		//				return nil
+		//			})
+		//	},
+		//},
 		"ok: Patient exists, auth, CarePlan returned, correct principal": {
 			context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal1),
 			request: FHIRHandlerRequest{
@@ -263,29 +260,6 @@ func TestService_handleSearchPatient(t *testing.T) {
 	patient1 := mustReadFile("./testdata/patient-1.json")
 	patient2 := mustReadFile("./testdata/patient-2.json")
 	patient3 := mustReadFile("./testdata/patient-3.json")
-
-	auditEvent := fhir.AuditEvent{
-		Id:     to.Ptr("1"),
-		Action: to.Ptr(fhir.AuditEventActionC),
-		Entity: []fhir.AuditEventEntity{
-			{
-				What: &fhir.Reference{
-					Reference: to.Ptr("Patient/1"),
-				},
-			},
-		},
-		Agent: []fhir.AuditEventAgent{
-			{
-				Who: &fhir.Reference{
-					Identifier: &fhir.Identifier{
-						System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
-						Value:  to.Ptr("3"),
-					},
-				},
-			},
-		},
-	}
-	auditEventRaw, _ := json.Marshal(auditEvent)
 
 	auditEventRead := fhir.AuditEvent{
 		Id:     to.Ptr("1"),
@@ -400,107 +374,104 @@ func TestService_handleSearchPatient(t *testing.T) {
 						*target = fhir.Bundle{Entry: []fhir.BundleEntry{}}
 						return nil
 					})
-				client.EXPECT().SearchWithContext(ctx, "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-						return nil
-					})
 			},
 			mockResponse:    &fhir.Bundle{Entry: []fhir.BundleEntry{}},
 			expectedEntries: []string{},
 		},
-		"error: Patient returned, careplan and careteam returned, incorrect principal": {
-			context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal3),
-			request: FHIRHandlerRequest{
-				Principal:   auth.TestPrincipal3,
-				FhirHeaders: &fhirclient.Headers{},
-				RequestUrl:  &url.URL{RawQuery: "_id=1"},
-				LocalIdentity: &fhir.Identifier{
-					System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
-					Value:  to.Ptr("1"),
-				},
-			},
-			expectedError: nil,
-			setup: func(ctx context.Context, client *mock.MockClient) {
-				client.EXPECT().SearchWithContext(ctx, "Patient", gomock.Any(), gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-						*target = fhir.Bundle{Entry: []fhir.BundleEntry{
-							{Resource: patient1},
-						}}
-						return nil
-					})
-				client.EXPECT().SearchWithContext(ctx, "CarePlan", gomock.Any(), gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-						*target = fhir.Bundle{Entry: []fhir.BundleEntry{
-							{Resource: careplan1Careteam2},
-						}}
-						return nil
-					})
-				client.EXPECT().SearchWithContext(ctx, "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-						return nil
-					})
-			},
-			mockResponse:    &fhir.Bundle{Entry: []fhir.BundleEntry{}},
-			expectedEntries: []string{},
-		},
-		"ok: Patient returned, careplan and careteam returned, incorrect principal, resource creator": {
-			context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal3),
-			request: FHIRHandlerRequest{
-				Principal:   auth.TestPrincipal3,
-				FhirHeaders: &fhirclient.Headers{},
-				RequestUrl:  &url.URL{RawQuery: "_id=1"},
-				LocalIdentity: &fhir.Identifier{
-					System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
-					Value:  to.Ptr("1"),
-				},
-			},
-			expectedError: nil,
-			setup: func(ctx context.Context, client *mock.MockClient) {
-				client.EXPECT().SearchWithContext(ctx, "Patient", gomock.Any(), gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-						*target = fhir.Bundle{
-							Link: []fhir.BundleLink{
-								{
-									Relation: "self",
-									Url:      "http://example.com/fhir/Patient?some-query-params",
-								},
-							},
-							Timestamp: to.Ptr("2021-09-01T12:00:00Z"),
-							Entry: []fhir.BundleEntry{
-								{Resource: patient1},
-							},
-						}
-						return nil
-					})
-				client.EXPECT().SearchWithContext(ctx, "CarePlan", gomock.Any(), gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-						*target = fhir.Bundle{Entry: []fhir.BundleEntry{
-							{Resource: careplan1Careteam2},
-						}}
-						return nil
-					})
-				client.EXPECT().SearchWithContext(ctx, "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-						*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: auditEventRaw}}}
-						return nil
-					})
-			},
-			mockResponse: &fhir.Bundle{Entry: []fhir.BundleEntry{
-				{
-					Resource: patient1,
-					Response: &fhir.BundleEntryResponse{
-						Status: "200 OK",
-					},
-				},
-				{
-					Resource: auditEventReadRaw,
-					Response: &fhir.BundleEntryResponse{
-						Status: "200 OK",
-					},
-				},
-			}},
-			expectedEntries: []string{string(patient1)},
-		},
+		// TODO: Re-implement, test case is still valid but auth mechanism needs to change
+		//"error: Patient returned, careplan and careteam returned, incorrect principal": {
+		//	context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal3),
+		//	request: FHIRHandlerRequest{
+		//		Principal:   auth.TestPrincipal3,
+		//		FhirHeaders: &fhirclient.Headers{},
+		//		RequestUrl:  &url.URL{RawQuery: "_id=1"},
+		//		LocalIdentity: &fhir.Identifier{
+		//			System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
+		//			Value:  to.Ptr("1"),
+		//		},
+		//	},
+		//	expectedError: nil,
+		//	setup: func(ctx context.Context, client *mock.MockClient) {
+		//		client.EXPECT().SearchWithContext(ctx, "Patient", gomock.Any(), gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+		//				*target = fhir.Bundle{Entry: []fhir.BundleEntry{
+		//					{Resource: patient1},
+		//				}}
+		//				return nil
+		//			})
+		//		client.EXPECT().SearchWithContext(ctx, "CarePlan", gomock.Any(), gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+		//				*target = fhir.Bundle{Entry: []fhir.BundleEntry{
+		//					{Resource: careplan1Careteam2},
+		//				}}
+		//				return nil
+		//			})
+		//		client.EXPECT().SearchWithContext(ctx, "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+		//				return nil
+		//			})
+		//	},
+		//	mockResponse:    &fhir.Bundle{Entry: []fhir.BundleEntry{}},
+		//	expectedEntries: []string{},
+		//},
+		//"ok: Patient returned, careplan and careteam returned, incorrect principal, resource creator": {
+		//	context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal3),
+		//	request: FHIRHandlerRequest{
+		//		Principal:   auth.TestPrincipal3,
+		//		FhirHeaders: &fhirclient.Headers{},
+		//		RequestUrl:  &url.URL{RawQuery: "_id=1"},
+		//		LocalIdentity: &fhir.Identifier{
+		//			System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
+		//			Value:  to.Ptr("1"),
+		//		},
+		//	},
+		//	expectedError: nil,
+		//	setup: func(ctx context.Context, client *mock.MockClient) {
+		//		client.EXPECT().SearchWithContext(ctx, "Patient", gomock.Any(), gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+		//				*target = fhir.Bundle{
+		//					Link: []fhir.BundleLink{
+		//						{
+		//							Relation: "self",
+		//							Url:      "http://example.com/fhir/Patient?some-query-params",
+		//						},
+		//					},
+		//					Timestamp: to.Ptr("2021-09-01T12:00:00Z"),
+		//					Entry: []fhir.BundleEntry{
+		//						{Resource: patient1},
+		//					},
+		//				}
+		//				return nil
+		//			})
+		//		client.EXPECT().SearchWithContext(ctx, "CarePlan", gomock.Any(), gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+		//				*target = fhir.Bundle{Entry: []fhir.BundleEntry{
+		//					{Resource: careplan1Careteam2},
+		//				}}
+		//				return nil
+		//			})
+		//		client.EXPECT().SearchWithContext(ctx, "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+		//				*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: auditEventRaw}}}
+		//				return nil
+		//			})
+		//	},
+		//	mockResponse: &fhir.Bundle{Entry: []fhir.BundleEntry{
+		//		{
+		//			Resource: patient1,
+		//			Response: &fhir.BundleEntryResponse{
+		//				Status: "200 OK",
+		//			},
+		//		},
+		//		{
+		//			Resource: auditEventReadRaw,
+		//			Response: &fhir.BundleEntryResponse{
+		//				Status: "200 OK",
+		//			},
+		//		},
+		//	}},
+		//	expectedEntries: []string{string(patient1)},
+		//},
 		"ok: Patient returned, careplan returned, correct principal": {
 			context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal1),
 			request: FHIRHandlerRequest{
@@ -615,10 +586,6 @@ func TestService_handleSearchPatient(t *testing.T) {
 								},
 							},
 						}}
-						return nil
-					})
-				client.EXPECT().SearchWithContext(ctx, "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
 						return nil
 					})
 			},

--- a/orchestrator/careplanservice/handle_getquestionnaireresponse_test.go
+++ b/orchestrator/careplanservice/handle_getquestionnaireresponse_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"net/http"
 	"net/url"
 	"testing"
 
@@ -102,79 +101,80 @@ func TestService_handleGetQuestionnaireResponse(t *testing.T) {
 					Return(errors.New("fhir error: no response"))
 			},
 		},
-		"error: QuestionnaireResponse exists, fetched task, incorrect principal (not task onwer or requester)": {
-			context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal3),
-			request: FHIRHandlerRequest{
-				Principal:   auth.TestPrincipal3,
-				ResourceId:  "1",
-				FhirHeaders: &fhirclient.Headers{},
-				LocalIdentity: &fhir.Identifier{
-					System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
-					Value:  to.Ptr("3"),
-				},
-			},
-			expectedError: &coolfhir.ErrorWithCode{
-				Message:    "Participant does not have access to QuestionnaireResponse",
-				StatusCode: http.StatusForbidden,
-			},
-			setup: func(ctx context.Context, client *mock.MockClient) {
-				client.EXPECT().ReadWithContext(ctx, "QuestionnaireResponse/1", gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, target *fhir.QuestionnaireResponse, _ ...fhirclient.Option) error {
-						*target = questionnaireResponse1
-						return nil
-					})
-				client.EXPECT().SearchWithContext(ctx, "Task", gomock.Any(), gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-						*target = fhir.Bundle{
-							Entry: []fhir.BundleEntry{
-								{Resource: task1Raw},
-							},
-						}
-						return nil
-					})
-				client.EXPECT().ReadWithContext(ctx, "CarePlan/1", gomock.Any(), gomock.Any()).
-					Return(errors.New("fhir error: no response"))
-				client.EXPECT().SearchWithContext(ctx, "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target any, _ ...fhirclient.Option) error {
-						return nil
-					})
-			},
-		},
-		"ok: QuestionnaireResponse exists, fetched task, incorrect principal, is creator": {
-			context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal3),
-			request: FHIRHandlerRequest{
-				Principal:   auth.TestPrincipal3,
-				ResourceId:  "1",
-				FhirHeaders: &fhirclient.Headers{},
-				LocalIdentity: &fhir.Identifier{
-					System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
-					Value:  to.Ptr("3"),
-				},
-			},
-			setup: func(ctx context.Context, client *mock.MockClient) {
-				client.EXPECT().ReadWithContext(ctx, "QuestionnaireResponse/1", gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, target *fhir.QuestionnaireResponse, _ ...fhirclient.Option) error {
-						*target = questionnaireResponse1
-						return nil
-					})
-				client.EXPECT().SearchWithContext(ctx, "Task", gomock.Any(), gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-						*target = fhir.Bundle{
-							Entry: []fhir.BundleEntry{
-								{Resource: task1Raw},
-							},
-						}
-						return nil
-					})
-				client.EXPECT().ReadWithContext(ctx, "CarePlan/1", gomock.Any(), gomock.Any()).
-					Return(errors.New("fhir error: no response"))
-				client.EXPECT().SearchWithContext(ctx, "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-						*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: auditEventRaw}}}
-						return nil
-					})
-			},
-		},
+		// TODO: Re-implement, test case is still valid but auth mechanism needs to change
+		//"error: QuestionnaireResponse exists, fetched task, incorrect principal (not task onwer or requester)": {
+		//	context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal3),
+		//	request: FHIRHandlerRequest{
+		//		Principal:   auth.TestPrincipal3,
+		//		ResourceId:  "1",
+		//		FhirHeaders: &fhirclient.Headers{},
+		//		LocalIdentity: &fhir.Identifier{
+		//			System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
+		//			Value:  to.Ptr("3"),
+		//		},
+		//	},
+		//	expectedError: &coolfhir.ErrorWithCode{
+		//		Message:    "Participant does not have access to QuestionnaireResponse",
+		//		StatusCode: http.StatusForbidden,
+		//	},
+		//	setup: func(ctx context.Context, client *mock.MockClient) {
+		//		client.EXPECT().ReadWithContext(ctx, "QuestionnaireResponse/1", gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, target *fhir.QuestionnaireResponse, _ ...fhirclient.Option) error {
+		//				*target = questionnaireResponse1
+		//				return nil
+		//			})
+		//		client.EXPECT().SearchWithContext(ctx, "Task", gomock.Any(), gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+		//				*target = fhir.Bundle{
+		//					Entry: []fhir.BundleEntry{
+		//						{Resource: task1Raw},
+		//					},
+		//				}
+		//				return nil
+		//			})
+		//		client.EXPECT().ReadWithContext(ctx, "CarePlan/1", gomock.Any(), gomock.Any()).
+		//			Return(errors.New("fhir error: no response"))
+		//		client.EXPECT().SearchWithContext(ctx, "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target any, _ ...fhirclient.Option) error {
+		//				return nil
+		//			})
+		//	},
+		//},
+		//"ok: QuestionnaireResponse exists, fetched task, incorrect principal, is creator": {
+		//	context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal3),
+		//	request: FHIRHandlerRequest{
+		//		Principal:   auth.TestPrincipal3,
+		//		ResourceId:  "1",
+		//		FhirHeaders: &fhirclient.Headers{},
+		//		LocalIdentity: &fhir.Identifier{
+		//			System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
+		//			Value:  to.Ptr("3"),
+		//		},
+		//	},
+		//	setup: func(ctx context.Context, client *mock.MockClient) {
+		//		client.EXPECT().ReadWithContext(ctx, "QuestionnaireResponse/1", gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, target *fhir.QuestionnaireResponse, _ ...fhirclient.Option) error {
+		//				*target = questionnaireResponse1
+		//				return nil
+		//			})
+		//		client.EXPECT().SearchWithContext(ctx, "Task", gomock.Any(), gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+		//				*target = fhir.Bundle{
+		//					Entry: []fhir.BundleEntry{
+		//						{Resource: task1Raw},
+		//					},
+		//				}
+		//				return nil
+		//			})
+		//		client.EXPECT().ReadWithContext(ctx, "CarePlan/1", gomock.Any(), gomock.Any()).
+		//			Return(errors.New("fhir error: no response"))
+		//		client.EXPECT().SearchWithContext(ctx, "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+		//				*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: auditEventRaw}}}
+		//				return nil
+		//			})
+		//	},
+		//},
 		"ok: QuestionnaireResponse exists, fetched task, task owner": {
 			context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal1),
 			request: FHIRHandlerRequest{

--- a/orchestrator/careplanservice/handle_getservicerequest_test.go
+++ b/orchestrator/careplanservice/handle_getservicerequest_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"net/url"
 	"testing"
 
@@ -58,6 +59,8 @@ func TestService_handleGetServiceRequest(t *testing.T) {
 		request       FHIRHandlerRequest
 		expectedError error
 		setup         func(ctx context.Context, client *mock.MockClient)
+		// TODO: Temporarily disabling the audit-based auth tests, re-enable tests once auth has been re-implemented
+		shouldSkip bool
 	}{
 		"error: ServiceRequest does not exist": {
 			context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal1),
@@ -98,81 +101,82 @@ func TestService_handleGetServiceRequest(t *testing.T) {
 					Return(errors.New("fhir error: Issue searching for task"))
 			},
 		},
-		// TODO: Re-implement, test case is still valid but auth mechanism needs to change
-		//"error: ServiceRequest exists, fetched task, incorrect principal": {
-		//	context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal3),
-		//	request: FHIRHandlerRequest{
-		//		Principal:   auth.TestPrincipal3,
-		//		ResourceId:  "1",
-		//		FhirHeaders: &fhirclient.Headers{},
-		//		LocalIdentity: &fhir.Identifier{
-		//			System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
-		//			Value:  to.Ptr("3"),
-		//		},
-		//	},
-		//	expectedError: &coolfhir.ErrorWithCode{
-		//		Message:    "Participant does not have access to ServiceRequest",
-		//		StatusCode: http.StatusForbidden,
-		//	},
-		//	setup: func(ctx context.Context, client *mock.MockClient) {
-		//		client.EXPECT().ReadWithContext(ctx, "ServiceRequest/1", gomock.Any(), gomock.Any()).
-		//			DoAndReturn(func(_ context.Context, _ string, target *fhir.ServiceRequest, _ ...fhirclient.Option) error {
-		//				*target = fhir.ServiceRequest{Id: to.Ptr("1")}
-		//				return nil
-		//			})
-		//		client.EXPECT().SearchWithContext(ctx, "Task", gomock.Any(), gomock.Any(), gomock.Any()).
-		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-		//				*target = fhir.Bundle{
-		//					Entry: []fhir.BundleEntry{
-		//						{Resource: task1Raw},
-		//					},
-		//				}
-		//				return nil
-		//			})
-		//		client.EXPECT().ReadWithContext(ctx, "CarePlan/1", gomock.Any(), gomock.Any()).
-		//			Return(errors.New("fhir error: no response"))
-		//		client.EXPECT().SearchWithContext(ctx, "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).
-		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-		//				*target = fhir.Bundle{Entry: []fhir.BundleEntry{}}
-		//				return nil
-		//			})
-		//	},
-		//},
-		//"ok: ServiceRequest exists, fetched task, incorrect principal, but is creator": {
-		//	context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal3),
-		//	request: FHIRHandlerRequest{
-		//		Principal:   auth.TestPrincipal3,
-		//		ResourceId:  "1",
-		//		FhirHeaders: &fhirclient.Headers{},
-		//		LocalIdentity: &fhir.Identifier{
-		//			System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
-		//			Value:  to.Ptr("3"),
-		//		},
-		//	},
-		//	setup: func(ctx context.Context, client *mock.MockClient) {
-		//		client.EXPECT().ReadWithContext(ctx, "ServiceRequest/1", gomock.Any(), gomock.Any()).
-		//			DoAndReturn(func(_ context.Context, _ string, target *fhir.ServiceRequest, _ ...fhirclient.Option) error {
-		//				*target = serviceRequest1
-		//				return nil
-		//			})
-		//		client.EXPECT().SearchWithContext(ctx, "Task", gomock.Any(), gomock.Any(), gomock.Any()).
-		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-		//				*target = fhir.Bundle{
-		//					Entry: []fhir.BundleEntry{
-		//						{Resource: task1Raw},
-		//					},
-		//				}
-		//				return nil
-		//			})
-		//		client.EXPECT().ReadWithContext(ctx, "CarePlan/1", gomock.Any(), gomock.Any()).
-		//			Return(errors.New("fhir error: no response"))
-		//		client.EXPECT().SearchWithContext(ctx, "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).
-		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-		//				*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: auditEventRaw}}}
-		//				return nil
-		//			})
-		//	},
-		//},
+		"error: ServiceRequest exists, fetched task, incorrect principal": {
+			shouldSkip: true,
+			context:    auth.WithPrincipal(context.Background(), *auth.TestPrincipal3),
+			request: FHIRHandlerRequest{
+				Principal:   auth.TestPrincipal3,
+				ResourceId:  "1",
+				FhirHeaders: &fhirclient.Headers{},
+				LocalIdentity: &fhir.Identifier{
+					System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
+					Value:  to.Ptr("3"),
+				},
+			},
+			expectedError: &coolfhir.ErrorWithCode{
+				Message:    "Participant does not have access to ServiceRequest",
+				StatusCode: http.StatusForbidden,
+			},
+			setup: func(ctx context.Context, client *mock.MockClient) {
+				client.EXPECT().ReadWithContext(ctx, "ServiceRequest/1", gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, target *fhir.ServiceRequest, _ ...fhirclient.Option) error {
+						*target = fhir.ServiceRequest{Id: to.Ptr("1")}
+						return nil
+					})
+				client.EXPECT().SearchWithContext(ctx, "Task", gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+						*target = fhir.Bundle{
+							Entry: []fhir.BundleEntry{
+								{Resource: task1Raw},
+							},
+						}
+						return nil
+					})
+				client.EXPECT().ReadWithContext(ctx, "CarePlan/1", gomock.Any(), gomock.Any()).
+					Return(errors.New("fhir error: no response"))
+				client.EXPECT().SearchWithContext(ctx, "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+						*target = fhir.Bundle{Entry: []fhir.BundleEntry{}}
+						return nil
+					})
+			},
+		},
+		"ok: ServiceRequest exists, fetched task, incorrect principal, but is creator": {
+			shouldSkip: true,
+			context:    auth.WithPrincipal(context.Background(), *auth.TestPrincipal3),
+			request: FHIRHandlerRequest{
+				Principal:   auth.TestPrincipal3,
+				ResourceId:  "1",
+				FhirHeaders: &fhirclient.Headers{},
+				LocalIdentity: &fhir.Identifier{
+					System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
+					Value:  to.Ptr("3"),
+				},
+			},
+			setup: func(ctx context.Context, client *mock.MockClient) {
+				client.EXPECT().ReadWithContext(ctx, "ServiceRequest/1", gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, target *fhir.ServiceRequest, _ ...fhirclient.Option) error {
+						*target = serviceRequest1
+						return nil
+					})
+				client.EXPECT().SearchWithContext(ctx, "Task", gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+						*target = fhir.Bundle{
+							Entry: []fhir.BundleEntry{
+								{Resource: task1Raw},
+							},
+						}
+						return nil
+					})
+				client.EXPECT().ReadWithContext(ctx, "CarePlan/1", gomock.Any(), gomock.Any()).
+					Return(errors.New("fhir error: no response"))
+				client.EXPECT().SearchWithContext(ctx, "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+						*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: auditEventRaw}}}
+						return nil
+					})
+			},
+		},
 		"ok: ServiceRequest exists, fetched task, task owner": {
 			context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal1),
 			request: FHIRHandlerRequest{
@@ -205,6 +209,10 @@ func TestService_handleGetServiceRequest(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			if tt.shouldSkip {
+				t.Skip()
+			}
+
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 

--- a/orchestrator/careplanservice/handle_getservicerequest_test.go
+++ b/orchestrator/careplanservice/handle_getservicerequest_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"net/http"
 	"net/url"
 	"testing"
 
@@ -99,80 +98,81 @@ func TestService_handleGetServiceRequest(t *testing.T) {
 					Return(errors.New("fhir error: Issue searching for task"))
 			},
 		},
-		"error: ServiceRequest exists, fetched task, incorrect principal": {
-			context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal3),
-			request: FHIRHandlerRequest{
-				Principal:   auth.TestPrincipal3,
-				ResourceId:  "1",
-				FhirHeaders: &fhirclient.Headers{},
-				LocalIdentity: &fhir.Identifier{
-					System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
-					Value:  to.Ptr("3"),
-				},
-			},
-			expectedError: &coolfhir.ErrorWithCode{
-				Message:    "Participant does not have access to ServiceRequest",
-				StatusCode: http.StatusForbidden,
-			},
-			setup: func(ctx context.Context, client *mock.MockClient) {
-				client.EXPECT().ReadWithContext(ctx, "ServiceRequest/1", gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, target *fhir.ServiceRequest, _ ...fhirclient.Option) error {
-						*target = fhir.ServiceRequest{Id: to.Ptr("1")}
-						return nil
-					})
-				client.EXPECT().SearchWithContext(ctx, "Task", gomock.Any(), gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-						*target = fhir.Bundle{
-							Entry: []fhir.BundleEntry{
-								{Resource: task1Raw},
-							},
-						}
-						return nil
-					})
-				client.EXPECT().ReadWithContext(ctx, "CarePlan/1", gomock.Any(), gomock.Any()).
-					Return(errors.New("fhir error: no response"))
-				client.EXPECT().SearchWithContext(ctx, "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-						*target = fhir.Bundle{Entry: []fhir.BundleEntry{}}
-						return nil
-					})
-			},
-		},
-		"ok: ServiceRequest exists, fetched task, incorrect principal, but is creator": {
-			context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal3),
-			request: FHIRHandlerRequest{
-				Principal:   auth.TestPrincipal3,
-				ResourceId:  "1",
-				FhirHeaders: &fhirclient.Headers{},
-				LocalIdentity: &fhir.Identifier{
-					System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
-					Value:  to.Ptr("3"),
-				},
-			},
-			setup: func(ctx context.Context, client *mock.MockClient) {
-				client.EXPECT().ReadWithContext(ctx, "ServiceRequest/1", gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, target *fhir.ServiceRequest, _ ...fhirclient.Option) error {
-						*target = serviceRequest1
-						return nil
-					})
-				client.EXPECT().SearchWithContext(ctx, "Task", gomock.Any(), gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-						*target = fhir.Bundle{
-							Entry: []fhir.BundleEntry{
-								{Resource: task1Raw},
-							},
-						}
-						return nil
-					})
-				client.EXPECT().ReadWithContext(ctx, "CarePlan/1", gomock.Any(), gomock.Any()).
-					Return(errors.New("fhir error: no response"))
-				client.EXPECT().SearchWithContext(ctx, "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).
-					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
-						*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: auditEventRaw}}}
-						return nil
-					})
-			},
-		},
+		// TODO: Re-implement, test case is still valid but auth mechanism needs to change
+		//"error: ServiceRequest exists, fetched task, incorrect principal": {
+		//	context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal3),
+		//	request: FHIRHandlerRequest{
+		//		Principal:   auth.TestPrincipal3,
+		//		ResourceId:  "1",
+		//		FhirHeaders: &fhirclient.Headers{},
+		//		LocalIdentity: &fhir.Identifier{
+		//			System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
+		//			Value:  to.Ptr("3"),
+		//		},
+		//	},
+		//	expectedError: &coolfhir.ErrorWithCode{
+		//		Message:    "Participant does not have access to ServiceRequest",
+		//		StatusCode: http.StatusForbidden,
+		//	},
+		//	setup: func(ctx context.Context, client *mock.MockClient) {
+		//		client.EXPECT().ReadWithContext(ctx, "ServiceRequest/1", gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, target *fhir.ServiceRequest, _ ...fhirclient.Option) error {
+		//				*target = fhir.ServiceRequest{Id: to.Ptr("1")}
+		//				return nil
+		//			})
+		//		client.EXPECT().SearchWithContext(ctx, "Task", gomock.Any(), gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+		//				*target = fhir.Bundle{
+		//					Entry: []fhir.BundleEntry{
+		//						{Resource: task1Raw},
+		//					},
+		//				}
+		//				return nil
+		//			})
+		//		client.EXPECT().ReadWithContext(ctx, "CarePlan/1", gomock.Any(), gomock.Any()).
+		//			Return(errors.New("fhir error: no response"))
+		//		client.EXPECT().SearchWithContext(ctx, "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+		//				*target = fhir.Bundle{Entry: []fhir.BundleEntry{}}
+		//				return nil
+		//			})
+		//	},
+		//},
+		//"ok: ServiceRequest exists, fetched task, incorrect principal, but is creator": {
+		//	context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal3),
+		//	request: FHIRHandlerRequest{
+		//		Principal:   auth.TestPrincipal3,
+		//		ResourceId:  "1",
+		//		FhirHeaders: &fhirclient.Headers{},
+		//		LocalIdentity: &fhir.Identifier{
+		//			System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
+		//			Value:  to.Ptr("3"),
+		//		},
+		//	},
+		//	setup: func(ctx context.Context, client *mock.MockClient) {
+		//		client.EXPECT().ReadWithContext(ctx, "ServiceRequest/1", gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, target *fhir.ServiceRequest, _ ...fhirclient.Option) error {
+		//				*target = serviceRequest1
+		//				return nil
+		//			})
+		//		client.EXPECT().SearchWithContext(ctx, "Task", gomock.Any(), gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+		//				*target = fhir.Bundle{
+		//					Entry: []fhir.BundleEntry{
+		//						{Resource: task1Raw},
+		//					},
+		//				}
+		//				return nil
+		//			})
+		//		client.EXPECT().ReadWithContext(ctx, "CarePlan/1", gomock.Any(), gomock.Any()).
+		//			Return(errors.New("fhir error: no response"))
+		//		client.EXPECT().SearchWithContext(ctx, "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).
+		//			DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+		//				*target = fhir.Bundle{Entry: []fhir.BundleEntry{{Resource: auditEventRaw}}}
+		//				return nil
+		//			})
+		//	},
+		//},
 		"ok: ServiceRequest exists, fetched task, task owner": {
 			context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal1),
 			request: FHIRHandlerRequest{

--- a/orchestrator/careplanservice/handle_updatepatient_test.go
+++ b/orchestrator/careplanservice/handle_updatepatient_test.go
@@ -59,6 +59,8 @@ func Test_handleUpdatePatient(t *testing.T) {
 		errorMessage          string
 		mockCreateBehavior    func(mockFHIRClient *mock.MockClient)
 		principal             *auth.Principal
+		// TODO: Temporarily disabling the audit-based auth tests, re-enable tests once auth has been re-implemented
+		shouldSkip bool
 	}{
 		{
 			name:                  "valid update - creator - success",
@@ -79,33 +81,22 @@ func Test_handleUpdatePatient(t *testing.T) {
 			wantErr:         true,
 			errorMessage:    "failed to search for Patient",
 		},
-		// TODO: Re-implement, test case is still valid but auth mechanism needs to change
-		//{
-		//	name:                  "invalid update - error querying audit events - fails",
-		//	principal:             auth.TestPrincipal1,
-		//	existingPatientBundle: &existingPatientBundle,
-		//	errorFromAuditQuery:   errors.New("failed to find creation AuditEvent"),
-		//	wantErr:               true,
-		//	errorMessage:          "Participant does not have access to Patient",
-		//},
-		//{
-		//	name:                  "invalid update - no creation audit event - fails",
-		//	principal:             auth.TestPrincipal1,
-		//	existingPatientBundle: &existingPatientBundle,
-		//	wantErr:               true,
-		//	errorMessage:          "Participant does not have access to Patient",
-		//},
-		//{
-		//	name:                  "invalid update - not creator - fails",
-		//	principal:             auth.TestPrincipal2,
-		//	existingPatientBundle: &existingPatientBundle,
-		//	wantErr:               true,
-		//	errorMessage:          "Participant does not have access to Patient",
-		//},
+		{
+			shouldSkip:            true,
+			name:                  "invalid update - not creator - fails",
+			principal:             auth.TestPrincipal2,
+			existingPatientBundle: &existingPatientBundle,
+			wantErr:               true,
+			errorMessage:          "Participant does not have access to Patient",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.shouldSkip {
+				t.Skip()
+			}
+
 			tx := coolfhir.Transaction()
 
 			mockFHIRClient := mock.NewMockClient(ctrl)

--- a/orchestrator/careplanservice/handle_updatepatient_test.go
+++ b/orchestrator/careplanservice/handle_updatepatient_test.go
@@ -40,36 +40,6 @@ func Test_handleUpdatePatient(t *testing.T) {
 
 	updatePatientData, _ := json.Marshal(defaultPatient)
 
-	// Create a mock audit event for the creation
-	creationAuditEvent := fhir.AuditEvent{
-		Id: to.Ptr("audit1"),
-		Agent: []fhir.AuditEventAgent{
-			{
-				Who: &fhir.Reference{
-					Identifier: &auth.TestPrincipal1.Organization.Identifier[0],
-				},
-			},
-		},
-		Entity: []fhir.AuditEventEntity{
-			{
-				What: &fhir.Reference{
-					Reference: to.Ptr("Patient/1"),
-				},
-			},
-		},
-	}
-
-	creationAuditBundle := fhir.Bundle{
-		Entry: []fhir.BundleEntry{
-			{
-				Resource: func() []byte {
-					b, _ := json.Marshal(creationAuditEvent)
-					return b
-				}(),
-			},
-		},
-	}
-
 	existingPatientBundle := fhir.Bundle{
 		Entry: []fhir.BundleEntry{
 			{
@@ -85,8 +55,6 @@ func Test_handleUpdatePatient(t *testing.T) {
 		name                  string
 		existingPatientBundle *fhir.Bundle
 		errorFromSearch       error
-		errorFromAuditQuery   error
-		auditBundle           *fhir.Bundle
 		wantErr               bool
 		errorMessage          string
 		mockCreateBehavior    func(mockFHIRClient *mock.MockClient)
@@ -96,7 +64,6 @@ func Test_handleUpdatePatient(t *testing.T) {
 			name:                  "valid update - creator - success",
 			principal:             auth.TestPrincipal1,
 			existingPatientBundle: &existingPatientBundle,
-			auditBundle:           &creationAuditBundle,
 			wantErr:               false,
 		},
 		{
@@ -106,36 +73,35 @@ func Test_handleUpdatePatient(t *testing.T) {
 			wantErr:               false,
 		},
 		{
-			name:                  "invalid update - not creator - fails",
-			principal:             auth.TestPrincipal2,
-			existingPatientBundle: &existingPatientBundle,
-			auditBundle:           &creationAuditBundle,
-			wantErr:               true,
-			errorMessage:          "Participant does not have access to Patient",
-		},
-		{
 			name:            "invalid update - error searching existing resource - fails",
 			principal:       auth.TestPrincipal1,
 			errorFromSearch: errors.New("failed to search for Patient"),
 			wantErr:         true,
 			errorMessage:    "failed to search for Patient",
 		},
-		{
-			name:                  "invalid update - error querying audit events - fails",
-			principal:             auth.TestPrincipal1,
-			existingPatientBundle: &existingPatientBundle,
-			errorFromAuditQuery:   errors.New("failed to find creation AuditEvent"),
-			wantErr:               true,
-			errorMessage:          "Participant does not have access to Patient",
-		},
-		{
-			name:                  "invalid update - no creation audit event - fails",
-			principal:             auth.TestPrincipal1,
-			existingPatientBundle: &existingPatientBundle,
-			auditBundle:           &fhir.Bundle{Entry: []fhir.BundleEntry{}},
-			wantErr:               true,
-			errorMessage:          "Participant does not have access to Patient",
-		},
+		// TODO: Re-implement, test case is still valid but auth mechanism needs to change
+		//{
+		//	name:                  "invalid update - error querying audit events - fails",
+		//	principal:             auth.TestPrincipal1,
+		//	existingPatientBundle: &existingPatientBundle,
+		//	errorFromAuditQuery:   errors.New("failed to find creation AuditEvent"),
+		//	wantErr:               true,
+		//	errorMessage:          "Participant does not have access to Patient",
+		//},
+		//{
+		//	name:                  "invalid update - no creation audit event - fails",
+		//	principal:             auth.TestPrincipal1,
+		//	existingPatientBundle: &existingPatientBundle,
+		//	wantErr:               true,
+		//	errorMessage:          "Participant does not have access to Patient",
+		//},
+		//{
+		//	name:                  "invalid update - not creator - fails",
+		//	principal:             auth.TestPrincipal2,
+		//	existingPatientBundle: &existingPatientBundle,
+		//	wantErr:               true,
+		//	errorMessage:          "Participant does not have access to Patient",
+		//},
 	}
 
 	for _, tt := range tests {
@@ -157,16 +123,6 @@ func Test_handleUpdatePatient(t *testing.T) {
 						return tt.errorFromSearch
 					}
 					*result = *tt.existingPatientBundle
-
-					if len(tt.existingPatientBundle.Entry) > 0 {
-						mockFHIRClient.EXPECT().SearchWithContext(gomock.Any(), "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, resourceType string, params url.Values, result *fhir.Bundle, option ...fhirclient.Option) error {
-							if tt.errorFromAuditQuery != nil {
-								return tt.errorFromAuditQuery
-							}
-							*result = *tt.auditBundle
-							return nil
-						})
-					}
 
 					return nil
 				})

--- a/orchestrator/careplanservice/handle_updatequestionnaireresponse_test.go
+++ b/orchestrator/careplanservice/handle_updatequestionnaireresponse_test.go
@@ -55,6 +55,8 @@ func Test_handleUpdateQuestionnaireResponse(t *testing.T) {
 		wantErr                        bool
 		errorMessage                   string
 		principal                      *auth.Principal
+		// TODO: Temporarily disabling the audit-based auth tests, re-enable tests once auth has been re-implemented
+		shouldSkip bool
 	}{
 		{
 			name:                           "valid update - creator - success",
@@ -69,32 +71,22 @@ func Test_handleUpdateQuestionnaireResponse(t *testing.T) {
 			wantErr:         true,
 			errorMessage:    "failed to read QuestionnaireResponse",
 		},
-		// TODO: Re-implement, test case is still valid but auth mechanism needs to change
-		//{
-		//	name:                           "invalid update - error querying audit events - fails",
-		//	principal:                      auth.TestPrincipal1,
-		//	existingQuestionnaireResBundle: &existingQuestionnaireResponseBundle,
-		//	wantErr:                        true,
-		//	errorMessage:                   "Participant does not have access to QuestionnaireResponse",
-		//},
-		//{
-		//	name:                           "invalid update - no creation audit event - fails",
-		//	principal:                      auth.TestPrincipal1,
-		//	existingQuestionnaireResBundle: &existingQuestionnaireResponseBundle,
-		//	wantErr:                        true,
-		//	errorMessage:                   "Participant does not have access to QuestionnaireResponse",
-		//},
-		//{
-		//	name:                           "invalid update - not creator - fails",
-		//	principal:                      auth.TestPrincipal2,
-		//	existingQuestionnaireResBundle: &existingQuestionnaireResponseBundle,
-		//	wantErr:                        true,
-		//	errorMessage:                   "Participant does not have access to QuestionnaireResponse",
-		//},
+		{
+			shouldSkip:                     true,
+			name:                           "invalid update - not creator - fails",
+			principal:                      auth.TestPrincipal2,
+			existingQuestionnaireResBundle: &existingQuestionnaireResponseBundle,
+			wantErr:                        true,
+			errorMessage:                   "Participant does not have access to QuestionnaireResponse",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.shouldSkip {
+				t.Skip()
+			}
+
 			tx := coolfhir.Transaction()
 
 			mockFHIRClient := mock.NewMockClient(ctrl)

--- a/orchestrator/careplanservice/handle_updateservicerequest_test.go
+++ b/orchestrator/careplanservice/handle_updateservicerequest_test.go
@@ -64,6 +64,8 @@ func Test_handleUpdateServiceRequest(t *testing.T) {
 		wantErr                      bool
 		errorMessage                 string
 		mockCreateBehavior           func(mockFHIRClient *mock.MockClient)
+		// TODO: Temporarily disabling the audit-based auth tests, re-enable tests once auth has been re-implemented
+		shouldSkip bool
 	}{
 		{
 			name:                         "valid update - creator - success",
@@ -84,32 +86,22 @@ func Test_handleUpdateServiceRequest(t *testing.T) {
 			wantErr:         true,
 			errorMessage:    "failed to search for ServiceRequest",
 		},
-		// TODO: Re-implement, test case is still valid but auth mechanism needs to change
-		//{
-		//	name:                         "invalid update - error querying audit events - fails",
-		//	principal:                    auth.TestPrincipal1,
-		//	existingServiceRequestBundle: &existingServiceRequestBundle,
-		//	wantErr:                      true,
-		//	errorMessage:                 "Participant does not have access to ServiceRequest",
-		//},
-		//{
-		//	name:                         "invalid update - no creation audit event - fails",
-		//	principal:                    auth.TestPrincipal1,
-		//	existingServiceRequestBundle: &existingServiceRequestBundle,
-		//	wantErr:                      true,
-		//	errorMessage:                 "Participant does not have access to ServiceRequest",
-		//},
-		//{
-		//	name:                         "invalid update - not creator - fails",
-		//	principal:                    auth.TestPrincipal2,
-		//	existingServiceRequestBundle: &existingServiceRequestBundle,
-		//	wantErr:                      true,
-		//	errorMessage:                 "Participant does not have access to ServiceRequest",
-		//},
+		{
+			shouldSkip:                   true,
+			name:                         "invalid update - not creator - fails",
+			principal:                    auth.TestPrincipal2,
+			existingServiceRequestBundle: &existingServiceRequestBundle,
+			wantErr:                      true,
+			errorMessage:                 "Participant does not have access to ServiceRequest",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.shouldSkip {
+				t.Skip()
+			}
+
 			tx := coolfhir.Transaction()
 
 			mockFHIRClient := mock.NewMockClient(ctrl)

--- a/orchestrator/careplanservice/handle_updateservicerequest_test.go
+++ b/orchestrator/careplanservice/handle_updateservicerequest_test.go
@@ -45,36 +45,6 @@ func Test_handleUpdateServiceRequest(t *testing.T) {
 
 	updateServiceRequestData, _ := json.Marshal(defaultServiceRequest)
 
-	// Create a mock audit event for the creation
-	creationAuditEvent := fhir.AuditEvent{
-		Id: to.Ptr("audit1"),
-		Agent: []fhir.AuditEventAgent{
-			{
-				Who: &fhir.Reference{
-					Identifier: &auth.TestPrincipal1.Organization.Identifier[0],
-				},
-			},
-		},
-		Entity: []fhir.AuditEventEntity{
-			{
-				What: &fhir.Reference{
-					Reference: to.Ptr("ServiceRequest/1"),
-				},
-			},
-		},
-	}
-
-	creationAuditBundle := fhir.Bundle{
-		Entry: []fhir.BundleEntry{
-			{
-				Resource: func() []byte {
-					b, _ := json.Marshal(creationAuditEvent)
-					return b
-				}(),
-			},
-		},
-	}
-
 	existingServiceRequestBundle := fhir.Bundle{
 		Entry: []fhir.BundleEntry{
 			{
@@ -91,8 +61,6 @@ func Test_handleUpdateServiceRequest(t *testing.T) {
 		principal                    *auth.Principal
 		existingServiceRequestBundle *fhir.Bundle
 		errorFromSearch              error
-		errorFromAuditQuery          error
-		auditBundle                  *fhir.Bundle
 		wantErr                      bool
 		errorMessage                 string
 		mockCreateBehavior           func(mockFHIRClient *mock.MockClient)
@@ -101,7 +69,6 @@ func Test_handleUpdateServiceRequest(t *testing.T) {
 			name:                         "valid update - creator - success",
 			principal:                    auth.TestPrincipal1,
 			existingServiceRequestBundle: &existingServiceRequestBundle,
-			auditBundle:                  &creationAuditBundle,
 			wantErr:                      false,
 		},
 		{
@@ -111,36 +78,34 @@ func Test_handleUpdateServiceRequest(t *testing.T) {
 			wantErr:                      false,
 		},
 		{
-			name:                         "invalid update - not creator - fails",
-			principal:                    auth.TestPrincipal2,
-			existingServiceRequestBundle: &existingServiceRequestBundle,
-			auditBundle:                  &creationAuditBundle,
-			wantErr:                      true,
-			errorMessage:                 "Participant does not have access to ServiceRequest",
-		},
-		{
 			name:            "invalid update - error searching existing resource - fails",
 			principal:       auth.TestPrincipal1,
 			errorFromSearch: errors.New("failed to search for ServiceRequest"),
 			wantErr:         true,
 			errorMessage:    "failed to search for ServiceRequest",
 		},
-		{
-			name:                         "invalid update - error querying audit events - fails",
-			principal:                    auth.TestPrincipal1,
-			existingServiceRequestBundle: &existingServiceRequestBundle,
-			errorFromAuditQuery:          errors.New("failed to find creation AuditEvent"),
-			wantErr:                      true,
-			errorMessage:                 "Participant does not have access to ServiceRequest",
-		},
-		{
-			name:                         "invalid update - no creation audit event - fails",
-			principal:                    auth.TestPrincipal1,
-			existingServiceRequestBundle: &existingServiceRequestBundle,
-			auditBundle:                  &fhir.Bundle{Entry: []fhir.BundleEntry{}},
-			wantErr:                      true,
-			errorMessage:                 "Participant does not have access to ServiceRequest",
-		},
+		// TODO: Re-implement, test case is still valid but auth mechanism needs to change
+		//{
+		//	name:                         "invalid update - error querying audit events - fails",
+		//	principal:                    auth.TestPrincipal1,
+		//	existingServiceRequestBundle: &existingServiceRequestBundle,
+		//	wantErr:                      true,
+		//	errorMessage:                 "Participant does not have access to ServiceRequest",
+		//},
+		//{
+		//	name:                         "invalid update - no creation audit event - fails",
+		//	principal:                    auth.TestPrincipal1,
+		//	existingServiceRequestBundle: &existingServiceRequestBundle,
+		//	wantErr:                      true,
+		//	errorMessage:                 "Participant does not have access to ServiceRequest",
+		//},
+		//{
+		//	name:                         "invalid update - not creator - fails",
+		//	principal:                    auth.TestPrincipal2,
+		//	existingServiceRequestBundle: &existingServiceRequestBundle,
+		//	wantErr:                      true,
+		//	errorMessage:                 "Participant does not have access to ServiceRequest",
+		//},
 	}
 
 	for _, tt := range tests {
@@ -177,16 +142,6 @@ func Test_handleUpdateServiceRequest(t *testing.T) {
 						return tt.errorFromSearch
 					}
 					*result = *tt.existingServiceRequestBundle
-
-					if len(tt.existingServiceRequestBundle.Entry) > 0 {
-						mockFHIRClient.EXPECT().SearchWithContext(gomock.Any(), "AuditEvent", gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, resourceType string, params url.Values, result *fhir.Bundle, option ...fhirclient.Option) error {
-							if tt.errorFromAuditQuery != nil {
-								return tt.errorFromAuditQuery
-							}
-							*result = *tt.auditBundle
-							return nil
-						})
-					}
 
 					return nil
 				})

--- a/orchestrator/careplanservice/integration_audit_test.go
+++ b/orchestrator/careplanservice/integration_audit_test.go
@@ -23,7 +23,7 @@ func Test_CRUD_AuditEvents(t *testing.T) {
 
 	cpc1NotificationEndpoint := setupNotificationEndpoint(t, func(n coolfhir.SubscriptionNotification) {})
 	cpc2NotificationEndpoint := setupNotificationEndpoint(t, func(n coolfhir.SubscriptionNotification) {})
-	carePlanContributor1, _, _, _ := setupIntegrationTest(t, cpc1NotificationEndpoint, cpc2NotificationEndpoint, fhirBaseURL)
+	carePlanContributor1, carePlanContributor2, _, _ := setupIntegrationTest(t, cpc1NotificationEndpoint, cpc2NotificationEndpoint, fhirBaseURL)
 
 	// Track all expected audit events
 	var expectedAuditEvents []ExpectedAuditEvent
@@ -36,14 +36,13 @@ func Test_CRUD_AuditEvents(t *testing.T) {
 		})
 	}
 
-	// TODO: Re-implement, test case is still valid but auth mechanism needs to change
-	//addExpectedSearchAudit := func(resourceRef string, queryParams map[string][]string) {
-	//	expectedAuditEvents = append(expectedAuditEvents, ExpectedAuditEvent{
-	//		ResourceRef: resourceRef,
-	//		Action:      fhir.AuditEventActionR,
-	//		QueryParams: queryParams,
-	//	})
-	//}
+	addExpectedSearchAudit := func(resourceRef string, queryParams map[string][]string) {
+		expectedAuditEvents = append(expectedAuditEvents, ExpectedAuditEvent{
+			ResourceRef: resourceRef,
+			Action:      fhir.AuditEventActionR,
+			QueryParams: queryParams,
+		})
+	}
 
 	// Create Patient
 	patient := fhir.Patient{
@@ -170,29 +169,33 @@ func Test_CRUD_AuditEvents(t *testing.T) {
 
 	// TODO: Re-implement, test case is still valid but auth mechanism needs to change
 	// Negative tests - different user trying to update resources
-	//t.Run("Update Patient with different requester - fails", func(t *testing.T) {
-	//	err = carePlanContributor2.Update("Patient/"+*patient.Id, patient, &patient)
-	//	require.Error(t, err)
-	//	require.Contains(t, err.Error(), "Participant does not have access to Patient")
-	//})
-	//
-	//t.Run("Update QuestionnaireResponse with different requester - fails", func(t *testing.T) {
-	//	err = carePlanContributor2.Update("QuestionnaireResponse/"+*questionnaireResponse.Id, questionnaireResponse, &questionnaireResponse)
-	//	require.Error(t, err)
-	//	require.Contains(t, err.Error(), "Participant does not have access to QuestionnaireResponse")
-	//})
-	//
-	//t.Run("Update ServiceRequest with different requester - fails", func(t *testing.T) {
-	//	err = carePlanContributor2.Update("ServiceRequest/"+*serviceRequest.Id, serviceRequest, &serviceRequest)
-	//	require.Error(t, err)
-	//	require.Contains(t, err.Error(), "Participant does not have access to ServiceRequest")
-	//})
-	//
-	//t.Run("Update Condition with different requester - fails", func(t *testing.T) {
-	//	err = carePlanContributor2.Update("Condition/"+*condition.Id, condition, &condition)
-	//	require.Error(t, err)
-	//	require.Contains(t, err.Error(), "Participant does not have access to Condition")
-	//})
+	t.Run("Update Patient with different requester - fails", func(t *testing.T) {
+		t.Skip()
+		err = carePlanContributor2.Update("Patient/"+*patient.Id, patient, &patient)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Participant does not have access to Patient")
+	})
+
+	t.Run("Update QuestionnaireResponse with different requester - fails", func(t *testing.T) {
+		t.Skip()
+		err = carePlanContributor2.Update("QuestionnaireResponse/"+*questionnaireResponse.Id, questionnaireResponse, &questionnaireResponse)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Participant does not have access to QuestionnaireResponse")
+	})
+
+	t.Run("Update ServiceRequest with different requester - fails", func(t *testing.T) {
+		t.Skip()
+		err = carePlanContributor2.Update("ServiceRequest/"+*serviceRequest.Id, serviceRequest, &serviceRequest)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Participant does not have access to ServiceRequest")
+	})
+
+	t.Run("Update Condition with different requester - fails", func(t *testing.T) {
+		t.Skip()
+		err = carePlanContributor2.Update("Condition/"+*condition.Id, condition, &condition)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "Participant does not have access to Condition")
+	})
 
 	// Update non-existing resources (creates new ones)
 	var nonExistingPatient fhir.Patient
@@ -309,21 +312,22 @@ func Test_CRUD_AuditEvents(t *testing.T) {
 	})
 
 	// TODO: Re-implement, test case is still valid but auth mechanism needs to change
-	//t.Run("Read Patient by id", func(t *testing.T) {
-	//	var readPatient fhir.Patient
-	//	err := carePlanContributor1.Read("Patient/"+*patient.Id, &readPatient)
-	//	require.NoError(t, err)
-	//	require.NotNil(t, readPatient)
-	//
-	//	addExpectedAudit("Patient/"+*readPatient.Id, fhir.AuditEventActionR)
-	//
-	//	// Read Patient by ID again, generates new AuditEvent
-	//	err = carePlanContributor1.Read("Patient/"+*patient.Id, &readPatient)
-	//	require.NoError(t, err)
-	//	require.NotNil(t, readPatient)
-	//
-	//	addExpectedAudit("Patient/"+*readPatient.Id, fhir.AuditEventActionR)
-	//})
+	t.Run("Read Patient by id", func(t *testing.T) {
+		t.Skip()
+		var readPatient fhir.Patient
+		err := carePlanContributor1.Read("Patient/"+*patient.Id, &readPatient)
+		require.NoError(t, err)
+		require.NotNil(t, readPatient)
+
+		addExpectedAudit("Patient/"+*readPatient.Id, fhir.AuditEventActionR)
+
+		// Read Patient by ID again, generates new AuditEvent
+		err = carePlanContributor1.Read("Patient/"+*patient.Id, &readPatient)
+		require.NoError(t, err)
+		require.NotNil(t, readPatient)
+
+		addExpectedAudit("Patient/"+*readPatient.Id, fhir.AuditEventActionR)
+	})
 
 	t.Run("Read Questionnaire by id", func(t *testing.T) {
 		var readQuestionnaire fhir.Questionnaire
@@ -374,31 +378,33 @@ func Test_CRUD_AuditEvents(t *testing.T) {
 	})
 
 	// TODO: Re-implement, test case is still valid but auth mechanism needs to change
-	//var readCondition fhir.Condition
-	//t.Run("Read Condition by id", func(t *testing.T) {
-	//	err := carePlanContributor1.Read("Condition/"+*condition.Id, &readCondition)
-	//	require.NoError(t, err)
-	//	require.NotNil(t, readCondition)
-	//
-	//	addExpectedAudit("Condition/"+*readCondition.Id, fhir.AuditEventActionR)
-	//
-	//	// Read Condition by ID again, generates new AuditEvent
-	//	err = carePlanContributor1.Read("Condition/"+*condition.Id, &readCondition)
-	//	require.NoError(t, err)
-	//	require.NotNil(t, readCondition)
-	//
-	//	addExpectedAudit("Condition/"+*readCondition.Id, fhir.AuditEventActionR)
-	//})
+	var readCondition fhir.Condition
+	t.Run("Read Condition by id", func(t *testing.T) {
+		t.Skip()
+		err := carePlanContributor1.Read("Condition/"+*condition.Id, &readCondition)
+		require.NoError(t, err)
+		require.NotNil(t, readCondition)
+
+		addExpectedAudit("Condition/"+*readCondition.Id, fhir.AuditEventActionR)
+
+		// Read Condition by ID again, generates new AuditEvent
+		err = carePlanContributor1.Read("Condition/"+*condition.Id, &readCondition)
+		require.NoError(t, err)
+		require.NotNil(t, readCondition)
+
+		addExpectedAudit("Condition/"+*readCondition.Id, fhir.AuditEventActionR)
+	})
 
 	// TODO: Re-implement, test case is still valid but auth mechanism needs to change
-	//var searchResult fhir.Bundle
-	//t.Run("Search Patient by id", func(t *testing.T) {
-	//	err := carePlanContributor1.Search("Patient", url.Values{"_id": {*patient.Id, *nonExistingPatient.Id, "fake-id"}}, &searchResult)
-	//	require.NoError(t, err)
-	//	require.NotNil(t, searchResult)
-	//
-	//	addExpectedSearchAudit("Patient/"+*patient.Id, url.Values{"_id": {*patient.Id, *nonExistingPatient.Id, "fake-id"}})
-	//})
+	var searchResult fhir.Bundle
+	t.Run("Search Patient by id", func(t *testing.T) {
+		t.Skip()
+		err := carePlanContributor1.Search("Patient", url.Values{"_id": {*patient.Id, *nonExistingPatient.Id, "fake-id"}}, &searchResult)
+		require.NoError(t, err)
+		require.NotNil(t, searchResult)
+
+		addExpectedSearchAudit("Patient/"+*patient.Id, url.Values{"_id": {*patient.Id, *nonExistingPatient.Id, "fake-id"}})
+	})
 
 	// Verify all audit events at the end
 	err = verifyAuditEvents(t, expectedAuditEvents, fhirBaseURL)

--- a/orchestrator/careplanservice/integration_audit_test.go
+++ b/orchestrator/careplanservice/integration_audit_test.go
@@ -23,7 +23,7 @@ func Test_CRUD_AuditEvents(t *testing.T) {
 
 	cpc1NotificationEndpoint := setupNotificationEndpoint(t, func(n coolfhir.SubscriptionNotification) {})
 	cpc2NotificationEndpoint := setupNotificationEndpoint(t, func(n coolfhir.SubscriptionNotification) {})
-	carePlanContributor1, carePlanContributor2, _, _ := setupIntegrationTest(t, cpc1NotificationEndpoint, cpc2NotificationEndpoint, fhirBaseURL)
+	carePlanContributor1, _, _, _ := setupIntegrationTest(t, cpc1NotificationEndpoint, cpc2NotificationEndpoint, fhirBaseURL)
 
 	// Track all expected audit events
 	var expectedAuditEvents []ExpectedAuditEvent
@@ -36,13 +36,14 @@ func Test_CRUD_AuditEvents(t *testing.T) {
 		})
 	}
 
-	addExpectedSearchAudit := func(resourceRef string, queryParams map[string][]string) {
-		expectedAuditEvents = append(expectedAuditEvents, ExpectedAuditEvent{
-			ResourceRef: resourceRef,
-			Action:      fhir.AuditEventActionR,
-			QueryParams: queryParams,
-		})
-	}
+	// TODO: Re-implement, test case is still valid but auth mechanism needs to change
+	//addExpectedSearchAudit := func(resourceRef string, queryParams map[string][]string) {
+	//	expectedAuditEvents = append(expectedAuditEvents, ExpectedAuditEvent{
+	//		ResourceRef: resourceRef,
+	//		Action:      fhir.AuditEventActionR,
+	//		QueryParams: queryParams,
+	//	})
+	//}
 
 	// Create Patient
 	patient := fhir.Patient{
@@ -167,30 +168,31 @@ func Test_CRUD_AuditEvents(t *testing.T) {
 	require.NoError(t, err)
 	addExpectedAudit("ServiceRequest/"+*serviceRequest.Id, fhir.AuditEventActionU)
 
+	// TODO: Re-implement, test case is still valid but auth mechanism needs to change
 	// Negative tests - different user trying to update resources
-	t.Run("Update Patient with different requester - fails", func(t *testing.T) {
-		err = carePlanContributor2.Update("Patient/"+*patient.Id, patient, &patient)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "Participant does not have access to Patient")
-	})
-
-	t.Run("Update QuestionnaireResponse with different requester - fails", func(t *testing.T) {
-		err = carePlanContributor2.Update("QuestionnaireResponse/"+*questionnaireResponse.Id, questionnaireResponse, &questionnaireResponse)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "Participant does not have access to QuestionnaireResponse")
-	})
-
-	t.Run("Update ServiceRequest with different requester - fails", func(t *testing.T) {
-		err = carePlanContributor2.Update("ServiceRequest/"+*serviceRequest.Id, serviceRequest, &serviceRequest)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "Participant does not have access to ServiceRequest")
-	})
-
-	t.Run("Update Condition with different requester - fails", func(t *testing.T) {
-		err = carePlanContributor2.Update("Condition/"+*condition.Id, condition, &condition)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "Participant does not have access to Condition")
-	})
+	//t.Run("Update Patient with different requester - fails", func(t *testing.T) {
+	//	err = carePlanContributor2.Update("Patient/"+*patient.Id, patient, &patient)
+	//	require.Error(t, err)
+	//	require.Contains(t, err.Error(), "Participant does not have access to Patient")
+	//})
+	//
+	//t.Run("Update QuestionnaireResponse with different requester - fails", func(t *testing.T) {
+	//	err = carePlanContributor2.Update("QuestionnaireResponse/"+*questionnaireResponse.Id, questionnaireResponse, &questionnaireResponse)
+	//	require.Error(t, err)
+	//	require.Contains(t, err.Error(), "Participant does not have access to QuestionnaireResponse")
+	//})
+	//
+	//t.Run("Update ServiceRequest with different requester - fails", func(t *testing.T) {
+	//	err = carePlanContributor2.Update("ServiceRequest/"+*serviceRequest.Id, serviceRequest, &serviceRequest)
+	//	require.Error(t, err)
+	//	require.Contains(t, err.Error(), "Participant does not have access to ServiceRequest")
+	//})
+	//
+	//t.Run("Update Condition with different requester - fails", func(t *testing.T) {
+	//	err = carePlanContributor2.Update("Condition/"+*condition.Id, condition, &condition)
+	//	require.Error(t, err)
+	//	require.Contains(t, err.Error(), "Participant does not have access to Condition")
+	//})
 
 	// Update non-existing resources (creates new ones)
 	var nonExistingPatient fhir.Patient
@@ -306,21 +308,22 @@ func Test_CRUD_AuditEvents(t *testing.T) {
 		addExpectedAudit("Condition/"+*nonExistingCondition.Id, fhir.AuditEventActionC)
 	})
 
-	t.Run("Read Patient by id", func(t *testing.T) {
-		var readPatient fhir.Patient
-		err := carePlanContributor1.Read("Patient/"+*patient.Id, &readPatient)
-		require.NoError(t, err)
-		require.NotNil(t, readPatient)
-
-		addExpectedAudit("Patient/"+*readPatient.Id, fhir.AuditEventActionR)
-
-		// Read Patient by ID again, generates new AuditEvent
-		err = carePlanContributor1.Read("Patient/"+*patient.Id, &readPatient)
-		require.NoError(t, err)
-		require.NotNil(t, readPatient)
-
-		addExpectedAudit("Patient/"+*readPatient.Id, fhir.AuditEventActionR)
-	})
+	// TODO: Re-implement, test case is still valid but auth mechanism needs to change
+	//t.Run("Read Patient by id", func(t *testing.T) {
+	//	var readPatient fhir.Patient
+	//	err := carePlanContributor1.Read("Patient/"+*patient.Id, &readPatient)
+	//	require.NoError(t, err)
+	//	require.NotNil(t, readPatient)
+	//
+	//	addExpectedAudit("Patient/"+*readPatient.Id, fhir.AuditEventActionR)
+	//
+	//	// Read Patient by ID again, generates new AuditEvent
+	//	err = carePlanContributor1.Read("Patient/"+*patient.Id, &readPatient)
+	//	require.NoError(t, err)
+	//	require.NotNil(t, readPatient)
+	//
+	//	addExpectedAudit("Patient/"+*readPatient.Id, fhir.AuditEventActionR)
+	//})
 
 	t.Run("Read Questionnaire by id", func(t *testing.T) {
 		var readQuestionnaire fhir.Questionnaire
@@ -370,37 +373,32 @@ func Test_CRUD_AuditEvents(t *testing.T) {
 		addExpectedAudit("ServiceRequest/"+*readServiceRequest.Id, fhir.AuditEventActionR)
 	})
 
-	var readCondition fhir.Condition
-	t.Run("Read Condition by id", func(t *testing.T) {
-		err := carePlanContributor1.Read("Condition/"+*condition.Id, &readCondition)
-		require.NoError(t, err)
-		require.NotNil(t, readCondition)
+	// TODO: Re-implement, test case is still valid but auth mechanism needs to change
+	//var readCondition fhir.Condition
+	//t.Run("Read Condition by id", func(t *testing.T) {
+	//	err := carePlanContributor1.Read("Condition/"+*condition.Id, &readCondition)
+	//	require.NoError(t, err)
+	//	require.NotNil(t, readCondition)
+	//
+	//	addExpectedAudit("Condition/"+*readCondition.Id, fhir.AuditEventActionR)
+	//
+	//	// Read Condition by ID again, generates new AuditEvent
+	//	err = carePlanContributor1.Read("Condition/"+*condition.Id, &readCondition)
+	//	require.NoError(t, err)
+	//	require.NotNil(t, readCondition)
+	//
+	//	addExpectedAudit("Condition/"+*readCondition.Id, fhir.AuditEventActionR)
+	//})
 
-		addExpectedAudit("Condition/"+*readCondition.Id, fhir.AuditEventActionR)
-
-		// Read Condition by ID again, generates new AuditEvent
-		err = carePlanContributor1.Read("Condition/"+*condition.Id, &readCondition)
-		require.NoError(t, err)
-		require.NotNil(t, readCondition)
-
-		addExpectedAudit("Condition/"+*readCondition.Id, fhir.AuditEventActionR)
-	})
-
-	var searchResult fhir.Bundle
-	t.Run("Search Patient by id", func(t *testing.T) {
-		err := carePlanContributor1.Search("Patient", url.Values{"_id": {*patient.Id, *nonExistingPatient.Id, "fake-id"}}, &searchResult)
-		require.NoError(t, err)
-		require.NotNil(t, searchResult)
-
-		addExpectedSearchAudit("Patient/"+*patient.Id, url.Values{"_id": {*patient.Id, *nonExistingPatient.Id, "fake-id"}})
-
-		// Read Condition by ID again, generates new AuditEvent
-		err = carePlanContributor1.Read("Condition/"+*condition.Id, &readCondition)
-		require.NoError(t, err)
-		require.NotNil(t, readCondition)
-
-		addExpectedAudit("Condition/"+*readCondition.Id, fhir.AuditEventActionR)
-	})
+	// TODO: Re-implement, test case is still valid but auth mechanism needs to change
+	//var searchResult fhir.Bundle
+	//t.Run("Search Patient by id", func(t *testing.T) {
+	//	err := carePlanContributor1.Search("Patient", url.Values{"_id": {*patient.Id, *nonExistingPatient.Id, "fake-id"}}, &searchResult)
+	//	require.NoError(t, err)
+	//	require.NotNil(t, searchResult)
+	//
+	//	addExpectedSearchAudit("Patient/"+*patient.Id, url.Values{"_id": {*patient.Id, *nonExistingPatient.Id, "fake-id"}})
+	//})
 
 	// Verify all audit events at the end
 	err = verifyAuditEvents(t, expectedAuditEvents, fhirBaseURL)

--- a/orchestrator/careplanservice/util.go
+++ b/orchestrator/careplanservice/util.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 
 	fhirclient "github.com/SanteonNL/go-fhir-client"
-	"github.com/SanteonNL/orca/orchestrator/lib/audit"
 	"github.com/SanteonNL/orca/orchestrator/lib/auth"
 
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
@@ -21,33 +20,39 @@ import (
 
 func (s *Service) isCreatorOfResource(ctx context.Context, principal auth.Principal, resourceType string, resourceID string) (bool, error) {
 
-	var auditBundle fhir.Bundle
-	err := s.fhirClient.SearchWithContext(ctx, "AuditEvent", url.Values{
-		"entity": []string{resourceType + "/" + resourceID},
-		"action": []string{fhir.AuditEventActionC.String()},
-	}, &auditBundle)
-	if err != nil {
-		return false, fmt.Errorf("failed to find creation AuditEvent: %w", err)
-	}
-
-	// Check if there's a creation audit event
-	if len(auditBundle.Entry) == 0 {
-		return false, coolfhir.NewErrorWithCode(fmt.Sprintf("No creation audit event found for %s", resourceType), http.StatusForbidden)
-	}
-
-	// Get the creator from the audit event
-	var creationAuditEvent fhir.AuditEvent
-	err = json.Unmarshal(auditBundle.Entry[0].Resource, &creationAuditEvent)
-	if err != nil {
-		return false, fmt.Errorf("failed to unmarshal AuditEvent: %w", err)
-	}
-
-	// Check if the current user is the creator
-	if !audit.IsCreator(creationAuditEvent, &principal) {
-		return false, coolfhir.NewErrorWithCode(fmt.Sprintf("Only the creator can update this %s", resourceType), http.StatusForbidden)
-	}
+	// TODO: Find a more suitable way to handle this auth.
+	// The AuditEvent implementation has proven unsuitable and we are using the AuditEvent for unintended purposes.
+	// For now, we can return true, as this will follow the same logic as was present before implementing the AuditEvent.
 
 	return true, nil
+
+	//var auditBundle fhir.Bundle
+	//err := s.fhirClient.SearchWithContext(ctx, "AuditEvent", url.Values{
+	//	"entity": []string{resourceType + "/" + resourceID},
+	//	"action": []string{fhir.AuditEventActionC.String()},
+	//}, &auditBundle)
+	//if err != nil {
+	//	return false, fmt.Errorf("failed to find creation AuditEvent: %w", err)
+	//}
+	//
+	//// Check if there's a creation audit event
+	//if len(auditBundle.Entry) == 0 {
+	//	return false, coolfhir.NewErrorWithCode(fmt.Sprintf("No creation audit event found for %s", resourceType), http.StatusForbidden)
+	//}
+	//
+	//// Get the creator from the audit event
+	//var creationAuditEvent fhir.AuditEvent
+	//err = json.Unmarshal(auditBundle.Entry[0].Resource, &creationAuditEvent)
+	//if err != nil {
+	//	return false, fmt.Errorf("failed to unmarshal AuditEvent: %w", err)
+	//}
+	//
+	//// Check if the current user is the creator
+	//if !audit.IsCreator(creationAuditEvent, &principal) {
+	//	return false, coolfhir.NewErrorWithCode(fmt.Sprintf("Only the creator can update this %s", resourceType), http.StatusForbidden)
+	//}
+	//
+	//return true, nil
 }
 
 // filterAuthorizedPatients will go through a list of patients and return the ones the requester has access to
@@ -113,22 +118,23 @@ func (s *Service) filterAuthorizedPatients(ctx context.Context, principal auth.P
 		}
 	}
 
+	// TODO: Re-implement. We need this logic, but AuditEvent is not a suitable mechanism
 	// For patients not yet authorized, check if the requester is the creator
-	for _, patient := range patients {
-		// Skip if patient is already authorized through CareTeam
-		if slices.ContainsFunc(retPatients, func(p fhir.Patient) bool {
-			return *p.Id == *patient.Id
-		}) {
-			continue
-		}
-
-		// Check if requester is the creator
-		isCreator, err := s.isCreatorOfResource(ctx, principal, "Patient", *patient.Id)
-		if err == nil && isCreator {
-			log.Ctx(ctx).Debug().Msgf("User is creator of Patient/%s", *patient.Id)
-			retPatients = append(retPatients, patient)
-		}
-	}
+	//for _, patient := range patients {
+	//	// Skip if patient is already authorized through CareTeam
+	//	if slices.ContainsFunc(retPatients, func(p fhir.Patient) bool {
+	//		return *p.Id == *patient.Id
+	//	}) {
+	//		continue
+	//	}
+	//
+	//	// Check if requester is the creator
+	//	isCreator, err := s.isCreatorOfResource(ctx, principal, "Patient", *patient.Id)
+	//	if err == nil && isCreator {
+	//		log.Ctx(ctx).Debug().Msgf("User is creator of Patient/%s", *patient.Id)
+	//		retPatients = append(retPatients, patient)
+	//	}
+	//}
 
 	return retPatients, nil
 }


### PR DESCRIPTION
After some experimentation between HAPI FHIR and Azure FHIR I have determined that AuditEvent may not be a suitable mechanism for verifying creator-based auth.

For the mean time, we will keep creating audit events but they will not be used for authentication