### PR TITLE
FIX | Implement missing search APIs

### DIFF
--- a/orchestrator/careplanservice/handle_getcondition.go
+++ b/orchestrator/careplanservice/handle_getcondition.go
@@ -5,9 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 
 	fhirclient "github.com/SanteonNL/go-fhir-client"
 	"github.com/SanteonNL/orca/orchestrator/lib/audit"
+	"github.com/SanteonNL/orca/orchestrator/lib/auth"
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
 	"github.com/SanteonNL/orca/orchestrator/lib/to"
 	"github.com/rs/zerolog/log"
@@ -73,4 +76,117 @@ func (s *Service) handleReadCondition(ctx context.Context, request FHIRHandlerRe
 		// We do not want to notify subscribers for a get
 		return []*fhir.BundleEntry{&bundleEntry}, []any{}, nil
 	}, nil
+}
+
+// handleSearchCondition performs a search for Condition based on the user request parameters
+// and filters the results based on user authorization
+// Pass in a pointer to a fhirclient.Headers object to get the headers from the fhir client request
+func (s *Service) handleSearchCondition(ctx context.Context, request FHIRHandlerRequest, tx *coolfhir.BundleBuilder) (FHIRHandlerResult, error) {
+	log.Ctx(ctx).Info().Msgf("Searching for Conditions")
+
+	bundle, err := s.searchCondition(ctx, request.QueryParams, request.FhirHeaders, *request.Principal)
+	if err != nil {
+		return nil, err
+	}
+
+	results := []*fhir.BundleEntry{}
+
+	for _, entry := range bundle.Entry {
+		var currentCondition fhir.Condition
+		if err := json.Unmarshal(entry.Resource, &currentCondition); err != nil {
+			log.Ctx(ctx).Error().
+				Err(err).
+				Msg("Failed to unmarshal resource for audit")
+			continue
+		}
+
+		// Create the query detail entity
+		queryEntity := fhir.AuditEventEntity{
+			Type: &fhir.Coding{
+				System:  to.Ptr("http://terminology.hl7.org/CodeSystem/audit-entity-type"),
+				Code:    to.Ptr("2"), // query parameters
+				Display: to.Ptr("Query Parameters"),
+			},
+			Detail: []fhir.AuditEventEntityDetail{},
+		}
+
+		// Add each query parameter as a detail
+		for param, values := range request.QueryParams {
+			queryEntity.Detail = append(queryEntity.Detail, fhir.AuditEventEntityDetail{
+				Type:        param, // parameter name as string
+				ValueString: to.Ptr(strings.Join(values, ",")),
+			})
+		}
+
+		bundleEntry := fhir.BundleEntry{
+			Resource: entry.Resource,
+			Response: &fhir.BundleEntryResponse{
+				Status: "200 OK",
+			},
+		}
+		results = append(results, &bundleEntry)
+
+		// Add audit event to the transaction
+		auditEvent := audit.Event(*request.LocalIdentity, fhir.AuditEventActionR, &fhir.Reference{
+			Id:        currentCondition.Id,
+			Type:      to.Ptr("Condition"),
+			Reference: to.Ptr("Condition/" + *currentCondition.Id),
+		}, &fhir.Reference{
+			Identifier: &request.Principal.Organization.Identifier[0],
+			Type:       to.Ptr("Organization"),
+		})
+		tx.Create(auditEvent)
+	}
+
+	return func(txResult *fhir.Bundle) ([]*fhir.BundleEntry, []any, error) {
+		// Simply return the already prepared results
+		return results, []any{}, nil
+	}, nil
+}
+
+// searchCondition performs the core functionality of searching for conditions and filtering by authorization
+// This can be used by other resources to search for conditions and filter by authorization
+func (s *Service) searchCondition(ctx context.Context, queryParams url.Values, headers *fhirclient.Headers, principal auth.Principal) (*fhir.Bundle, error) {
+	conditions, bundle, err := handleSearchResource[fhir.Condition](ctx, s, "Condition", queryParams, headers)
+	if err != nil {
+		return nil, err
+	}
+	if len(conditions) == 0 {
+		// If there are no conditions in the bundle there is no point in doing validation, return empty bundle to user
+		return &fhir.Bundle{Entry: []fhir.BundleEntry{}}, nil
+	}
+
+	// For each Condition, verify the user has access to the patient referenced in the subject
+	var allowedConditionRefs []string
+	for _, cond := range conditions {
+		// Verify if the Condition has a valid Patient subject and the user has access to this patient
+		if cond.Subject.Identifier != nil && cond.Subject.Identifier.System != nil && cond.Subject.Identifier.Value != nil {
+			patientBundle, err := s.searchPatient(ctx, map[string][]string{"identifier": {fmt.Sprintf("%s|%s", *cond.Subject.Identifier.System, *cond.Subject.Identifier.Value)}}, headers, principal)
+			if err != nil {
+				log.Ctx(ctx).Error().Err(err).Msgf("Error checking patient access for Condition/%s", *cond.Id)
+				continue
+			}
+
+			// If patient is found and user has access, the user also has access to the condition
+			if len(patientBundle.Entry) > 0 {
+				allowedConditionRefs = append(allowedConditionRefs, "Condition/"+*cond.Id)
+				continue
+			}
+		}
+
+		// If user doesn't have access via patient, check if they are the creator of the condition
+		isCreator, err := s.isCreatorOfResource(ctx, principal, "Condition", *cond.Id)
+		if err != nil {
+			log.Ctx(ctx).Error().Err(err).Msgf("Error checking if user is creator of Condition/%s", *cond.Id)
+			continue
+		}
+
+		if isCreator {
+			allowedConditionRefs = append(allowedConditionRefs, "Condition/"+*cond.Id)
+		}
+	}
+
+	retBundle := filterMatchingResourcesInBundle(ctx, bundle, []string{"Condition"}, allowedConditionRefs)
+
+	return &retBundle, nil
 }

