### PR TITLE
DEV-610: Fix OIDC launch bug "no identifier in practitioner resource" because Zorgplatform app launch takes generalPractitioner as current user

### DIFF
--- a/orchestrator/careplancontributor/applaunch/zorgplatform/handle_create_access_token_test.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/handle_create_access_token_test.go
@@ -169,7 +169,6 @@ func TestService_sign(t *testing.T) {
 				},
 			},
 		},
-		SubjectNameId:  "Subject",
 		WorkflowId:     "workflow-1234",
 		ServiceRequest: fhir.ServiceRequest{},
 	}

--- a/orchestrator/careplancontributor/applaunch/zorgplatform/handle_validation.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/handle_validation.go
@@ -97,6 +97,11 @@ func (s *Service) parseSamlResponse(ctx context.Context, samlResponse string) (L
 	if err != nil {
 		return LaunchContext{}, fmt.Errorf("unable to extract PractitionerRole from SAML Assertion.Subject: %w", err)
 	}
+	if len(practitioner.Identifier) > 0 {
+		practitionerRole.Practitioner = &fhir.Reference{
+			Identifier: &practitioner.Identifier[0],
+		}
+	}
 
 	// Extract resource-id claim to select the correct patient
 	resourceID, err := s.extractResourceID(assertion)

--- a/orchestrator/careplancontributor/applaunch/zorgplatform/handle_validation_test.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/handle_validation_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor/applaunch/session"
 	"github.com/SanteonNL/orca/orchestrator/lib/crypto"
 	"os"
-	"strings"
 	"testing"
 	"time"
 
@@ -140,8 +139,8 @@ func TestValidateAudienceIssuerAndExtractSubjectAndExtractResourceID(t *testing.
 				assert.EqualError(t, err, tt.expectedError.Error())
 			} else {
 				require.NoError(t, err)
-				subjectNameId := *practitioner.Identifier[0].Value + "@" + *practitioner.Identifier[0].System
-				assert.Equal(t, tt.expectedSubj, subjectNameId)
+				assert.Equal(t, HIX_LOCALUSER_SYSTEM, *practitioner.Identifier[0].System)
+				assert.Equal(t, tt.expectedSubj, *practitioner.Identifier[0].Value)
 			}
 
 			// Extract Resource ID
@@ -171,21 +170,12 @@ func TestValidateAudienceIssuerAndExtractSubjectAndExtractResourceID(t *testing.
 				assert.Equal(t, tt.expectedRoleCode, *practitionerRole.Code[0].Coding[0].Code)
 				assert.Equal(t, tt.expectedRoleCodeSystem, *practitionerRole.Code[0].Coding[0].System)
 
-				// Verify both identifiers are set
-				assert.Len(t, practitionerRole.Identifier, 2)
-				expectedParts := strings.Split(tt.expectedSubj, "@")
-				userIdentifier := fhir.Identifier{
-					System: to.Ptr(HIX_LOCALUSER_SYSTEM),
-					Value:  to.Ptr(expectedParts[0]),
-				}
-
-				orgIdentifier := fhir.Identifier{
-					System: to.Ptr(HIX_ORG_OID_SYSTEM),
-					Value:  to.Ptr(expectedParts[1]),
-				}
-
-				assert.Contains(t, practitionerRole.Identifier, userIdentifier)
-				assert.Contains(t, practitionerRole.Identifier, orgIdentifier)
+				assert.Equal(t, []fhir.Identifier{
+					{
+						System: to.Ptr(HIX_LOCALUSER_SYSTEM),
+						Value:  to.Ptr(tt.expectedSubj),
+					},
+				}, practitionerRole.Identifier)
 			}
 
 			//TODO: Add signature validation
@@ -293,7 +283,6 @@ func TestValidateZorgplatformForgedSignatureSelfSigned(t *testing.T) {
 				},
 			},
 		},
-		SubjectNameId:  "Subject",
 		WorkflowId:     "workflow-1234",
 		ServiceRequest: fhir.ServiceRequest{},
 	}
@@ -346,8 +335,8 @@ func TestService_parseSamlResponse(t *testing.T) {
 		assert.NotEmpty(t, actual)
 		assert.Equal(t, "999999151", actual.Bsn)
 		assert.Len(t, actual.Practitioner.Identifier, 1)
-		assert.Equal(t, "urn:oid:2.16.840.1.113883.4.1", *actual.Practitioner.Identifier[0].System)
-		assert.Equal(t, "999999999", *actual.Practitioner.Identifier[0].Value)
+		assert.Equal(t, HIX_LOCALUSER_SYSTEM, *actual.Practitioner.Identifier[0].System)
+		assert.Equal(t, "999999999@urn:oid:2.16.840.1.113883.4.1", *actual.Practitioner.Identifier[0].Value)
 		assert.Equal(t, "b526e773-e1a6-4533-bd00-1360c97e745f", actual.WorkflowId)
 
 	})
