### PR TITLE
Fix Azure Service Bus out of bounds error

### DIFF
--- a/orchestrator/messaging/azservicebus.go
+++ b/orchestrator/messaging/azservicebus.go
@@ -138,6 +138,10 @@ func (c *AzureServiceBusBroker) receive(receiver *azservicebus.Receiver, fullNam
 				}
 				continue
 			}
+			if len(messages) == 0 {
+				time.Sleep(1 * time.Second) // Make sure we don't busy-wait on some external resource.
+				continue                    // No messages received, continue to the next iteration
+			}
 			azMessage := messages[0]
 			message := Message{
 				Body:          azMessage.Body,

--- a/orchestrator/messaging/azservicebus.go
+++ b/orchestrator/messaging/azservicebus.go
@@ -123,7 +123,7 @@ func (c *AzureServiceBusBroker) receive(receiver *azservicebus.Receiver, fullNam
 		defer c.receivers.Done()
 		for c.ctx.Err() == nil {
 			messages, err := receiver.ReceiveMessages(c.ctx, 1, &azservicebus.ReceiveMessagesOptions{})
-			if err != nil {
+			if err != nil || len(messages) == 0 {
 				const backoffTime = time.Minute
 				if !errors.Is(err, context.Canceled) {
 					log.Ctx(c.ctx).Err(err).Msgf("AzureServiceBus: receive message failed, backing off for %s (src: %s)", backoffTime, fullName)
@@ -137,10 +137,6 @@ func (c *AzureServiceBusBroker) receive(receiver *azservicebus.Receiver, fullNam
 				case <-time.After(backoffTime):
 				}
 				continue
-			}
-			if len(messages) == 0 {
-				time.Sleep(1 * time.Second) // Make sure we don't busy-wait on some external resource.
-				continue                    // No messages received, continue to the next iteration
 			}
 			azMessage := messages[0]
 			message := Message{


### PR DESCRIPTION
At night, Azure seems to be having network issues on Service Bus now and then, leading to:

```go
created by github.com/SanteonNL/orca/orchestrator/messaging.(*AzureServiceBusBroker).receive in goroutine 1
/go/messaging/azservicebus.go:122 +0xb6
/go/messaging/azservicebus.go:141 +0x6d0
github.com/SanteonNL/orca/orchestrator/messaging.(*AzureServiceBusBroker).receive.func1()

panic: runtime error: index out of range [0] with length 0
```