--- a/orchestrator/careplanservice/handle_getcondition.go
+++ b/orchestrator/careplanservice/handle_getcondition.go
@@ -80,7 +80,6 @@ func (s *Service) handleReadCondition(ctx context.Context, request FHIRHandlerRe
 
 // handleSearchCondition performs a search for Condition based on the user request parameters
 // and filters the results based on user authorization
-// Pass in a pointer to a fhirclient.Headers object to get the headers from the fhir client request
 func (s *Service) handleSearchCondition(ctx context.Context, request FHIRHandlerRequest, tx *coolfhir.BundleBuilder) (FHIRHandlerResult, error) {
 	log.Ctx(ctx).Info().Msgf("Searching for Conditions")
 
@@ -160,7 +159,7 @@ func (s *Service) searchCondition(ctx context.Context, queryParams url.Values, h
 	var allowedConditionRefs []string
 	for _, cond := range conditions {
 		// Verify if the Condition has a valid Patient subject and the user has access to this patient
-		if cond.Subject.Identifier != nil && cond.Subject.Identifier.System != nil && cond.Subject.Identifier.Value != nil {
+		if coolfhir.ValidateReference(cond.Subject) {
 			patientBundle, err := s.searchPatient(ctx, map[string][]string{"identifier": {fmt.Sprintf("%s|%s", *cond.Subject.Identifier.System, *cond.Subject.Identifier.Value)}}, headers, principal)
 			if err != nil {
 				log.Ctx(ctx).Error().Err(err).Msgf("Error checking patient access for Condition/%s", *cond.Id)

--- a/orchestrator/careplanservice/handle_getcondition_test.go
+++ b/orchestrator/careplanservice/handle_getcondition_test.go
@@ -319,3 +319,390 @@ func TestService_handleGetCondition(t *testing.T) {
 		})
 	}
 }
+
+func TestService_handleSearchCondition(t *testing.T) {
+	condition1 := fhir.Condition{
+		Id: to.Ptr("1"),
+		Subject: fhir.Reference{
+			Identifier: &fhir.Identifier{
+				System: to.Ptr("http://fhir.nl/fhir/NamingSystem/bsn"),
+				Value:  to.Ptr("123456789"),
+			},
+		},
+	}
+	condition1Raw, _ := json.Marshal(condition1)
+
+	condition2 := fhir.Condition{
+		Id: to.Ptr("2"),
+		Subject: fhir.Reference{
+			Identifier: &fhir.Identifier{
+				System: to.Ptr("http://fhir.nl/fhir/NamingSystem/bsn"),
+				Value:  to.Ptr("123456789"),
+			},
+		},
+	}
+	condition2Raw, _ := json.Marshal(condition2)
+
+	condition3 := fhir.Condition{
+		Id: to.Ptr("3"),
+		Subject: fhir.Reference{
+			Identifier: &fhir.Identifier{
+				System: to.Ptr("http://fhir.nl/fhir/NamingSystem/bsn"),
+				Value:  to.Ptr("987654321"),
+			},
+		},
+	}
+	condition3Raw, _ := json.Marshal(condition3)
+
+	patient1 := fhir.Patient{
+		Id: to.Ptr("1"),
+		Identifier: []fhir.Identifier{
+			{
+				System: to.Ptr("http://fhir.nl/fhir/NamingSystem/bsn"),
+				Value:  to.Ptr("123456789"),
+			},
+		},
+	}
+	patient1Raw, _ := json.Marshal(patient1)
+
+	careTeamJson := `{"resourceType":"CareTeam","id":"ct-1","participant":[{"member":{"identifier":{"system":"http://fhir.nl/fhir/NamingSystem/ura","value":"1"}}}]}`
+	carePlan1 := fhir.CarePlan{
+		Id: to.Ptr("1"),
+		Subject: fhir.Reference{
+			Reference: to.Ptr("Patient/1"),
+		},
+		Contained: json.RawMessage(`[` + careTeamJson + `]`),
+		CareTeam: []fhir.Reference{
+			{
+				Reference: to.Ptr("#ct-1"),
+			},
+		},
+	}
+	carePlan1Raw, _ := json.Marshal(carePlan1)
+
+	auditEventRead := fhir.AuditEvent{
+		Id:     to.Ptr("1"),
+		Action: to.Ptr(fhir.AuditEventActionR),
+		Entity: []fhir.AuditEventEntity{
+			{
+				What: &fhir.Reference{
+					Reference: to.Ptr("Condition/1"),
+				},
+			},
+		},
+	}
+	auditEventReadRaw, _ := json.Marshal(auditEventRead)
+
+	tests := map[string]struct {
+		context         context.Context
+		request         FHIRHandlerRequest
+		expectedError   error
+		setup           func(ctx context.Context, client *mock.MockClient)
+		mockResponse    *fhir.Bundle
+		expectedEntries []string
+	}{
+		"error: Empty bundle": {
+			context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal1),
+			request: FHIRHandlerRequest{
+				Principal:   auth.TestPrincipal1,
+				FhirHeaders: &fhirclient.Headers{},
+				RequestUrl:  &url.URL{RawQuery: "_id=1"},
+				LocalIdentity: &fhir.Identifier{
+					System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
+					Value:  to.Ptr("1"),
+				},
+			},
+			expectedError: nil,
+			setup: func(ctx context.Context, client *mock.MockClient) {
+				client.EXPECT().SearchWithContext(ctx, "Condition", gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+						*target = fhir.Bundle{Entry: []fhir.BundleEntry{}}
+						return nil
+					})
+			},
+			mockResponse:    &fhir.Bundle{Entry: []fhir.BundleEntry{}},
+			expectedEntries: []string{},
+		},
+		"error: fhirclient error": {
+			context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal1),
+			request: FHIRHandlerRequest{
+				Principal:   auth.TestPrincipal1,
+				FhirHeaders: &fhirclient.Headers{},
+				RequestUrl:  &url.URL{RawQuery: "_id=1"},
+				LocalIdentity: &fhir.Identifier{
+					System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
+					Value:  to.Ptr("1"),
+				},
+			},
+			expectedError: errors.New("error"),
+			setup: func(ctx context.Context, client *mock.MockClient) {
+				client.EXPECT().SearchWithContext(ctx, "Condition", gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(errors.New("error"))
+			},
+			mockResponse:    &fhir.Bundle{Entry: []fhir.BundleEntry{}},
+			expectedEntries: []string{},
+		},
+		"ok: Condition returned, patient access found": {
+			context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal1),
+			request: FHIRHandlerRequest{
+				Principal:   auth.TestPrincipal1,
+				FhirHeaders: &fhirclient.Headers{},
+				RequestUrl:  &url.URL{RawQuery: "_id=1"},
+				LocalIdentity: &fhir.Identifier{
+					System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
+					Value:  to.Ptr("1"),
+				},
+			},
+			expectedError: nil,
+			setup: func(ctx context.Context, client *mock.MockClient) {
+				// Patient search for condition's subject
+				client.EXPECT().SearchWithContext(ctx, "Patient", gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, params url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+						require.Equal(t, "http://fhir.nl/fhir/NamingSystem/bsn|123456789", params.Get("identifier"))
+						*target = fhir.Bundle{
+							Entry: []fhir.BundleEntry{
+								{Resource: patient1Raw},
+							},
+						}
+						return nil
+					})
+
+				// The searchPatient method calls to search for CarePlans to validate patient access
+				client.EXPECT().SearchWithContext(ctx, "CarePlan", gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, params url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+						// It's searching for CarePlans related to this patient
+						require.Contains(t, params.Get("subject"), "Patient/1")
+						*target = fhir.Bundle{
+							Entry: []fhir.BundleEntry{
+								{Resource: carePlan1Raw},
+							},
+						}
+						return nil
+					}).AnyTimes()
+
+				client.EXPECT().SearchWithContext(ctx, "Condition", gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+						*target = fhir.Bundle{
+							Entry: []fhir.BundleEntry{
+								{Resource: condition1Raw},
+							},
+						}
+						return nil
+					})
+			},
+			mockResponse: &fhir.Bundle{Entry: []fhir.BundleEntry{
+				{
+					Resource: condition1Raw,
+					Response: &fhir.BundleEntryResponse{
+						Status: "200 OK",
+					},
+				},
+				{
+					Resource: auditEventReadRaw,
+					Response: &fhir.BundleEntryResponse{
+						Status: "200 OK",
+					},
+				},
+			}},
+			expectedEntries: []string{string(condition1Raw)},
+		},
+		"ok: Condition returned, no patient access but is creator": {
+			context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal1),
+			request: FHIRHandlerRequest{
+				Principal:   auth.TestPrincipal1,
+				FhirHeaders: &fhirclient.Headers{},
+				RequestUrl:  &url.URL{RawQuery: "_id=2"},
+				LocalIdentity: &fhir.Identifier{
+					System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
+					Value:  to.Ptr("1"),
+				},
+			},
+			expectedError: nil,
+			setup: func(ctx context.Context, client *mock.MockClient) {
+				client.EXPECT().SearchWithContext(ctx, "Condition", gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+						*target = fhir.Bundle{
+							Entry: []fhir.BundleEntry{
+								{Resource: condition2Raw},
+							},
+						}
+						return nil
+					})
+
+				// Patient search for condition's subject returns empty (no access)
+				client.EXPECT().SearchWithContext(ctx, "Patient", gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, params url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+						require.Equal(t, "http://fhir.nl/fhir/NamingSystem/bsn|123456789", params.Get("identifier"))
+						*target = fhir.Bundle{Entry: []fhir.BundleEntry{}}
+						return nil
+					})
+
+				// Since patient search returns empty, we won't search for CarePlans, but just to be safe:
+				client.EXPECT().SearchWithContext(ctx, "CarePlan", gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, params url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+						*target = fhir.Bundle{
+							Entry: []fhir.BundleEntry{
+								{Resource: carePlan1Raw},
+							},
+						}
+						return nil
+					}).AnyTimes()
+
+				// isCreator check is expected to return true since our implementation currently always returns true
+			},
+			mockResponse: &fhir.Bundle{Entry: []fhir.BundleEntry{
+				{
+					Resource: condition2Raw,
+					Response: &fhir.BundleEntryResponse{
+						Status: "200 OK",
+					},
+				},
+				{
+					Resource: auditEventReadRaw,
+					Response: &fhir.BundleEntryResponse{
+						Status: "200 OK",
+					},
+				},
+			}},
+			expectedEntries: []string{string(condition2Raw)},
+		},
+		"ok: Multiple resources returned, correctly filtered": {
+			context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal1),
+			request: FHIRHandlerRequest{
+				Principal:   auth.TestPrincipal1,
+				FhirHeaders: &fhirclient.Headers{},
+				QueryParams: url.Values{"_id": []string{"1,2,3"}},
+				LocalIdentity: &fhir.Identifier{
+					System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
+					Value:  to.Ptr("1"),
+				},
+			},
+			expectedError: nil,
+			setup: func(ctx context.Context, client *mock.MockClient) {
+				client.EXPECT().SearchWithContext(ctx, "Condition", gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+						*target = fhir.Bundle{
+							Entry: []fhir.BundleEntry{
+								{Resource: condition1Raw},
+								{Resource: condition2Raw},
+								{Resource: condition3Raw},
+							},
+						}
+						return nil
+					}).AnyTimes()
+
+				// Patient search for first and second condition's subject (same BSN)
+				client.EXPECT().SearchWithContext(ctx, "Patient", gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, params url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+						if params.Get("identifier") == "http://fhir.nl/fhir/NamingSystem/bsn|123456789" {
+							*target = fhir.Bundle{
+								Entry: []fhir.BundleEntry{
+									{Resource: patient1Raw},
+								},
+							}
+						} else if params.Get("identifier") == "http://fhir.nl/fhir/NamingSystem/bsn|987654321" {
+							// No access to patient2
+							*target = fhir.Bundle{Entry: []fhir.BundleEntry{}}
+						}
+						return nil
+					}).AnyTimes()
+
+				// The searchPatient method calls to search for CarePlans to validate patient access
+				client.EXPECT().SearchWithContext(ctx, "CarePlan", gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, params url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+						// It's searching for CarePlans related to this patient
+						require.Contains(t, params.Get("subject"), "Patient/1")
+						*target = fhir.Bundle{
+							Entry: []fhir.BundleEntry{
+								{Resource: carePlan1Raw},
+							},
+						}
+						return nil
+					}).AnyTimes()
+
+				// isCreator check for condition3 returns true
+			},
+			mockResponse: &fhir.Bundle{Entry: []fhir.BundleEntry{
+				{
+					Resource: condition1Raw,
+					Response: &fhir.BundleEntryResponse{
+						Status: "200 OK",
+					},
+				},
+				{
+					Resource: auditEventReadRaw,
+					Response: &fhir.BundleEntryResponse{
+						Status: "200 OK",
+					},
+				},
+				{
+					Resource: condition2Raw,
+					Response: &fhir.BundleEntryResponse{
+						Status: "200 OK",
+					},
+				},
+				{
+					Resource: auditEventReadRaw,
+					Response: &fhir.BundleEntryResponse{
+						Status: "200 OK",
+					},
+				},
+				{
+					Resource: condition3Raw,
+					Response: &fhir.BundleEntryResponse{
+						Status: "200 OK",
+					},
+				},
+				{
+					Resource: auditEventReadRaw,
+					Response: &fhir.BundleEntryResponse{
+						Status: "200 OK",
+					},
+				},
+			}},
+			expectedEntries: []string{string(condition1Raw), string(condition2Raw), string(condition3Raw)},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			client := mock.NewMockClient(ctrl)
+			tt.setup(tt.context, client)
+
+			service := &Service{fhirClient: client}
+			tx := coolfhir.Transaction()
+			result, err := service.handleSearchCondition(tt.context, tt.request, tx)
+
+			if tt.expectedError != nil {
+				require.Equal(t, tt.expectedError, err)
+				require.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+
+				entries, notifications, err := result(tt.mockResponse)
+				require.NoError(t, err)
+				require.NotNil(t, entries)
+				require.Len(t, notifications, 0)
+
+				if len(tt.expectedEntries) > 0 {
+					// Check that we have the expected number of entries
+					require.Len(t, entries, len(tt.expectedEntries))
+
+					actualEntries := []string{}
+					for _, entry := range entries {
+						actualEntries = append(actualEntries, string(entry.Resource))
+					}
+
+					// Verify that the actual entries match the expected entries
+					require.ElementsMatch(t, tt.expectedEntries, actualEntries)
+				} else {
+					require.Empty(t, entries)
+				}
+			}
+		})
+	}
+}