@@ -365,4 +354,23 @@ func TestService_parseSamlResponse(t *testing.T) {
 		assert.Empty(t, actual)
 		require.EqualError(t, err, "SAMLResponse from server contains an error, see log for details")
 	})
+}
+
+func TestService_parseAssertion(t *testing.T) {
+	assertionXML, err := os.ReadFile("saml_hix_sso_assertion.xml")
+	require.NoError(t, err)
+	doc := etree.NewDocument()
+	err = doc.ReadFromBytes(assertionXML)
+	require.NoError(t, err)
+
+	launchContext, err := (&Service{}).parseAssertion(context.Background(), doc.Root())
+
+	require.NoError(t, err)
+	assert.Equal(t, "999999102", launchContext.Bsn)
+	assert.Len(t, launchContext.Practitioner.Identifier, 1)
+	assert.Equal(t, HIX_LOCALUSER_SYSTEM, *launchContext.Practitioner.Identifier[0].System)
+	assert.Equal(t, "1234@1.2.3.4.5", *launchContext.Practitioner.Identifier[0].Value)
+	assert.Equal(t, "Arts", *launchContext.Practitioner.Name[0].Family)
+	assert.Equal(t, "H.", launchContext.Practitioner.Name[0].Given[0])
+	assert.Equal(t, "f8cab0af-901b-417e-8bb4-5198e2c47732", launchContext.WorkflowId)
 }

--- a/orchestrator/careplancontributor/applaunch/zorgplatform/saml_hix_sso_assertion.xml
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/saml_hix_sso_assertion.xml
@@ -1,0 +1,69 @@
+<Assertion ID="_c202b2cb-522f-4e4e-a08b-215010dd0066" IssueInstant="2025-06-05T14:28:06.122Z" Version="2.0"
+           xmlns="urn:oasis:names:tc:SAML:2.0:assertion">
+    <Issuer>https://zorgplatform.online/sts</Issuer>
+    <Subject>
+        <NameID>1234@1.2.3.4.5</NameID>
+        <SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"/>
+    </Subject>
+    <Conditions NotBefore="2025-06-05T14:28:06.122Z" NotOnOrAfter="2025-06-05T14:40:06.122Z">
+        <AudienceRestriction>
+            <Audience>https://example.com/audience/</Audience>
+        </AudienceRestriction>
+    </Conditions>
+    <AttributeStatement>
+        <Attribute Name="urn:ihe:iti:xca:2010:homeCommunityId">
+            <AttributeValue>urn:oid:5.4.3.2.1</AttributeValue>
+        </Attribute>
+        <Attribute Name="urn:oasis:names:tc:xspa:1.0:subject:purposeofuse"
+                   a:OriginalIssuer="CN=example.com"
+                   xmlns:a="http://schemas.xmlsoap.org/ws/2009/09/identity/claims">
+            <AttributeValue>
+                <PurposeOfUse code="TREATMENT" codeSystem="2.16.840.1.113883.3.18.7.1" codeSystemName="nhin-purpose"
+                              displayName="" xmlns="urn:hl7-org:v3"/>
+            </AttributeValue>
+        </Attribute>
+        <Attribute Name="urn:oasis:names:tc:xacml:1.0:resource:resource-id"
+                   a:OriginalIssuer="CN=example.com"
+                   xmlns:a="http://schemas.xmlsoap.org/ws/2009/09/identity/claims">
+            <AttributeValue>
+                <InstanceIdentifier root="2.16.840.1.113883.2.4.6.3" extension="999999102" xmlns="urn:hl7-org:v3"/>
+            </AttributeValue>
+        </Attribute>
+        <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress"
+                   a:OriginalIssuer="CN=example.com"
+                   xmlns:a="http://schemas.xmlsoap.org/ws/2009/09/identity/claims">
+            <AttributeValue>chipsoft@zorgplatform.online</AttributeValue>
+        </Attribute>
+        <Attribute Name="urn:oasis:names:tc:xspa:1.0:subject:organization-id"
+                   a:OriginalIssuer="CN=example.com"
+                   xmlns:a="http://schemas.xmlsoap.org/ws/2009/09/identity/claims">
+            <AttributeValue>orgid:1.2.3.4.5</AttributeValue>
+        </Attribute>
+        <Attribute Name="urn:oasis:names:tc:xacml:2.0:subject:role"
+                   a:OriginalIssuer="CN=example.com"
+                   xmlns:a="http://schemas.xmlsoap.org/ws/2009/09/identity/claims">
+            <AttributeValue>
+                <Role code="223366009" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED_CT"
+                      displayName="Healthcare professional (occupation)" xmlns="urn:hl7-org:v3"/>
+            </AttributeValue>
+        </Attribute>
+        <Attribute Name="http://schemas.xmlsoap.org/ws/2005/05/identity/claims/name"
+                   a:OriginalIssuer="CN=example.com"
+                   xmlns:a="http://schemas.xmlsoap.org/ws/2009/09/identity/claims">
+            <AttributeValue>Arts, H.</AttributeValue>
+        </Attribute>
+        <Attribute Name="http://sts.zorgplatform.online/ws/claims/2017/07/workflow/workflow-id"
+                   a:OriginalIssuer="CN=example.com"
+                   xmlns:a="http://schemas.xmlsoap.org/ws/2009/09/identity/claims">
+            <AttributeValue>f8cab0af-901b-417e-8bb4-5198e2c47732</AttributeValue>
+        </Attribute>
+        <Attribute Name="http://sts.zorgplatform.online/ws/claims/2017/07/identity/patient-connectionTypeId">
+            <AttributeValue>c0b98bf2-de02-4b97-94fb-ffffd57b058a</AttributeValue>
+        </Attribute>
+    </AttributeStatement>
+    <AuthnStatement AuthnInstant="2025-06-05T14:28:05.693Z">
+        <AuthnContext>
+            <AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:X509</AuthnContextClassRef>
+        </AuthnContext>
+    </AuthnStatement>
+</Assertion>

