### PR TITLE
DEV-189 | Support DELETE for resources in non-strict mode

### DIFF
--- a/orchestrator/careplanservice/authz_careplan.go
+++ b/orchestrator/careplanservice/authz_careplan.go
@@ -5,3 +5,7 @@ import "github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
 func ReadCarePlanAuthzPolicy() Policy[*fhir.CarePlan] {
 	return CareTeamMemberPolicy[fhir.CarePlan]{}
 }
+
+func DeleteCarePlanAuthzPolicy() Policy[*fhir.CarePlan] {
+	return AnyonePolicy[*fhir.CarePlan]{}
+}

--- a/orchestrator/careplanservice/authz_careplan_test.go
+++ b/orchestrator/careplanservice/authz_careplan_test.go
@@ -50,4 +50,17 @@ func TestCarePlanAuthzPolicy(t *testing.T) {
 			},
 		})
 	})
+
+	t.Run("delete", func(t *testing.T) {
+		policy := DeleteCarePlanAuthzPolicy()
+		testPolicies(t, []AuthzPolicyTest[*fhir.CarePlan]{
+			{
+				name:      "allow (anyone can delete)",
+				policy:    policy,
+				resource:  &carePlan,
+				principal: auth.TestPrincipal1,
+				wantAllow: true,
+			},
+		})
+	})
 }

--- a/orchestrator/careplanservice/authz_condition.go
+++ b/orchestrator/careplanservice/authz_condition.go
@@ -41,3 +41,7 @@ func ReadConditionAuthzPolicy(fhirClient fhirclient.Client) Policy[*fhir.Conditi
 		},
 	}
 }
+
+func DeleteConditionAuthzPolicy() Policy[*fhir.Condition] {
+	return AnyonePolicy[*fhir.Condition]{}
+}

--- a/orchestrator/careplanservice/authz_condition_test.go
+++ b/orchestrator/careplanservice/authz_condition_test.go
@@ -128,4 +128,17 @@ func TestConditionAuthzPolicy(t *testing.T) {
 			},
 		})
 	})
+
+	t.Run("delete", func(t *testing.T) {
+		policy := DeleteConditionAuthzPolicy()
+		testPolicies(t, []AuthzPolicyTest[*fhir.Condition]{
+			{
+				name:      "allow (anyone can delete)",
+				policy:    policy,
+				resource:  &condition,
+				principal: auth.TestPrincipal1,
+				wantAllow: true,
+			},
+		})
+	})
 }

--- a/orchestrator/careplanservice/authz_patient.go
+++ b/orchestrator/careplanservice/authz_patient.go
@@ -32,3 +32,7 @@ func ReadPatientAuthzPolicy(fhirClient fhirclient.Client) Policy[*fhir.Patient] 
 		},
 	}
 }
+
+func DeletePatientAuthzPolicy() Policy[*fhir.Patient] {
+	return AnyonePolicy[*fhir.Patient]{}
+}

--- a/orchestrator/careplanservice/authz_patient_test.go
+++ b/orchestrator/careplanservice/authz_patient_test.go
@@ -111,4 +111,17 @@ func TestPatientAuthzPolicy(t *testing.T) {
 			},
 		})
 	})
+
+	t.Run("delete", func(t *testing.T) {
+		policy := DeletePatientAuthzPolicy()
+		testPolicies(t, []AuthzPolicyTest[*fhir.Patient]{
+			{
+				name:      "allow (anyone can delete)",
+				policy:    policy,
+				resource:  &patient,
+				principal: auth.TestPrincipal1,
+				wantAllow: true,
+			},
+		})
+	})
 }