--- a/orchestrator/careplanservice/handle_getquestionnaire.go
+++ b/orchestrator/careplanservice/handle_getquestionnaire.go
@@ -3,6 +3,8 @@ package careplanservice
 import (
 	"context"
 	"encoding/json"
+	"net/url"
+	"strings"
 
 	fhirclient "github.com/SanteonNL/go-fhir-client"
 	"github.com/SanteonNL/orca/orchestrator/lib/audit"
@@ -47,4 +49,80 @@ func (s *Service) handleReadQuestionnaire(ctx context.Context, request FHIRHandl
 		// We do not want to notify subscribers for a get
 		return []*fhir.BundleEntry{&bundleEntry}, []any{}, nil
 	}, nil
+}
+
+// handleSearchQuestionnaire performs a search for Questionnaire based on the user request parameters
+func (s *Service) handleSearchQuestionnaire(ctx context.Context, request FHIRHandlerRequest, tx *coolfhir.BundleBuilder) (FHIRHandlerResult, error) {
+	log.Ctx(ctx).Info().Msgf("Searching for Questionnaires")
+
+	bundle, err := s.searchQuestionnaire(ctx, request.QueryParams, request.FhirHeaders)
+	if err != nil {
+		return nil, err
+	}
+
+	results := []*fhir.BundleEntry{}
+
+	for _, entry := range bundle.Entry {
+		var currentQuestionnaire fhir.Questionnaire
+		if err := json.Unmarshal(entry.Resource, &currentQuestionnaire); err != nil {
+			log.Ctx(ctx).Error().
+				Err(err).
+				Msg("Failed to unmarshal resource for audit")
+			continue
+		}
+
+		// Create the query detail entity
+		queryEntity := fhir.AuditEventEntity{
+			Type: &fhir.Coding{
+				System:  to.Ptr("http://terminology.hl7.org/CodeSystem/audit-entity-type"),
+				Code:    to.Ptr("2"), // query parameters
+				Display: to.Ptr("Query Parameters"),
+			},
+			Detail: []fhir.AuditEventEntityDetail{},
+		}
+
+		// Add each query parameter as a detail
+		for param, values := range request.QueryParams {
+			queryEntity.Detail = append(queryEntity.Detail, fhir.AuditEventEntityDetail{
+				Type:        param, // parameter name as string
+				ValueString: to.Ptr(strings.Join(values, ",")),
+			})
+		}
+
+		bundleEntry := fhir.BundleEntry{
+			Resource: entry.Resource,
+			Response: &fhir.BundleEntryResponse{
+				Status: "200 OK",
+			},
+		}
+		results = append(results, &bundleEntry)
+
+		// Add audit event to the transaction
+		auditEvent := audit.Event(*request.LocalIdentity, fhir.AuditEventActionR, &fhir.Reference{
+			Id:        currentQuestionnaire.Id,
+			Type:      to.Ptr("Questionnaire"),
+			Reference: to.Ptr("Questionnaire/" + *currentQuestionnaire.Id),
+		}, &fhir.Reference{
+			Identifier: &request.Principal.Organization.Identifier[0],
+			Type:       to.Ptr("Organization"),
+		})
+		tx.Create(auditEvent)
+	}
+
+	return func(txResult *fhir.Bundle) ([]*fhir.BundleEntry, []any, error) {
+		// Simply return the already prepared results
+		return results, []any{}, nil
+	}, nil
+}
+
+// searchQuestionnaire performs the core functionality of searching for questionnaires
+// This can be used by other resources to search for questionnaires
+func (s *Service) searchQuestionnaire(ctx context.Context, queryParams url.Values, headers *fhirclient.Headers) (*fhir.Bundle, error) {
+	var bundle fhir.Bundle
+	err := s.fhirClient.SearchWithContext(ctx, "Questionnaire", queryParams, &bundle, fhirclient.ResponseHeaders(headers))
+	if err != nil {
+		return nil, err
+	}
+
+	return &bundle, nil
 }

