### PR TITLE
DEV-506: Remove ACR and AMR OIDC id_token claims

### DIFF
--- a/orchestrator/careplancontributor/oidc/op/service_test.go
+++ b/orchestrator/careplancontributor/oidc/op/service_test.go
@@ -127,4 +127,6 @@ func TestService_IntegrationTest(t *testing.T) {
 	assert.Equal(t, "john@example.com", capturedIDTokenClaims.GetUserInfo().Email)
 	assert.Equal(t, []any{"nurse-level-4@example.com/CodeSystem"}, capturedIDTokenClaims.Claims["roles"])
 	assert.Equal(t, []any{"example.com/CodeSystem|SOME-PATIENT-IDENTIFIER"}, capturedIDTokenClaims.Claims["patient"])
+	assert.NotContains(t, capturedIDTokenClaims.Claims, "amr")
+	assert.NotContains(t, capturedIDTokenClaims.Claims, "acr")
 }

--- a/orchestrator/careplancontributor/oidc/op/storage.go
+++ b/orchestrator/careplancontributor/oidc/op/storage.go
@@ -349,11 +349,11 @@ func (a AuthRequest) GetID() string {
 }
 
 func (a AuthRequest) GetACR() string {
-	return "TODO"
+	return ""
 }
 
 func (a AuthRequest) GetAMR() []string {
-	return []string{"TODO"}
+	return nil
 }
 
 func (a AuthRequest) GetAudience() []string {


### PR DESCRIPTION
Since they contain no sensible values, and they're optional in OIDC.