--- a/orchestrator/careplanservice/authz_questionnaire.go
+++ b/orchestrator/careplanservice/authz_questionnaire.go
@@ -13,3 +13,8 @@ func UpdateQuestionnaireAuthzPolicy() Policy[*fhir.Questionnaire] {
 func ReadQuestionnaireAuthzPolicy() Policy[*fhir.Questionnaire] {
 	return AnyonePolicy[*fhir.Questionnaire]{}
 }
+
+// DeleteQuestionnaireAuthzPolicy returns a policy that always allows deletion of Questionnaire resources.
+func DeleteQuestionnaireAuthzPolicy() Policy[*fhir.Questionnaire] {
+	return AnyonePolicy[*fhir.Questionnaire]{}
+}

--- a/orchestrator/careplanservice/authz_questionnaire_test.go
+++ b/orchestrator/careplanservice/authz_questionnaire_test.go
@@ -47,3 +47,17 @@ func TestReadQuestionnaireAuthzPolicy(t *testing.T) {
 		},
 	})
 }
+
+func TestDeleteQuestionnaireAuthzPolicy(t *testing.T) {
+	questionnaire := fhir.Questionnaire{}
+	policy := DeleteQuestionnaireAuthzPolicy()
+	testPolicies(t, []AuthzPolicyTest[*fhir.Questionnaire]{
+		{
+			name:      "allow (anyone can delete)",
+			policy:    policy,
+			resource:  &questionnaire,
+			principal: auth.TestPrincipal1,
+			wantAllow: true,
+		},
+	})
+}

--- a/orchestrator/careplanservice/authz_questionnaireresponse.go
+++ b/orchestrator/careplanservice/authz_questionnaireresponse.go
@@ -32,3 +32,7 @@ func ReadQuestionnaireResponseAuthzPolicy(fhirClient fhirclient.Client) Policy[*
 		},
 	}
 }
+
+func DeleteQuestionnaireResponseAuthzPolicy() Policy[*fhir.QuestionnaireResponse] {
+	return AnyonePolicy[*fhir.QuestionnaireResponse]{}
+}

--- a/orchestrator/careplanservice/authz_questionnaireresponse_test.go
+++ b/orchestrator/careplanservice/authz_questionnaireresponse_test.go
@@ -104,4 +104,17 @@ func TestQuestionnaireResponseAuthzPolicy(t *testing.T) {
 			},
 		})
 	})
+
+	t.Run("delete", func(t *testing.T) {
+		policy := DeleteQuestionnaireResponseAuthzPolicy()
+		testPolicies(t, []AuthzPolicyTest[*fhir.QuestionnaireResponse]{
+			{
+				name:      "allow (anyone can delete)",
+				policy:    policy,
+				resource:  &questionnaireResponse,
+				principal: auth.TestPrincipal1,
+				wantAllow: true,
+			},
+		})
+	})
 }

--- a/orchestrator/careplanservice/authz_servicerequest.go
+++ b/orchestrator/careplanservice/authz_servicerequest.go
@@ -32,3 +32,7 @@ func ReadServiceRequestAuthzPolicy(fhirClient fhirclient.Client) Policy[*fhir.Se
 		},
 	}
 }
+
+func DeleteServiceRequestAuthzPolicy() Policy[*fhir.ServiceRequest] {
+	return AnyonePolicy[*fhir.ServiceRequest]{}
+}

--- a/orchestrator/careplanservice/authz_servicerequest_test.go
+++ b/orchestrator/careplanservice/authz_servicerequest_test.go
@@ -109,4 +109,17 @@ func TestServiceRequestAuthzPolicy(t *testing.T) {
 		})
 	})
 
+	t.Run("delete", func(t *testing.T) {
+		policy := DeleteServiceRequestAuthzPolicy()
+		testPolicies(t, []AuthzPolicyTest[*fhir.ServiceRequest]{
+			{
+				name:      "allow (anyone can delete)",
+				policy:    policy,
+				resource:  &serviceRequest,
+				principal: auth.TestPrincipal1,
+				wantAllow: true,
+			},
+		})
+	})
+
 }