--- a/orchestrator/careplanservice/handle_getquestionnaire_test.go
+++ b/orchestrator/careplanservice/handle_getquestionnaire_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net/url"
 	"testing"
 
 	fhirclient "github.com/SanteonNL/go-fhir-client"
@@ -115,6 +116,268 @@ func TestService_handleGetQuestionnaire(t *testing.T) {
 				require.Equal(t, questionnaire.Id, to.Ptr("1"))
 
 				require.Len(t, notifications, 0)
+			}
+		})
+	}
+}
+
+func TestService_handleSearchQuestionnaire(t *testing.T) {
+	questionnaire1 := fhir.Questionnaire{
+		Id:     to.Ptr("1"),
+		Status: fhir.PublicationStatusActive,
+		Title:  to.Ptr("Questionnaire 1"),
+	}
+	questionnaire1Raw, _ := json.Marshal(questionnaire1)
+
+	questionnaire2 := fhir.Questionnaire{
+		Id:     to.Ptr("2"),
+		Status: fhir.PublicationStatusDraft,
+		Title:  to.Ptr("Questionnaire 2"),
+	}
+	questionnaire2Raw, _ := json.Marshal(questionnaire2)
+
+	questionnaire3 := fhir.Questionnaire{
+		Id:     to.Ptr("3"),
+		Status: fhir.PublicationStatusActive,
+		Title:  to.Ptr("Questionnaire 3"),
+	}
+	questionnaire3Raw, _ := json.Marshal(questionnaire3)
+
+	auditEventRead := fhir.AuditEvent{
+		Id:     to.Ptr("1"),
+		Action: to.Ptr(fhir.AuditEventActionR),
+		Entity: []fhir.AuditEventEntity{
+			{
+				What: &fhir.Reference{
+					Reference: to.Ptr("Questionnaire/1"),
+				},
+			},
+		},
+	}
+	auditEventReadRaw, _ := json.Marshal(auditEventRead)
+
+	tests := map[string]struct {
+		context         context.Context
+		request         FHIRHandlerRequest
+		expectedError   error
+		setup           func(ctx context.Context, client *mock.MockClient)
+		mockResponse    *fhir.Bundle
+		expectedEntries []string
+	}{
+		"empty bundle": {
+			context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal1),
+			request: FHIRHandlerRequest{
+				Principal:   auth.TestPrincipal1,
+				FhirHeaders: &fhirclient.Headers{},
+				RequestUrl:  &url.URL{RawQuery: "_id=nonexistent"},
+				LocalIdentity: &fhir.Identifier{
+					System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
+					Value:  to.Ptr("1"),
+				},
+			},
+			expectedError: nil,
+			setup: func(ctx context.Context, client *mock.MockClient) {
+				client.EXPECT().SearchWithContext(ctx, "Questionnaire", gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+						*target = fhir.Bundle{Entry: []fhir.BundleEntry{}}
+						return nil
+					})
+			},
+			mockResponse:    &fhir.Bundle{Entry: []fhir.BundleEntry{}},
+			expectedEntries: []string{},
+		},
+		"fhirclient error": {
+			context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal1),
+			request: FHIRHandlerRequest{
+				Principal:   auth.TestPrincipal1,
+				FhirHeaders: &fhirclient.Headers{},
+				RequestUrl:  &url.URL{RawQuery: "_id=1"},
+				LocalIdentity: &fhir.Identifier{
+					System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
+					Value:  to.Ptr("1"),
+				},
+			},
+			expectedError: errors.New("error"),
+			setup: func(ctx context.Context, client *mock.MockClient) {
+				client.EXPECT().SearchWithContext(ctx, "Questionnaire", gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(errors.New("error"))
+			},
+			mockResponse:    &fhir.Bundle{Entry: []fhir.BundleEntry{}},
+			expectedEntries: []string{},
+		},
+		"single questionnaire returned": {
+			context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal1),
+			request: FHIRHandlerRequest{
+				Principal:   auth.TestPrincipal1,
+				FhirHeaders: &fhirclient.Headers{},
+				RequestUrl:  &url.URL{RawQuery: "_id=1"},
+				LocalIdentity: &fhir.Identifier{
+					System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
+					Value:  to.Ptr("1"),
+				},
+			},
+			expectedError: nil,
+			setup: func(ctx context.Context, client *mock.MockClient) {
+				client.EXPECT().SearchWithContext(ctx, "Questionnaire", gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, _ url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+						*target = fhir.Bundle{
+							Entry: []fhir.BundleEntry{
+								{Resource: questionnaire1Raw},
+							},
+						}
+						return nil
+					})
+			},
+			mockResponse: &fhir.Bundle{Entry: []fhir.BundleEntry{
+				{
+					Resource: questionnaire1Raw,
+					Response: &fhir.BundleEntryResponse{
+						Status: "200 OK",
+					},
+				},
+				{
+					Resource: auditEventReadRaw,
+					Response: &fhir.BundleEntryResponse{
+						Status: "200 OK",
+					},
+				},
+			}},
+			expectedEntries: []string{string(questionnaire1Raw)},
+		},
+		"multiple questionnaires returned": {
+			context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal1),
+			request: FHIRHandlerRequest{
+				Principal:   auth.TestPrincipal1,
+				FhirHeaders: &fhirclient.Headers{},
+				QueryParams: url.Values{"status": []string{"active"}},
+				LocalIdentity: &fhir.Identifier{
+					System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
+					Value:  to.Ptr("1"),
+				},
+			},
+			expectedError: nil,
+			setup: func(ctx context.Context, client *mock.MockClient) {
+				client.EXPECT().SearchWithContext(ctx, "Questionnaire", gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, params url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+						require.Equal(t, "active", params.Get("status"))
+						*target = fhir.Bundle{
+							Entry: []fhir.BundleEntry{
+								{Resource: questionnaire1Raw},
+								{Resource: questionnaire3Raw},
+							},
+						}
+						return nil
+					})
+			},
+			mockResponse: &fhir.Bundle{Entry: []fhir.BundleEntry{
+				{
+					Resource: questionnaire1Raw,
+					Response: &fhir.BundleEntryResponse{
+						Status: "200 OK",
+					},
+				},
+				{
+					Resource: auditEventReadRaw,
+					Response: &fhir.BundleEntryResponse{
+						Status: "200 OK",
+					},
+				},
+				{
+					Resource: questionnaire3Raw,
+					Response: &fhir.BundleEntryResponse{
+						Status: "200 OK",
+					},
+				},
+				{
+					Resource: auditEventReadRaw,
+					Response: &fhir.BundleEntryResponse{
+						Status: "200 OK",
+					},
+				},
+			}},
+			expectedEntries: []string{string(questionnaire1Raw), string(questionnaire3Raw)},
+		},
+		"search by multiple parameters": {
+			context: auth.WithPrincipal(context.Background(), *auth.TestPrincipal1),
+			request: FHIRHandlerRequest{
+				Principal:   auth.TestPrincipal1,
+				FhirHeaders: &fhirclient.Headers{},
+				QueryParams: url.Values{"_id": []string{"1,2,3"}, "status": []string{"draft"}},
+				LocalIdentity: &fhir.Identifier{
+					System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
+					Value:  to.Ptr("1"),
+				},
+			},
+			expectedError: nil,
+			setup: func(ctx context.Context, client *mock.MockClient) {
+				client.EXPECT().SearchWithContext(ctx, "Questionnaire", gomock.Any(), gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, _ string, params url.Values, target *fhir.Bundle, _ ...fhirclient.Option) error {
+						require.Equal(t, "1,2,3", params.Get("_id"))
+						require.Equal(t, "draft", params.Get("status"))
+						*target = fhir.Bundle{
+							Entry: []fhir.BundleEntry{
+								{Resource: questionnaire2Raw},
+							},
+						}
+						return nil
+					})
+			},
+			mockResponse: &fhir.Bundle{Entry: []fhir.BundleEntry{
+				{
+					Resource: questionnaire2Raw,
+					Response: &fhir.BundleEntryResponse{
+						Status: "200 OK",
+					},
+				},
+				{
+					Resource: auditEventReadRaw,
+					Response: &fhir.BundleEntryResponse{
+						Status: "200 OK",
+					},
+				},
+			}},
+			expectedEntries: []string{string(questionnaire2Raw)},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			client := mock.NewMockClient(ctrl)
+			tt.setup(tt.context, client)
+
+			service := &Service{fhirClient: client}
+			tx := coolfhir.Transaction()
+			result, err := service.handleSearchQuestionnaire(tt.context, tt.request, tx)
+
+			if tt.expectedError != nil {
+				require.Equal(t, tt.expectedError, err)
+				require.Nil(t, result)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+
+				entries, notifications, err := result(tt.mockResponse)
+				require.NoError(t, err)
+				require.NotNil(t, entries)
+				require.Len(t, notifications, 0)
+
+				if len(tt.expectedEntries) > 0 {
+					// Check that we have the expected number of entries
+					require.Len(t, entries, len(tt.expectedEntries))
+
+					actualEntries := []string{}
+					for _, entry := range entries {
+						actualEntries = append(actualEntries, string(entry.Resource))
+					}
+
+					// Verify that the actual entries match the expected entries
+					require.ElementsMatch(t, tt.expectedEntries, actualEntries)
+				} else {
+					require.Empty(t, entries)
+				}
 			}
 		})
 	}

