### PR TITLE
SMART on FHIR: Fix nil deref when issuer is not known

### DIFF
--- a/orchestrator/careplancontributor/applaunch/smartonfhir/service.go
+++ b/orchestrator/careplancontributor/applaunch/smartonfhir/service.go
@@ -165,6 +165,7 @@ func (s *Service) handleAppLaunch(response http.ResponseWriter, request *http.Re
 	provider, err := s.getIssuerByURL(request, issuer)
 	if err != nil {
 		s.SendError(request.Context(), issuer, fmt.Errorf("failed to get OIDC client for issuer: %w", err), response, http.StatusInternalServerError)
+		return
 	}
 	urlOptions := []rp.URLParamOpt{}
 	if launch != "" {


### PR DESCRIPTION
Otherwise, it leads to:

<img width="774" height="30" alt="Screenshot 2025-07-21 at 15 02 24" src="https://github.com/user-attachments/assets/52eba3f3-5064-4b60-bf2d-06db07f69225" />