--- a/orchestrator/careplanservice/authz_task.go
+++ b/orchestrator/careplanservice/authz_task.go
@@ -32,3 +32,7 @@ func ReadTaskAuthzPolicy(fhirClient fhirclient.Client) Policy[*fhir.Task] {
 		},
 	}
 }
+
+func DeleteTaskAuthzPolicy() Policy[*fhir.Task] {
+	return AnyonePolicy[*fhir.Task]{}
+}

--- a/orchestrator/careplanservice/authz_task_test.go
+++ b/orchestrator/careplanservice/authz_task_test.go
@@ -97,4 +97,17 @@ func TestReadTaskAuthzPolicy(t *testing.T) {
 			},
 		})
 	})
+
+	t.Run("delete", func(t *testing.T) {
+		policy := DeleteTaskAuthzPolicy()
+		testPolicies(t, []AuthzPolicyTest[*fhir.Task]{
+			{
+				name:      "allow (anyone can delete)",
+				policy:    policy,
+				resource:  &taskWithRequester,
+				principal: auth.TestPrincipal1,
+				wantAllow: true,
+			},
+		})
+	})
 }

--- a/orchestrator/careplanservice/integration_audit_test.go
+++ b/orchestrator/careplanservice/integration_audit_test.go
@@ -629,9 +629,38 @@ func Test_CRUD_AuditEvents(t *testing.T) {
 		addExpectedSearchAudit("Patient/"+*patient.Id, url.Values{"_id": {*patient.Id, *nonExistingPatient.Id, "fake-id"}})
 	})
 
-	// Verify all audit events at the end
+	// Verify all audit events at the end - check before deleting resources, as deleting them will remove the audit events
 	err = verifyAuditEvents(t, expectedAuditEvents, fhirBaseURL)
 	require.NoError(t, err)
+
+	// Delete resources
+	t.Run("Delete Patient", func(t *testing.T) {
+		err = carePlanContributor1.Delete("Patient/" + *patient.Id)
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete QuestionnaireResponse", func(t *testing.T) {
+		err = carePlanContributor1.Delete("QuestionnaireResponse/" + *questionnaireResponse.Id)
+		require.NoError(t, err)
+
+		err = carePlanContributor1.Delete("QuestionnaireResponse/non-existing-questionnaire-response")
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete Questionnaire", func(t *testing.T) {
+		err = carePlanContributor1.Delete("Questionnaire/" + *questionnaire.Id)
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete ServiceRequest", func(t *testing.T) {
+		err = carePlanContributor1.Delete("ServiceRequest/" + *serviceRequest.Id)
+		require.NoError(t, err)
+	})
+
+	t.Run("Delete Condition", func(t *testing.T) {
+		err = carePlanContributor1.Delete("Condition/" + *condition.Id)
+		require.NoError(t, err)
+	})
 }
 
 // Define a new type to hold expected audit events without timestamp requirements

