### PR TITLE
Hospital simulator: sort patient overview descending order 

### DIFF
--- a/hospital_simulator/app/(DashboardLayout)/components/patients/patient-overview.tsx
+++ b/hospital_simulator/app/(DashboardLayout)/components/patients/patient-overview.tsx
@@ -41,6 +41,7 @@ export default async function PatientOverview() {
             primaryIdentifier: patient.identifier?.find((identifier: Identifier) => identifier.system === "http://fhir.nl/fhir/NamingSystem/bsn")!!,
             name: patient.name?.[0]!!,
             gender: patient.gender!!,
+            lastUpdated: new Date(patient.meta?.lastUpdated || 0),
         }
     })
     return (

--- a/hospital_simulator/app/(DashboardLayout)/components/patients/patient-table.tsx
+++ b/hospital_simulator/app/(DashboardLayout)/components/patients/patient-table.tsx
@@ -11,6 +11,7 @@ interface Props {
 
 interface PatientDetails {
     id: string
+    lastUpdated: Date
     primaryIdentifier: Identifier
     name: HumanName
     gender: string
@@ -22,6 +23,7 @@ const PatientTable: React.FC<Props> = ({ rows }) => {
             field: 'id',
             headerName: 'BSN',
         },
+        { field: 'lastUpdated', headerName: 'Last Updated', type: 'dateTime', flex: 1 },
         {
             field: 'name',
             headerName: 'Name',


### PR DESCRIPTION
Currently, new patients are added at the bottom of the table, which is annoying. This reverses that sort order (date/time created). Or actually fix it (because it was intended to work like that, but broken).