### PR TITLE
CPS: Use Task.Requester as CareTeam member, so displayName is set

### DIFF
--- a/orchestrator/careplanservice/handle_createtask.go
+++ b/orchestrator/careplanservice/handle_createtask.go
@@ -129,10 +129,7 @@ func (s *Service) handleCreateTask(ctx context.Context, request FHIRHandlerReque
 			}
 		}
 
-		ok := careteamservice.ActivateMembership(&careTeam, &fhir.Reference{
-			Identifier: &request.Principal.Organization.Identifier[0],
-			Type:       to.Ptr("Organization"),
-		})
+		ok := careteamservice.ActivateMembership(&careTeam, task.Requester)
 		if !ok {
 			return nil, errors.New("failed to activate membership for new CareTeam")
 		}


### PR DESCRIPTION
`Task.requester` is enriched with the care organization name, so we should use that one to make sure displayName is set.