--- a/orchestrator/careplanservice/operation_delete.go
+++ b/orchestrator/careplanservice/operation_delete.go
@@ -1,0 +1,93 @@
+package careplanservice
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	fhirclient "github.com/SanteonNL/go-fhir-client"
+	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
+	"github.com/rs/zerolog/log"
+	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+var _ FHIROperation = &FHIRDeleteOperationHandler[fhir.HasExtension]{}
+
+type FHIRDeleteOperationHandler[T fhir.HasExtension] struct {
+	fhirClient  fhirclient.Client
+	authzPolicy Policy[T]
+}
+
+func (h FHIRDeleteOperationHandler[T]) Handle(ctx context.Context, request FHIRHandlerRequest, tx *coolfhir.BundleBuilder) (FHIRHandlerResult, error) {
+	resourceType := getResourceType(request.ResourcePath)
+	var resource T
+	err := h.fhirClient.ReadWithContext(ctx, resourceType+"/"+request.ResourceId, &resource, fhirclient.ResponseHeaders(request.FhirHeaders))
+	if err != nil {
+		return nil, err
+	}
+	resourceID := request.ResourceId
+
+	authzDecision, err := h.authzPolicy.HasAccess(ctx, resource, *request.Principal)
+	if authzDecision == nil || !authzDecision.Allowed {
+		if err != nil {
+			log.Ctx(ctx).Error().Err(err).Msgf("Error checking if principal has access to delete %s", resourceType)
+		}
+		return nil, &coolfhir.ErrorWithCode{
+			Message:    fmt.Sprintf("Participant is not authorized to delete %s", resourceType),
+			StatusCode: http.StatusForbidden,
+		}
+	}
+	log.Ctx(ctx).Info().Msgf("Deleting %s/%s (authz=%s)", resourceType, resourceID, strings.Join(authzDecision.Reasons, ";"))
+
+	// Delete AuditEvents first
+	var auditBundle fhir.Bundle
+	err = h.fhirClient.SearchWithContext(ctx, "AuditEvent", url.Values{
+		"entity": []string{resourceType + "/" + resourceID},
+	}, &auditBundle)
+	if err != nil {
+		// Log the error but don't return, if it fails we can still delete the resource
+		log.Ctx(ctx).Error().Err(err).Msgf("Error searching for AuditEvents for %s/%s", resourceType, resourceID)
+	}
+
+	// Delete each AuditEvent
+	for _, entry := range auditBundle.Entry {
+		var auditEvent fhir.AuditEvent
+		err := json.Unmarshal(entry.Resource, &auditEvent)
+		if err != nil {
+			log.Ctx(ctx).Error().Err(err).Msgf("Error unmarshaling AuditEvent for %s/%s", resourceType, resourceID)
+			continue
+		}
+
+		if auditEvent.Id != nil {
+			tx.Append(auditEvent, &fhir.BundleEntryRequest{
+				Method: fhir.HTTPVerbDELETE,
+				Url:    "AuditEvent/" + *auditEvent.Id,
+			}, nil)
+		}
+	}
+
+	// Add delete operation to the transaction
+	idx := len(tx.Entry)
+	tx.Append(resource, &fhir.BundleEntryRequest{
+		Method: fhir.HTTPVerbDELETE,
+		Url:    resourceType + "/" + resourceID,
+	}, nil)
+
+	return func(txResult *fhir.Bundle) ([]*fhir.BundleEntry, []any, error) {
+		bundleEntry := &fhir.BundleEntry{
+			Response: &fhir.BundleEntryResponse{
+				Status: "200 OK",
+			},
+		}
+
+		// Check if we have a response in the transaction result
+		if idx < len(txResult.Entry) {
+			bundleEntry.Response = txResult.Entry[idx].Response
+		}
+
+		// We do not want to notify subscribers for a delete operation
+		return []*fhir.BundleEntry{bundleEntry}, []any{}, nil
+	}, nil
+}

