### PR TITLE
Use a fixed phone number for new patients, to prevent accidentally sending messages to actual phones

### DIFF
--- a/hospital_simulator/app/(DashboardLayout)/components/service-requests/create-service-request-dialog.tsx
+++ b/hospital_simulator/app/(DashboardLayout)/components/service-requests/create-service-request-dialog.tsx
@@ -348,12 +348,14 @@ function generatePatientBsn() {
 }
 
 function generatePatientPhone() {
-    let prefix = "+31 6 ";
-    // Ensure the tail is exactly 4 digits, pad with zeros if necessary.
-    const tail = Math.floor(Math.random() * 100000000).toString().padStart(8, '0');
-    // Concatenate to form an 8-digit candidate.
-    let bsn = prefix + tail;
-    return bsn
+    // Some downstream systems might be sending actual messages to these phone numbers, so use a fixed, non-existing one.
+    return '+31 6 12345678';
+    // let prefix = "+31 6 ";
+    // // Ensure the tail is exactly 4 digits, pad with zeros if necessary.
+    // const tail = Math.floor(Math.random() * 100000000).toString().padStart(8, '0');
+    // // Concatenate to form an 8-digit candidate.
+    // let bsn = prefix + tail;
+    // return bsn
 }
 /**
  * Nederlandse burgerservicenummers, de vroegere sofinummers, voldoen aan een variant van de elfproef.


### PR DESCRIPTION
Some downstream systems might be sending actual messages to these phone numbers, so use a fixed, non-existing one.