### PR TITLE
FIX | Support searching for resources via Bundle

### DIFF
--- a/orchestrator/lib/coolfhir/bundle.go
+++ b/orchestrator/lib/coolfhir/bundle.go
@@ -487,3 +487,18 @@ func NormalizeTransactionBundleResponseEntry(ctx context.Context, fhirClient fhi
 	}
 	return &resultEntry, nil
 }
+
+func IsBatchSearchBundle(bundle *fhir.Bundle) bool {
+	if bundle == nil || bundle.Type != fhir.BundleTypeBatch {
+		return false
+	}
+
+	// Ensure that all entries are of type GET
+	for _, entry := range bundle.Entry {
+		if entry.Request == nil || entry.Request.Method != fhir.HTTPVerbGET {
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
To better support the BGZ spec which has a list of 20+ queries, it is better to handle this as a batch bundle query. This change supports only search via bundle by ensuring the type is correct and that all the entries are GET