--- a/orchestrator/careplanservice/operation_delete_test.go
+++ b/orchestrator/careplanservice/operation_delete_test.go
@@ -1,0 +1,104 @@
+package careplanservice
+
+import (
+	"context"
+	fhirclient "github.com/SanteonNL/go-fhir-client"
+	"github.com/SanteonNL/orca/orchestrator/lib/auth"
+	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
+	"github.com/SanteonNL/orca/orchestrator/lib/test"
+	"github.com/SanteonNL/orca/orchestrator/lib/to"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
+	"net/http"
+	"testing"
+)
+
+func TestFHIRDeleteOperationHandler_Handle(t *testing.T) {
+	ctx := context.Background()
+	t.Run("not found", func(t *testing.T) {
+		fhirClient := &test.StubFHIRClient{}
+		request := FHIRHandlerRequest{
+			ResourcePath: "Task/1",
+			ResourceId:   "1",
+		}
+		tx := coolfhir.Transaction()
+		result, err := FHIRDeleteOperationHandler[*fhir.Task]{
+			fhirClient:  fhirClient,
+			authzPolicy: AnyonePolicy[*fhir.Task]{},
+		}.Handle(ctx, request, tx)
+		assert.Error(t, err)
+		var outcome fhirclient.OperationOutcomeError
+		require.ErrorAs(t, err, &outcome)
+		assert.Equal(t, http.StatusNotFound, outcome.HttpStatusCode)
+		assert.Nil(t, result)
+		assert.Empty(t, tx.Entry)
+	})
+	t.Run("no access", func(t *testing.T) {
+		fhirClient := &test.StubFHIRClient{
+			Resources: []any{
+				fhir.Task{
+					Id: to.Ptr("1"),
+				},
+			},
+		}
+		request := FHIRHandlerRequest{
+			ResourcePath: "Task/1",
+			ResourceId:   "1",
+			Principal:    auth.TestPrincipal1,
+		}
+		tx := coolfhir.Transaction()
+		result, err := FHIRDeleteOperationHandler[*fhir.Task]{
+			fhirClient:  fhirClient,
+			authzPolicy: TestPolicy[*fhir.Task]{},
+		}.Handle(ctx, request, tx)
+		assert.Error(t, err)
+		errorWithCode := new(coolfhir.ErrorWithCode)
+		require.ErrorAs(t, err, &errorWithCode)
+		assert.Equal(t, http.StatusForbidden, errorWithCode.StatusCode)
+		assert.Equal(t, "Participant is not authorized to delete Task", errorWithCode.Message)
+		assert.Nil(t, result)
+		assert.Empty(t, tx.Entry)
+	})
+	t.Run("ok", func(t *testing.T) {
+		fhirClient := &test.StubFHIRClient{
+			Resources: []any{
+				fhir.Task{
+					Id: to.Ptr("1"),
+				},
+			},
+		}
+		request := FHIRHandlerRequest{
+			ResourcePath: "Task/1",
+			ResourceId:   "1",
+			Principal:    auth.TestPrincipal1,
+			LocalIdentity: &fhir.Identifier{
+				System: to.Ptr("http://fhir.nl/fhir/NamingSystem/ura"),
+				Value:  to.Ptr("1"),
+			},
+		}
+		tx := coolfhir.Transaction()
+		result, err := FHIRDeleteOperationHandler[*fhir.Task]{
+			fhirClient:  fhirClient,
+			authzPolicy: AnyonePolicy[*fhir.Task]{},
+		}.Handle(ctx, request, tx)
+		assert.NoError(t, err)
+		assert.NotNil(t, result)
+
+		// Verify the transaction contains the delete operation
+		assert.Len(t, tx.Entry, 1)
+		assert.Equal(t, fhir.HTTPVerbDELETE, tx.Entry[0].Request.Method)
+		assert.Equal(t, "Task/1", tx.Entry[0].Request.Url)
+
+		// Verify the handler result
+		txResponse := coolfhir.Transaction().
+			Append(nil, nil, &fhir.BundleEntryResponse{
+				Status: "204 No Content",
+			}).Bundle()
+		responseEntries, notifications, err := result(&txResponse)
+		require.NoError(t, err)
+		assert.Len(t, responseEntries, 1)
+		assert.Equal(t, "204 No Content", responseEntries[0].Response.Status)
+		assert.Empty(t, notifications)
+	})
+}

--- a/orchestrator/careplanservice/service.go
+++ b/orchestrator/careplanservice/service.go
@@ -230,6 +230,15 @@ func (s *Service) RegisterHandlers(mux *http.ServeMux) {
 		resourceId := request.PathValue("id")
 		s.handleGet(request, httpResponse, resourceId, resourceType, "CarePlanService/Get"+resourceType)
 	}))