--- a/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
@@ -499,12 +499,6 @@ func (s *Service) defaultGetSessionData(ctx context.Context, accessToken string,
 	if err := coolfhir.ResourceInBundle(&patientAndPractitionerBundle, coolfhir.EntryIsOfType("Patient"), &patient); err != nil {
 		return nil, fmt.Errorf("unable to find Patient resource in Bundle: %w", err)
 	}
-	var practitioner fhir.Practitioner
-	//TODO: The Practitioner has no identifier set, so we cannot ensure this is the launched Practitioner. Verify with Zorgplatform
-	// if err := coolfhir.ResourceInBundle(&patientAndPractitionerBundle, coolfhir.EntryHasIdentifier(launchContext.Practitioner.Identifier[0]), &practitioner); err != nil {
-	if err := coolfhir.ResourceInBundle(&patientAndPractitionerBundle, coolfhir.EntryIsOfType("Practitioner"), &practitioner); err != nil {
-		return nil, fmt.Errorf("unable to find Practitioner resource in Bundle: %w", err)
-	}
 
 	// var conditionBundle fhir.Bundle
 	//TODO: We assume this is in context as the HCP token is workflow-specific. Double-check with Zorgplatform
@@ -608,7 +602,7 @@ func (s *Service) defaultGetSessionData(ctx context.Context, accessToken string,
 	}
 	sessionData.Set("Patient/"+*patient.Id, patient)
 	sessionData.Set("ServiceRequest/magic-"+uuid.NewString(), *serviceRequest)
-	sessionData.Set("Practitioner/magic-"+uuid.NewString(), practitioner)
+	sessionData.Set("Practitioner/magic-"+uuid.NewString(), launchContext.Practitioner)
 	sessionData.Set("PractitionerRole/magic-"+uuid.NewString(), launchContext.PractitionerRole)
 	sessionData.Set("Organization/magic-"+uuid.NewString(), organization)
 	sessionData.Set(*reasonReference.Reference, reason)

--- a/orchestrator/careplancontributor/applaunch/zorgplatform/service_test.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/service_test.go
@@ -213,7 +213,7 @@ func TestService(t *testing.T) {
 			sessionData := user.SessionFromHttpResponse(sessionManager, launchHttpResponse)
 			require.NotNil(t, sessionData)
 
-			t.Run("check Practitioner is in session", func(t *testing.T) {
+			t.Run("check Practitioner in session", func(t *testing.T) {
 				assert.NotNil(t, session.Get[fhir.Practitioner](sessionData))
 			})
 			t.Run("check ServiceRequest is in session", func(t *testing.T) {


### PR DESCRIPTION
Also changes practitioner identifiers from 2 separate identifiers to 1 compound identifier. They were 2 identifiers, 1 for the org, 1 for the practitioner, but this is wrong: a single identifier should identify the resource, so it can't be spread over 2 identifiers.

I checked the usage, the identifier isn't used outside of ORCA, so no impact on other systems.