### PR TITLE
Remove CPS proxy endpoint in favor of generic SCP proxy endpoint

### DIFF
--- a/e2e-tests/go.mod
+++ b/e2e-tests/go.mod
@@ -3,7 +3,7 @@ module e2e-tests
 go 1.24
 
 require (
-	github.com/SanteonNL/go-fhir-client v0.4.0
+	github.com/SanteonNL/go-fhir-client v0.5.0
 	github.com/nuts-foundation/go-nuts-client v0.1.9
 	github.com/stretchr/testify v1.10.0
 	github.com/testcontainers/testcontainers-go v0.37.0

--- a/e2e-tests/go.sum
+++ b/e2e-tests/go.sum
@@ -7,8 +7,8 @@ github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg6
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
-github.com/SanteonNL/go-fhir-client v0.4.0 h1:vQJkvEAuiNj/3Iovz5jBDDLW6MJ0GT/W8wvWdo5lnpM=
-github.com/SanteonNL/go-fhir-client v0.4.0/go.mod h1:CcU6J3vgxsdjTWry0s2BAJcV6SvdaRTsry9ixR7zqc4=
+github.com/SanteonNL/go-fhir-client v0.5.0 h1:3Lg/zpqQKvh193F3Hkgrqi1kCuNGBQ2S2UquwKgaPpI=
+github.com/SanteonNL/go-fhir-client v0.5.0/go.mod h1:CcU6J3vgxsdjTWry0s2BAJcV6SvdaRTsry9ixR7zqc4=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=

--- a/e2e-tests/main_test.go
+++ b/e2e-tests/main_test.go
@@ -56,7 +56,7 @@ func Test_Main(t *testing.T) {
 	require.NoError(t, err)
 	hospitalOrcaURL := setupOrchestrator(t, dockerNetwork.Name, "hospital-orchestrator", "hospital", true, hospitalFHIRStoreURL, clinicQuestionnaireFHIRStoreURL, true)
 	// hospitalOrcaFHIRClient is the FHIR client the hospital uses to interact with the CarePlanService
-	hospitalOrcaFHIRClient := fhirclient.New(hospitalOrcaURL.JoinPath("/cpc/cps/fhir"), orcaHttpClient, nil)
+	hospitalOrcaFHIRClient := fhirclient.New(hospitalOrcaURL.JoinPath("/cpc/external/fhir"), orcaHttpClient, nil)
 
 	// Set up FHIR client for clinic that can interact with hospital's CPS
 	hospitalAuthServerURL, _ := url.Parse("http://nutsnode:8080/oauth2/hospital")
@@ -93,7 +93,9 @@ func Test_Main(t *testing.T) {
 					},
 				},
 			}
-			err := hospitalOrcaFHIRClient.Create(patient, &patient)
+			err := hospitalOrcaFHIRClient.Create(patient, &patient, fhirclient.RequestHeaders(map[string][]string{
+				"X-Scp-Fhir-Url": {"local-cps"},
+			}))
 			require.NoError(t, err)
 		}
 		t.Run("Hospital EHR creates new Task", func(t *testing.T) {

--- a/e2e-tests/main_test.go
+++ b/e2e-tests/main_test.go
@@ -60,6 +60,7 @@ func Test_Main(t *testing.T) {
 		DefaultOptions: []fhirclient.Option{
 			fhirclient.RequestHeaders(map[string][]string{"X-Scp-Fhir-Url": {"local-cps"}}),
 		},
+		UsePostSearch: true,
 	})
 
 	// Set up FHIR client for clinic that can interact with hospital's CPS

--- a/e2e-tests/main_test.go
+++ b/e2e-tests/main_test.go
@@ -56,7 +56,11 @@ func Test_Main(t *testing.T) {
 	require.NoError(t, err)
 	hospitalOrcaURL := setupOrchestrator(t, dockerNetwork.Name, "hospital-orchestrator", "hospital", true, hospitalFHIRStoreURL, clinicQuestionnaireFHIRStoreURL, true)
 	// hospitalOrcaFHIRClient is the FHIR client the hospital uses to interact with the CarePlanService
-	hospitalOrcaFHIRClient := fhirclient.New(hospitalOrcaURL.JoinPath("/cpc/external/fhir"), orcaHttpClient, nil)
+	hospitalOrcaFHIRClient := fhirclient.New(hospitalOrcaURL.JoinPath("/cpc/external/fhir"), orcaHttpClient, &fhirclient.Config{
+		DefaultOptions: []fhirclient.Option{
+			fhirclient.RequestHeaders(map[string][]string{"X-Scp-Fhir-Url": {"local-cps"}}),
+		},
+	})
 
 	// Set up FHIR client for clinic that can interact with hospital's CPS
 	hospitalAuthServerURL, _ := url.Parse("http://nutsnode:8080/oauth2/hospital")
@@ -93,9 +97,8 @@ func Test_Main(t *testing.T) {
 					},
 				},
 			}