--- a/orchestrator/careplanservice/handle_getquestionnaireresponse.go
+++ b/orchestrator/careplanservice/handle_getquestionnaireresponse.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"strings"
 
 	fhirclient "github.com/SanteonNL/go-fhir-client"
 	"github.com/SanteonNL/orca/orchestrator/lib/audit"
+	"github.com/SanteonNL/orca/orchestrator/lib/auth"
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
 	"github.com/SanteonNL/orca/orchestrator/lib/to"
 	"github.com/rs/zerolog/log"
@@ -74,4 +76,114 @@ func (s *Service) handleReadQuestionnaireResponse(ctx context.Context, request F
 		// We do not want to notify subscribers for a get
 		return []*fhir.BundleEntry{&bundleEntry}, []any{}, nil
 	}, nil
+}
+
+// handleSearchQuestionnaireResponse performs a search for QuestionnaireResponse based on the user request parameters
+// and filters the results based on user authorization
+func (s *Service) handleSearchQuestionnaireResponse(ctx context.Context, request FHIRHandlerRequest, tx *coolfhir.BundleBuilder) (FHIRHandlerResult, error) {
+	log.Ctx(ctx).Info().Msgf("Searching for QuestionnaireResponses")
+
+	bundle, err := s.searchQuestionnaireResponse(ctx, request.QueryParams, request.FhirHeaders, *request.Principal)
+	if err != nil {
+		return nil, err
+	}
+
+	results := []*fhir.BundleEntry{}
+
+	for _, entry := range bundle.Entry {
+		var currentQuestionnaireResponse fhir.QuestionnaireResponse
+		if err := json.Unmarshal(entry.Resource, &currentQuestionnaireResponse); err != nil {
+			log.Ctx(ctx).Error().
+				Err(err).
+				Msg("Failed to unmarshal resource for audit")
+			continue
+		}
+
+		// Create the query detail entity
+		queryEntity := fhir.AuditEventEntity{
+			Type: &fhir.Coding{
+				System:  to.Ptr("http://terminology.hl7.org/CodeSystem/audit-entity-type"),
+				Code:    to.Ptr("2"), // query parameters
+				Display: to.Ptr("Query Parameters"),
+			},
+			Detail: []fhir.AuditEventEntityDetail{},
+		}
+
+		// Add each query parameter as a detail
+		for param, values := range request.QueryParams {
+			queryEntity.Detail = append(queryEntity.Detail, fhir.AuditEventEntityDetail{
+				Type:        param, // parameter name as string
+				ValueString: to.Ptr(strings.Join(values, ",")),
+			})
+		}
+
+		bundleEntry := fhir.BundleEntry{
+			Resource: entry.Resource,
+			Response: &fhir.BundleEntryResponse{
+				Status: "200 OK",
+			},
+		}
+		results = append(results, &bundleEntry)
+
+		// Add audit event to the transaction
+		auditEvent := audit.Event(*request.LocalIdentity, fhir.AuditEventActionR, &fhir.Reference{
+			Id:        currentQuestionnaireResponse.Id,
+			Type:      to.Ptr("QuestionnaireResponse"),
+			Reference: to.Ptr("QuestionnaireResponse/" + *currentQuestionnaireResponse.Id),
+		}, &fhir.Reference{
+			Identifier: &request.Principal.Organization.Identifier[0],
+			Type:       to.Ptr("Organization"),
+		})
+		tx.Create(auditEvent)
+	}
+
+	return func(txResult *fhir.Bundle) ([]*fhir.BundleEntry, []any, error) {
+		// Simply return the already prepared results
+		return results, []any{}, nil
+	}, nil
+}
+
+// searchQuestionnaireResponse performs the core functionality of searching for questionnaire responses and filtering by authorization
+// This can be used by other resources to search for questionnaire responses and filter by authorization
+func (s *Service) searchQuestionnaireResponse(ctx context.Context, queryParams url.Values, headers *fhirclient.Headers, principal auth.Principal) (*fhir.Bundle, error) {
+	questionnaireResponses, bundle, err := handleSearchResource[fhir.QuestionnaireResponse](ctx, s, "QuestionnaireResponse", queryParams, headers)
+	if err != nil {
+		return nil, err
+	}
+	if len(questionnaireResponses) == 0 {
+		// If there are no questionnaire responses in the bundle there is no point in doing validation, return empty bundle to user
+		return &fhir.Bundle{Entry: []fhir.BundleEntry{}}, nil
+	}
+
+	// For each QuestionnaireResponse, check if the user has access via Task or as creator
+	var allowedQuestionnaireResponseRefs []string
+	for _, qr := range questionnaireResponses {
+		// Try to find a Task that references this QuestionnaireResponse in output
+		taskBundle, err := s.searchTask(ctx, url.Values{"output-reference": []string{"QuestionnaireResponse/" + *qr.Id}}, headers, principal)
+		if err != nil {
+			log.Ctx(ctx).Error().Err(err).Msgf("Error checking tasks for QuestionnaireResponse/%s", *qr.Id)
+			continue
+		}
+
+		// If task is found, the user has access
+		if len(taskBundle.Entry) > 0 {
+			allowedQuestionnaireResponseRefs = append(allowedQuestionnaireResponseRefs, "QuestionnaireResponse/"+*qr.Id)
+			continue
+		}
+
+		// If no task is found, check if the user is the creator
+		isCreator, err := s.isCreatorOfResource(ctx, principal, "QuestionnaireResponse", *qr.Id)
+		if err != nil {
+			log.Ctx(ctx).Error().Err(err).Msgf("Error checking if user is creator of QuestionnaireResponse/%s", *qr.Id)
+			continue
+		}
+
+		if isCreator {
+			allowedQuestionnaireResponseRefs = append(allowedQuestionnaireResponseRefs, "QuestionnaireResponse/"+*qr.Id)
+		}
+	}
+
+	retBundle := filterMatchingResourcesInBundle(ctx, bundle, []string{"QuestionnaireResponse"}, allowedQuestionnaireResponseRefs)
+
+	return &retBundle, nil
 }

