### PR TITLE
DEV-319: Fix hot reloading for NextJS applications

### DIFF
--- a/deployments/dev/clinic/config/nginx-proxy.conf
+++ b/deployments/dev/clinic/config/nginx-proxy.conf
@@ -27,6 +27,17 @@ server {
     proxy_set_header X-Forwarded-Host $host:7080;
     proxy_set_header X-Forwarded-Proto $scheme;
   }
+  # Proxy for Next.js hot module replacement
+  location /viewer/_next/webpack-hmr {
+    proxy_pass http://viewer;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-Host $host:7080;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    # Headers required for hot module replacement:
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_read_timeout 86400;
+  }
 
   # Required for messaging HTTP delivery
   client_body_buffer_size 128k;

--- a/deployments/dev/docker-compose.yaml
+++ b/deployments/dev/docker-compose.yaml
@@ -50,7 +50,7 @@ services:
       dockerfile: Dockerfile-dev
     volumes:
       - ../../frontend:/app
-      - /app/node_modules
+      - /app/node_modules # do not mount node_modules from host, as it will cause issues with the NextJS build
     environment:
       #TERMINOLOGY_SERVER_BASE_URL=https://terminologieserver.nl/fhir
       NEXT_PUBLIC_BASE_PATH: /frontend
@@ -145,6 +145,9 @@ services:
       ORCA_PERFORMER_ORGANIZATION_NAME: Demo Clinic
       NEXT_ALLOWED_ORIGINS: localhost:8081
       FHIR_BASE_URL: http://fhirstore:8080/fhir
+    volumes:
+      - ../../hospital_simulator:/app
+      - /app/node_modules # do not mount node_modules from host, as it will cause issues with the NextJS build
   clinic_proxy:
     image: nginx:latest
     depends_on:
@@ -199,6 +202,9 @@ services:
       CLINIC_IDENTIFIER: http://fhir.nl/fhir/NamingSystem/ura|1234
       CLINIC_CPS_URL: http://hospital_orchestrator:8080/cps
       NEXT_ALLOWED_ORIGINS: localhost:8081
+    volumes:
+      - ../../viewer_simulator:/app
+      - /app/node_modules # do not mount node_modules from host, as it will cause issues with the NextJS build
   # Orchestrator's Task Engine posts to Viewer over HTTP, but the first call will time-out due to NextJS compilation.
   # So, we use curl to force NextJS to make sure the receiving endpoint is compiled.
   clinic_viewer-init:

--- a/deployments/dev/hospital/config/nginx-proxy.conf
+++ b/deployments/dev/hospital/config/nginx-proxy.conf
@@ -45,11 +45,35 @@ server {
     proxy_set_header X-Forwarded-Host localhost:9080;
     proxy_set_header X-Forwarded-Proto $scheme;
   }
+  # Proxy for Next.js hot module replacement
+  location /ehr/_next/webpack-hmr {
+    proxy_pass http://ehr;
+    proxy_http_version 1.1;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-Host localhost:9080;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    # Headers required for hot module replacement:
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_read_timeout 86400;
+  }
   location /frontend {
     proxy_pass http://frontend;
     proxy_http_version 1.1;
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-Host localhost:9080;
     proxy_set_header X-Forwarded-Proto $scheme;
+  }
+  # Proxy for Next.js hot module replacement
+  location /frontend/_next/webpack-hmr {
+    proxy_pass http://frontend;
+    proxy_http_version 1.1;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-Host localhost:9080;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    # Headers required for hot module replacement:
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_read_timeout 86400;
   }
 }


### PR DESCRIPTION
Applications were rebuilding (or at least for the one where I didn't forget to mount the source folder), but were not automatically refreshed due to NGINX missing config to proxy the Webpack HMR websocket.

Now, Demo EHR, Demo Viewer and Frontend properly hot reload.