-			err := hospitalOrcaFHIRClient.Create(patient, &patient, fhirclient.RequestHeaders(map[string][]string{
-				"X-Scp-Fhir-Url": {"local-cps"},
-			}))
+
+			err := hospitalOrcaFHIRClient.Create(patient, &patient)
 			require.NoError(t, err)
 		}
 		t.Run("Hospital EHR creates new Task", func(t *testing.T) {

--- a/frontend/lib/fhirUtils.ts
+++ b/frontend/lib/fhirUtils.ts
@@ -43,7 +43,12 @@ export const createCpsClient = () => {
         ? `${typeof window !== 'undefined' ? window.location.origin : ''}/orca/cpc/cps/fhir`
         : "http://localhost:9090/fhir";
 
-    return new Client({ baseUrl });
+    return new Client({
+        baseUrl: baseUrl,
+        customHeaders: {
+            'X-Scp-Fhir-Url': 'local-cps',
+        }
+    });
 };
 
 export const fetchAllBundlePages = async <T extends Resource>(
@@ -287,8 +292,8 @@ export const findQuestionnaireResponse = async (task?: Task, questionnaire?: Que
 
 /**
  * Returns a string representation of an Identifier ONLY if both the system and value are set. Otherwise, returns undefined.
- * @param identifier 
- * @returns 
+ * @param identifier
+ * @returns
  */
 export function identifierToString(identifier?: Identifier) {
 

--- a/orchestrator/careplancontributor/service_test.go
+++ b/orchestrator/careplancontributor/service_test.go
@@ -637,100 +637,6 @@ func TestService_Proxy_ProxyToEHR_WithLogout(t *testing.T) {
 	require.Equal(t, http.StatusUnauthorized, httpResponse.StatusCode)
 }
 
-func TestService_Proxy_ProxyToCPS_WithLogout(t *testing.T) {
-	// Test that the service registers the CarePlanService FHIR proxy URL that proxies to the CarePlanService
-	// Setup: configure CarePlanService to which the service proxies
-	carePlanServiceMux := http.NewServeMux()
-	var capturedHost string
-	var capturedBody []byte
-	carePlanServiceMux.HandleFunc("POST /fhir/Patient/_search", func(writer http.ResponseWriter, request *http.Request) {
-		writer.WriteHeader(http.StatusOK)
-		capturedHost = request.Host
-		capturedBody, _ = io.ReadAll(request.Body)
-		_ = json.NewEncoder(writer).Encode(fhir.Bundle{})
-	})
-	carePlanServiceMux.HandleFunc("GET /fhir/Patient/1", func(writer http.ResponseWriter, request *http.Request) {
-		writer.WriteHeader(http.StatusOK)
-		capturedHost = request.Host
-		_ = json.NewEncoder(writer).Encode(fhir.Patient{
-			Id: to.Ptr("1"),
-		})
-	})
-	carePlanService := httptest.NewServer(carePlanServiceMux)
-	carePlanServiceURL, _ := url.Parse(carePlanService.URL)
-	carePlanServiceURL.Path = "/fhir"
-
-	messageBroker, err := messaging.New(messaging.Config{}, nil)
-	require.NoError(t, err)
-	sessionManager, sessionID := createTestSession()
-
-	service, err := New(Config{}, profile.Test(), orcaPublicURL, sessionManager, messageBroker, events.NewManager(messageBroker), &httputil.ReverseProxy{}, carePlanServiceURL)
-	require.NoError(t, err)
-	// Setup: configure the service to proxy to the upstream CarePlanService
-	frontServerMux := http.NewServeMux()
-	service.RegisterHandlers(frontServerMux)
-	frontServer := httptest.NewServer(frontServerMux)
-
-	params := url.Values{
-		"foo": {"bar"},
-	}
-	httpRequest, _ := http.NewRequest("POST", frontServer.URL+"/cpc/cps/fhir/Patient/_search", strings.NewReader(params.Encode()))
-	httpRequest.AddCookie(&http.Cookie{
-		Name:  "sid",
-		Value: sessionID,
-	})
-	httpResponse, err := frontServer.Client().Do(httpRequest)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, httpResponse.StatusCode)
-	require.Equal(t, carePlanServiceURL.Host, capturedHost)
-	expectedValues := url.Values{
-		"foo": {"bar"},
-	}
-	actualValues, err := url.ParseQuery(string(capturedBody))
-	require.NoError(t, err)
-	require.Equal(t, expectedValues, actualValues)
-
-	t.Run("check meta.source is set for read operations", func(t *testing.T) {
-		httpRequest, _ := http.NewRequest("GET", frontServer.URL+"/cpc/cps/fhir/Patient/1", nil)
-		httpRequest.AddCookie(&http.Cookie{
-			Name:  "sid",
-			Value: sessionID,
-		})
-		httpResponse, err := frontServer.Client().Do(httpRequest)
-		require.NoError(t, err)
-		responseData, err := io.ReadAll(httpResponse.Body)
-		require.NoError(t, err)
-		var patient fhir.Patient
-		err = json.Unmarshal(responseData, &patient)
-		require.NoError(t, err)
-		require.NotNil(t, patient.Meta)
-		require.NotNil(t, patient.Meta.Source)
-	})
-
-	t.Run("caching is not allowed", func(t *testing.T) {
-		assert.Equal(t, "no-store", httpResponse.Header.Get("Cache-Control"))
-	})
-
-	// Logout and attempt to get the patient again
-	httpRequest, _ = http.NewRequest("POST", frontServer.URL+"/logout", nil)
-	httpRequest.AddCookie(&http.Cookie{
-		Name:  "sid",
-		Value: sessionID,
-	})
-	httpResponse, err = frontServer.Client().Do(httpRequest)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, httpResponse.StatusCode)
-
-	httpRequest, _ = http.NewRequest("POST", frontServer.URL+"/cpc/cps/fhir/Patient/_search", strings.NewReader(params.Encode()))
-	httpRequest.AddCookie(&http.Cookie{
-		Name:  "sid",
-		Value: sessionID,
-	})
-	httpResponse, err = frontServer.Client().Do(httpRequest)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusUnauthorized, httpResponse.StatusCode)
-}
-
 func TestService_HandleSearchEndpoints(t *testing.T) {
 	// Test that the service registers the /cpc URL that proxies to the backing FHIR server
 	// Setup: configure backing FHIR server to which the service proxies
@@ -774,97 +680,6 @@ func TestService_HandleSearchEndpoints(t *testing.T) {
 	t.Run("search parameters not allowed", func(t *testing.T) {
 		httpRequest, _ := http.NewRequest("GET", frontServer.URL+"/cpc/fhir/Endpoint?foo=bar", nil)
 		httpResponse, err := httpClient.Do(httpRequest)
-		require.NoError(t, err)
-		require.Equal(t, http.StatusBadRequest, httpResponse.StatusCode)
-	})
-}
-
-func TestService_ProxyToExternalCPS(t *testing.T) {
-	// Test that providing an X-Cps-Url header will proxy to an external CPS via NUTS authz
-	// Setup: configure a "local" CarePlanService
-	localCarePlanServiceMux := http.NewServeMux()
-	localCarePlanService := httptest.NewServer(localCarePlanServiceMux)
-	localCarePlanServiceURL, _ := url.Parse(localCarePlanService.URL)
-
-	// Setup: configure a "remote" CarePlanService
-	remoteCarePlanServiceMux := http.NewServeMux()
-	var capturedHost string
-	var capturedBody []byte
-	remoteCarePlanServiceMux.HandleFunc("POST /fhir/Patient/_search", func(writer http.ResponseWriter, request *http.Request) {
-		writer.WriteHeader(http.StatusOK)
-		capturedHost = request.Host
-		capturedBody, _ = io.ReadAll(request.Body)
-		searchBundle := fhir.Bundle{
-			Entry: []fhir.BundleEntry{
-				{
-					Resource: func() json.RawMessage {
-						b, _ := json.Marshal(fhir.Patient{
-							Id: to.Ptr("1"),
-						})
-						return b
-					}(),
-				},
-			},
-		}
-		_ = json.NewEncoder(writer).Encode(searchBundle)
-	})
-	remoteCarePlanService := httptest.NewServer(remoteCarePlanServiceMux)
-	remoteCarePlanServiceURL, _ := url.Parse(remoteCarePlanService.URL)
-	remoteCarePlanServiceURL.Path = "/fhir"
-
-	messageBroker, err := messaging.New(messaging.Config{}, nil)
-	require.NoError(t, err)
-	sessionManager, sessionID := createTestSession()
-
-	service, err := New(Config{}, profile.Test(), orcaPublicURL, sessionManager, messageBroker, events.NewManager(messageBroker), &httputil.ReverseProxy{}, localCarePlanServiceURL)
-	require.NoError(t, err)
-
-	// Setup: configure the service to proxy to the upstream CarePlanService
-	frontServerMux := http.NewServeMux()
-	service.RegisterHandlers(frontServerMux)
-	frontServer := httptest.NewServer(frontServerMux)
-
-	params := url.Values{
-		"foo": {"bar"},
-	}
-	httpRequest, _ := http.NewRequest("POST", frontServer.URL+"/cpc/cps/fhir/Patient/_search", strings.NewReader(params.Encode()))
-	httpRequest.Header.Add("X-Cps-Url", remoteCarePlanServiceURL.String())
-	httpRequest.AddCookie(&http.Cookie{
-		Name:  "sid",
-		Value: sessionID,
-	})
-	httpResponse, err := frontServer.Client().Do(httpRequest)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, httpResponse.StatusCode)
-	require.Equal(t, remoteCarePlanServiceURL.Host, capturedHost)
-	expectedValues := url.Values{
-		"foo": {"bar"},
-	}
-	actualValues, err := url.ParseQuery(string(capturedBody))
-	require.NoError(t, err)
-	require.Equal(t, expectedValues, actualValues)
-
-	var bundle fhir.Bundle
-	err = json.NewDecoder(httpResponse.Body).Decode(&bundle)
-	require.NoError(t, err)
-	require.Len(t, bundle.Entry, 1)
-
-	patientBytes, err := json.Marshal(bundle.Entry[0].Resource)
-	require.NoError(t, err)
-	var patient fhir.Patient
-	err = json.Unmarshal(patientBytes, &patient)
-	require.NoError(t, err)
-	require.NotNil(t, patient.Id)
-	require.Equal(t, "1", *patient.Id)
-
-	t.Run("it should fail with invalid URL", func(t *testing.T) {
-		httpRequest, _ := http.NewRequest("POST", frontServer.URL+"/cpc/cps/fhir/Patient/_search", strings.NewReader(params.Encode()))
-		httpRequest.Header.Add("X-Cps-Url", "invalid-url")
-		httpRequest.AddCookie(&http.Cookie{
-			Name:  "sid",
-			Value: sessionID,
-		})
-		httpResponse, err := frontServer.Client().Do(httpRequest)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusBadRequest, httpResponse.StatusCode)
 	})
@@ -1093,15 +908,16 @@ func TestService_ExternalFHIRProxy(t *testing.T) {
 	t.Log("This tests the external FHIR proxy functionality (/cpc/external/fhir, used by the EHR and ORCA Frontend to query remote SCP-nodes' FHIR APIs.")
 
 	remoteFHIRAPIMux := http.NewServeMux()
-	remoteFHIRAPIMux.HandleFunc("POST /fhir/Task/_search", func(writer http.ResponseWriter, request *http.Request) {
-		results := coolfhir.SearchSet().Append(fhir.Task{
-			Id: to.Ptr("1"),
-		}, nil, nil)
-		coolfhir.SendResponse(writer, http.StatusOK, results)
+	remoteFHIRAPIMux.HandleFunc("GET /fhir/Task/1", func(writer http.ResponseWriter, request *http.Request) {
+		coolfhir.SendResponse(writer, http.StatusOK, fhir.Task{Id: to.Ptr("1")})
 	})
 	remoteSCPNode := httptest.NewServer(remoteFHIRAPIMux)
 
 	mux := http.NewServeMux()
+	mux.HandleFunc("GET /fhir/Task/2", func(writer http.ResponseWriter, request *http.Request) {
+		coolfhir.SendResponse(writer, http.StatusOK, fhir.Task{Id: to.Ptr("2")})
+	})
+
 	httpServer := httptest.NewServer(mux)
 	service := &Service{
 		profile: profile.TestProfile{
@@ -1114,13 +930,15 @@ func TestService_ExternalFHIRProxy(t *testing.T) {
 				},
 			},
 		},
-		orcaPublicURL: must.ParseURL(httpServer.URL),
-		config:        Config{StaticBearerToken: "secret"},
+		localCarePlanServiceUrl: must.ParseURL(httpServer.URL + "/fhir"),
+		orcaPublicURL:           must.ParseURL(httpServer.URL),
+		config:                  Config{StaticBearerToken: "secret"},
 	}
+	service.createFHIRClientForURL = service.defaultCreateFHIRClientForURL
 	service.RegisterHandlers(mux)
 
 	t.Run("X-Scp-Entity-Identifier", func(t *testing.T) {
-		httpRequest, _ := http.NewRequest(http.MethodPost, httpServer.URL+"/cpc/external/fhir/Task/_search", nil)
+		httpRequest, _ := http.NewRequest(http.MethodGet, httpServer.URL+"/cpc/external/fhir/Task/1", nil)
 		httpRequest.Header.Set("Authorization", "Bearer secret")
 		httpRequest.Header.Set("X-Scp-Entity-Identifier", "http://fhir.nl/fhir/NamingSystem/ura|2")
 		httpResponse, err := httpServer.Client().Do(httpRequest)
@@ -1129,6 +947,37 @@ func TestService_ExternalFHIRProxy(t *testing.T) {
 		responseData, err := io.ReadAll(httpResponse.Body)
 		require.NoError(t, err)
 		assert.NotEmpty(t, responseData)
+
+		t.Run("assert meta source is set", func(t *testing.T) {
+			var bundle fhir.Bundle
+			err = json.Unmarshal(responseData, &bundle)
+			require.NoError(t, err)
+			assert.Equal(t, remoteSCPNode.URL+"/fhir/Task/1", *bundle.Meta.Source)
+		})
+	})
+	t.Run("X-Scp-Fhir-Url", func(t *testing.T) {
+		t.Run("external", func(t *testing.T) {
+			httpRequest, _ := http.NewRequest(http.MethodGet, httpServer.URL+"/cpc/external/fhir/Task/1", nil)
+			httpRequest.Header.Set("Authorization", "Bearer secret")
+			httpRequest.Header.Set("X-Scp-Fhir-Url", remoteSCPNode.URL+"/fhir")
+			httpResponse, err := httpServer.Client().Do(httpRequest)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, httpResponse.StatusCode)
+			responseData, err := io.ReadAll(httpResponse.Body)
+			require.NoError(t, err)
+			assert.NotEmpty(t, responseData)
+		})
+		t.Run("local", func(t *testing.T) {
+			httpRequest, _ := http.NewRequest(http.MethodGet, httpServer.URL+"/cpc/external/fhir/Task/2", nil)
+			httpRequest.Header.Set("Authorization", "Bearer secret")
+			httpRequest.Header.Set("X-Scp-Fhir-Url", "local-cps")
+			httpResponse, err := httpServer.Client().Do(httpRequest)
+			require.NoError(t, err)
+			require.Equal(t, http.StatusOK, httpResponse.StatusCode)
+			responseData, err := io.ReadAll(httpResponse.Body)
+			require.NoError(t, err)
+			assert.NotEmpty(t, responseData)
+		})
 	})
 	t.Run("can't determine remote node", func(t *testing.T) {
 		httpRequest, _ := http.NewRequest(http.MethodPost, httpServer.URL+"/cpc/external/fhir/Task/_search", nil)

--- a/viewer_simulator/app/api/bgz/careplans/route.ts
+++ b/viewer_simulator/app/api/bgz/careplans/route.ts
@@ -27,13 +27,13 @@ export async function GET(req: NextRequest) {
             headers: {
                 Authorization: `Bearer ${process.env[`${name}_BEARER_TOKEN`] ?? ''}`,
                 'Content-Type': 'x-www-form-urlencoded',
-                'X-Cps-Url': baseUrl,
+                'X-Scp-Fhir-Url': baseUrl,
             },
             body: `_count=1000`
         });
 
         if(!resp.ok) {
-            console.error(`Failed to fetch data: ${process.env.ORCA_CPC_URL}/cps/fhir/CarePlan/_search (X-Cps-Url: ${baseUrl})`, resp.status);
+            console.error(`Failed to fetch data: ${process.env.ORCA_CPC_URL}/cps/fhir/CarePlan/_search (X-Scp-Fhir-Url: ${baseUrl})`, resp.status);
             return NextResponse.json({
                 error: `Failed to fetch data from ${baseUrl}`},
                 {   


### PR DESCRIPTION
We introduced `/cpc/external/fhir`, a new proxy endpoint to which all other outbound FHIR endpoints should migrate. This PR removes the `/cpc/cps/fhir` endpoint, which is used to either call the local CPS (ORCA Frontend, to create Tasks) or the Viewer (to fetch CarePlans).

This removes the `X-Cps-Url` header on the old endpoint, in favor of the new `X-Scp-Fhir-Url` header on the new endpoint. This header can be used to indicate CPC or CPS FHIR APIs, not just CPS.

It can also still be used by the ORCA Frontend to call the local CPS API (like the old endpoint supported), by specifying `local-cps`.