--- a/orchestrator/careplanservice/handle_getquestionnaireresponse.go
+++ b/orchestrator/careplanservice/handle_getquestionnaireresponse.go
@@ -25,28 +25,14 @@ func (s *Service) handleReadQuestionnaireResponse(ctx context.Context, request F
 		return nil, err
 	}
 
-	// Fetch tasks where the QuestionnaireResponse is in the task Output
-	// If the user has access to the task, they have access to the questionnaire response
-	bundle, err := s.searchTask(ctx, url.Values{"output-reference": []string{"QuestionnaireResponse/" + request.ResourceId}}, request.FhirHeaders, *request.Principal)
-	if err != nil {
-		return nil, err
-	}
-
-	// If the user does not have access to the task, check if they are the creator of the questionnaire response
-	if len(bundle.Entry) == 0 {
-		// If the user created the questionnaire response, they have access to it
-		isCreator, err := s.isCreatorOfResource(ctx, *request.Principal, "QuestionnaireResponse", request.ResourceId)
-		if isCreator {
-			// User has access, continue with transaction
-		} else {
-			if err != nil {
-				log.Ctx(ctx).Error().Err(err).Msg("Error checking if user is creator of QuestionnaireResponse")
-			}
-
-			return nil, &coolfhir.ErrorWithCode{
-				Message:    "Participant does not have access to QuestionnaireResponse",
-				StatusCode: http.StatusForbidden,
-			}
+	canAccess, err := s.canRequesterAccessQuestionnaireResponse(ctx, *questionnaireResponse.Id, request.FhirHeaders, *request.Principal)
+	if !canAccess {
+		if err != nil {
+			log.Ctx(ctx).Error().Err(err).Msg("Error checking if user is creator of QuestionnaireResponse")
+		}
+		return nil, &coolfhir.ErrorWithCode{
+			Message:    "Participant does not have access to QuestionnaireResponse",
+			StatusCode: http.StatusForbidden,
 		}
 	}
 
@@ -158,27 +144,8 @@ func (s *Service) searchQuestionnaireResponse(ctx context.Context, queryParams u
 	// For each QuestionnaireResponse, check if the user has access via Task or as creator
 	var allowedQuestionnaireResponseRefs []string
 	for _, qr := range questionnaireResponses {
-		// Try to find a Task that references this QuestionnaireResponse in output
-		taskBundle, err := s.searchTask(ctx, url.Values{"output-reference": []string{"QuestionnaireResponse/" + *qr.Id}}, headers, principal)
-		if err != nil {
-			log.Ctx(ctx).Error().Err(err).Msgf("Error checking tasks for QuestionnaireResponse/%s", *qr.Id)
-			continue
-		}
-
-		// If task is found, the user has access
-		if len(taskBundle.Entry) > 0 {
-			allowedQuestionnaireResponseRefs = append(allowedQuestionnaireResponseRefs, "QuestionnaireResponse/"+*qr.Id)
-			continue
-		}
-
-		// If no task is found, check if the user is the creator
-		isCreator, err := s.isCreatorOfResource(ctx, principal, "QuestionnaireResponse", *qr.Id)
-		if err != nil {
-			log.Ctx(ctx).Error().Err(err).Msgf("Error checking if user is creator of QuestionnaireResponse/%s", *qr.Id)
-			continue
-		}
-
-		if isCreator {
+		canAccess, _ := s.canRequesterAccessQuestionnaireResponse(ctx, *qr.Id, headers, principal)
+		if canAccess {
 			allowedQuestionnaireResponseRefs = append(allowedQuestionnaireResponseRefs, "QuestionnaireResponse/"+*qr.Id)
 		}
 	}
@@ -186,4 +153,31 @@ func (s *Service) searchQuestionnaireResponse(ctx context.Context, queryParams u
 	retBundle := filterMatchingResourcesInBundle(ctx, bundle, []string{"QuestionnaireResponse"}, allowedQuestionnaireResponseRefs)
 
 	return &retBundle, nil
+}
+
+// TODO: Abstract access checking to a common function that can be applied to all resources
+func (s *Service) canRequesterAccessQuestionnaireResponse(ctx context.Context, qrId string, headers *fhirclient.Headers, principal auth.Principal) (bool, error) {
+	// Try to find a Task that references this QuestionnaireResponse in output
+	taskBundle, err := s.searchTask(ctx, url.Values{"output-reference": []string{"QuestionnaireResponse/" + qrId}}, headers, principal)
+	if err != nil {
+		log.Ctx(ctx).Error().Err(err).Msgf("Error checking tasks for QuestionnaireResponse/%s", qrId)
+		return false, err
+	}
+
+	// If task is found, the user has access
+	if len(taskBundle.Entry) > 0 {
+		return true, nil
+	}
+
+	// If no task is found, check if the user is the creator
+	isCreator, err := s.isCreatorOfResource(ctx, principal, "QuestionnaireResponse", qrId)
+	if err != nil {
+		log.Ctx(ctx).Error().Err(err).Msgf("Error checking if user is creator of QuestionnaireResponse/%s", qrId)
+		return false, err
+	}
+
+	if isCreator {
+		return true, nil
+	}
+	return false, nil
 }

--- a/orchestrator/careplanservice/service.go
+++ b/orchestrator/careplanservice/service.go
@@ -574,6 +574,12 @@ func (s *Service) handleSearch(resourcePath string) func(context.Context, FHIRHa
 		return s.handleSearchTask
 	case "ServiceRequest":
 		return s.handleSearchServiceRequest
+	case "Questionnaire":
+		return s.handleSearchQuestionnaire
+	case "QuestionnaireResponse":
+		return s.handleSearchQuestionnaireResponse
+	case "Condition":
+		return s.handleSearchCondition
 	default:
 		return func(ctx context.Context, request FHIRHandlerRequest, tx *coolfhir.BundleBuilder) (FHIRHandlerResult, error) {
 			return s.handleUnmanagedOperation(ctx, request, tx)

--- a/viewer_simulator/app/api/bgz/careplans/route.ts
+++ b/viewer_simulator/app/api/bgz/careplans/route.ts
@@ -19,10 +19,9 @@ export async function GET(req: NextRequest) {
             method: 'POST',
             headers: {
                 Authorization: `Bearer ${process.env[`${name}_BEARER_TOKEN`] ?? ''}`,
-                'Content-Type': 'application/x-www-form-urlencoded',
+                'Content-Type': 'application/fhir+json',
                 'X-Cps-Url': baseUrl,
             },
-            body: `_count=10000`
         });
 
         if(!resp.ok) {

--- a/viewer_simulator/app/api/bgz/careplans/route.ts
+++ b/viewer_simulator/app/api/bgz/careplans/route.ts
@@ -19,9 +19,10 @@ export async function GET(req: NextRequest) {
             method: 'POST',
             headers: {
                 Authorization: `Bearer ${process.env[`${name}_BEARER_TOKEN`] ?? ''}`,
-                'Content-Type': 'application/fhir+json',
+                'Content-Type': 'application/x-www-form-urlencoded',
                 'X-Cps-Url': baseUrl,
             },
+            body: `_count=10000`
         });
 
         if(!resp.ok) {


### PR DESCRIPTION
The BGZ viewer does queries on all our data types using Search, previously this was handled by the proxy but this change implements Search for each type explicitly