+	mux.HandleFunc("DELETE  "+basePath+"/{type}/{id}", s.profile.Authenticator(baseUrl, func(httpResponse http.ResponseWriter, request *http.Request) {
+		if globals.StrictMode {
+			coolfhir.WriteOperationOutcomeFromError(request.Context(), coolfhir.BadRequest("delete not allowed"), "CarePlanService/Delete", httpResponse)
+			return
+		}
+		resourceType := request.PathValue("type")
+		resourceId := request.PathValue("id")
+		s.handleGet(request, httpResponse, resourceId, resourceType, "CarePlanService/Delete"+resourceType)
+	}))
 }
 
 // commitTransaction sends the given transaction Bundle to the FHIR server, and processes the result with the given resultHandlers.
@@ -635,6 +644,51 @@ func (s *Service) handleRead(resourcePath string) func(context.Context, FHIRHand
 	return handleFunc
 }
 
+func (s *Service) handleDelete(resourcePath string) func(context.Context, FHIRHandlerRequest, *coolfhir.BundleBuilder) (FHIRHandlerResult, error) {
+	resourceType := getResourceType(resourcePath)
+	var handleFunc func(ctx context.Context, request FHIRHandlerRequest, tx *coolfhir.BundleBuilder) (FHIRHandlerResult, error)
+	switch resourceType {
+	case "Patient":
+		handleFunc = FHIRDeleteOperationHandler[*fhir.Patient]{
+			authzPolicy: DeletePatientAuthzPolicy(),
+			fhirClient:  s.fhirClient,
+		}.Handle
+	case "Condition":
+		handleFunc = FHIRDeleteOperationHandler[*fhir.Condition]{
+			authzPolicy: DeleteConditionAuthzPolicy(),
+			fhirClient:  s.fhirClient,
+		}.Handle
+	case "CarePlan":
+		handleFunc = FHIRDeleteOperationHandler[*fhir.CarePlan]{
+			authzPolicy: DeleteCarePlanAuthzPolicy(),
+			fhirClient:  s.fhirClient,
+		}.Handle
+	case "Task":
+		handleFunc = FHIRDeleteOperationHandler[*fhir.Task]{
+			authzPolicy: DeleteTaskAuthzPolicy(),
+			fhirClient:  s.fhirClient,
+		}.Handle
+	case "ServiceRequest":
+		handleFunc = FHIRDeleteOperationHandler[*fhir.ServiceRequest]{
+			authzPolicy: DeleteServiceRequestAuthzPolicy(),
+			fhirClient:  s.fhirClient,
+		}.Handle
+	case "Questionnaire":
+		handleFunc = FHIRDeleteOperationHandler[*fhir.Questionnaire]{
+			authzPolicy: DeleteQuestionnaireAuthzPolicy(),
+			fhirClient:  s.fhirClient,
+		}.Handle
+	case "QuestionnaireResponse":
+		handleFunc = FHIRDeleteOperationHandler[*fhir.QuestionnaireResponse]{
+			authzPolicy: DeleteQuestionnaireResponseAuthzPolicy(),
+			fhirClient:  s.fhirClient,
+		}.Handle
+	default:
+		handleFunc = s.handleUnmanagedOperation
+	}
+	return handleFunc
+}
+
 func (s *Service) validateSearchRequest(httpRequest *http.Request) error {
 	contentType := httpRequest.Header.Get("Content-Type")
 
@@ -877,6 +931,8 @@ func (s *Service) defaultHandlerProvider(method string, resourcePath string) fun
 		return s.handleUpdate(resourcePath)
 	case http.MethodGet:
 		return s.handleRead(resourcePath)
+	case http.MethodDelete:
+		return s.handleDelete(resourcePath)
 	}
 	return func(ctx context.Context, request FHIRHandlerRequest, tx *coolfhir.BundleBuilder) (FHIRHandlerResult, error) {
 		return s.handleUnmanagedOperation(ctx, request, tx)


### PR DESCRIPTION
In order to clean up test environments we need to be able to delete resources. This is possible by directly interacting with the FHIR endpoint but far easier to do it through ORCA. This functionality is not intended for prod environments and will not work when StrictMode is enabled