### PR TITLE
Fix enrolment due to broken cached FHIR resources in session

### DIFF
--- a/orchestrator/careplancontributor/applaunch/demo/service_test.go
+++ b/orchestrator/careplancontributor/applaunch/demo/service_test.go
@@ -65,9 +65,9 @@ func TestService_handle(t *testing.T) {
 		require.Equal(t, "/cpc/new", response.Header().Get("Location"))
 		sessionData := user.SessionFromHttpResponse(sessionManager, response.Result())
 		require.NotNil(t, sessionData)
-		require.Equal(t, "Patient/a", sessionData.Get("Patient").Path)
-		require.Equal(t, "ServiceRequest/b", sessionData.Get("ServiceRequest").Path)
-		require.Equal(t, "Practitioner/c", sessionData.Get("Practitioner").Path)
+		require.Equal(t, "Patient/a", sessionData.GetByType("Patient").Path)
+		require.Equal(t, "ServiceRequest/b", sessionData.GetByType("ServiceRequest").Path)
+		require.Equal(t, "Practitioner/c", sessionData.GetByType("Practitioner").Path)
 		require.Equal(t, "unit-test-system|10", *sessionData.TaskIdentifier)
 	})
 	t.Run("subpath base URL", func(t *testing.T) {

--- a/orchestrator/careplancontributor/applaunch/session/data.go
+++ b/orchestrator/careplancontributor/applaunch/session/data.go
@@ -32,7 +32,16 @@ func (d *Data) Set(path string, resource any) {
 	d.ContextResources = append(d.ContextResources, res)
 }
 
-func (d *Data) Get(resourceType string) *FHIRResource {
+func (d *Data) GetByPath(resourcePath string) *FHIRResource {
+	for _, resource := range d.ContextResources {
+		if resource.Path == resourcePath {
+			return &resource
+		}
+	}
+	return nil
+}
+
+func (d *Data) GetByType(resourceType string) *FHIRResource {
 	for _, resource := range d.ContextResources {
 		if strings.HasPrefix(resource.Path, resourceType+"/") {
 			return &resource
@@ -43,7 +52,7 @@ func (d *Data) Get(resourceType string) *FHIRResource {
 
 func Get[T any](data *Data) *T {
 	var zero T
-	resource := data.Get(coolfhir.ResourceType(zero))
+	resource := data.GetByType(coolfhir.ResourceType(zero))
 	if resource == nil {
 		return nil
 	}

--- a/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
@@ -361,7 +361,7 @@ func (s *Service) handleLaunch(response http.ResponseWriter, request *http.Reque
 	// Redirect to landing page
 	log.Ctx(request.Context()).Info().Msg("Successfully launched through ChipSoft HiX app launch")
 
-	taskResource := sessionData.Get("Task")
+	taskResource := sessionData.GetByType("Task")
 	redirectURL := s.frontendLandingUrl
 	// If the task doesn't exist yet, send the user to the new page, where data is first confirmed
 	if taskResource == nil {

--- a/orchestrator/careplancontributor/applaunch/zorgplatform/service_test.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/service_test.go
@@ -250,7 +250,7 @@ func TestService(t *testing.T) {
 		sessionData := user.SessionFromHttpResponse(sessionManager, launchHttpResponse)
 		require.NotNil(t, sessionData)
 		require.Equal(t, "/frontend/task/12345678910", launchHttpResponse.Header.Get("Location"))
-		assert.Equal(t, "Task/"+*existingTask.Id, sessionData.Get("Task").Path)
+		assert.Equal(t, "Task/"+*existingTask.Id, sessionData.GetByType("Task").Path)
 	})
 
 	t.Run("test invalid SAML response", func(t *testing.T) {

--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -344,7 +344,7 @@ func (s Service) handleProxyAppRequestToEHR(writer http.ResponseWriter, request 
 	resourcePath := request.PathValue("rest")
 	// If the requested resource is cached in the session, directly return it. This is used to support resources that are required (e.g. by Frontend), but not provided by the EHR.
 	// E.g., ChipSoft HiX doesn't provide ServiceRequest and Practitioner as FHIR resources, so whatever there is, is converted to FHIR and cached in the session.
-	if resource := sessionData.Get(resourcePath); resource != nil && resource.Resource != nil {
+	if resource := sessionData.GetByPath(resourcePath); resource != nil && resource.Resource != nil {
 		coolfhir.SendResponse(writer, http.StatusOK, *resource.Resource)
 	} else {
 		proxy.ServeHTTP(writer, request)
@@ -606,11 +606,11 @@ func (s Service) handleGetContext(response http.ResponseWriter, _ *http.Request,
 		Task             string  `json:"task"`
 		TaskIdentifier   *string `json:"taskIdentifier"`
 	}{
-		Patient:          to.Empty(sessionData.Get("Patient")).Path,
-		ServiceRequest:   to.Empty(sessionData.Get("ServiceRequest")).Path,
-		Practitioner:     to.Empty(sessionData.Get("Practitioner")).Path,
-		PractitionerRole: to.Empty(sessionData.Get("PractitionerRole")).Path,
-		Task:             to.Empty(sessionData.Get("Task")).Path,
+		Patient:          to.Empty(sessionData.GetByType("Patient")).Path,
+		ServiceRequest:   to.Empty(sessionData.GetByType("ServiceRequest")).Path,
+		Practitioner:     to.Empty(sessionData.GetByType("Practitioner")).Path,
+		PractitionerRole: to.Empty(sessionData.GetByType("PractitionerRole")).Path,
+		Task:             to.Empty(sessionData.GetByType("Task")).Path,
 		TaskIdentifier:   sessionData.TaskIdentifier,
 	}
 	response.Header().Add("Content-Type", "application/json")


### PR DESCRIPTION
The `/cpc/ehr` proxies calls to the EHR's FHIR API, but it should try cached resources from session first (it contains resources that aren't available in the EHR's FHIR API). Recent refactor broke this.