### PR TITLE
[FEAT] Implement aspire-dashboard when running ORCA locally

### DIFF
--- a/deployments/dev/docker-compose.yaml
+++ b/deployments/dev/docker-compose.yaml
@@ -1,4 +1,16 @@
 services:
+  aspire-dashboard:
+    image: mcr.microsoft.com/dotnet/aspire-dashboard
+    ports:
+      - "18888:18888"  # Dashboard UI
+      - "18889:18889"  # OTLP gRPC endpoint
+    environment:
+      - DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS=true
+    volumes:
+      - ./aspire-dashboard-data:/data
+    restart: unless-stopped
+    networks:
+      - orca-shared-services
   nutsnode:
     image: nutsfoundation/nuts-node:6.1.2
     ports:
@@ -15,6 +27,8 @@ services:
       - NUTS_DISCOVERY_DEFINITIONS_DIRECTORY=/nuts/discovery/
       - NUTS_DISCOVERY_SERVER_IDS=dev:HomeMonitoring2024
       - NUTS_DIDMETHODS=web
+    networks:
+      - orca-shared-services
   nutsnode-init:
     image: badouralix/curl-jq:alpine
     volumes:
@@ -24,12 +38,16 @@ services:
         condition: service_healthy
     entrypoint: [ "sh", "-c", "echo 'Waiting for Nuts Node to be ready...'; while ! curl -s -f http://nutsnode:8080/status > /dev/null; do echo 'Waiting for nutsnode to be ready...'; sleep 1; done; echo 'Nutsnode is up and running.' && sh /nutsnode-init.sh" ]
     restart: "no"
+    networks:
+      - orca-shared-services
   nutsadmin:
     image: "nutsfoundation/nuts-admin:main"
     environment:
       - NUTS_NODE_ADDRESS=http://nutsnode:8081
     ports:
       - "1405:1305"
+    networks:
+      - orca-shared-services
   hospital_proxy:
     image: nginx:latest
     depends_on:
@@ -43,6 +61,8 @@ services:
       - "8081:8080"
     volumes:
       - "${orca_dev_base}/hospital/config/nginx-proxy.conf:/etc/nginx/conf.d/nginx-proxy.conf:ro"
+    networks:
+      - orca-shared-services
   hospital_frontend:
     #image: ghcr.io/santeonnl/orca_frontend:main
     build:
@@ -58,6 +78,8 @@ services:
       NEXT_ALLOWED_ORIGINS: localhost:8081
     ports:
       - "3003:3000"
+    networks:
+      - orca-shared-services
   hospital_orchestrator:
     #image: ghcr.io/santeonnl/orca_orchestrator:main
     build:
@@ -94,6 +116,10 @@ services:
       - ORCA_TENANT_HOSPITAL_NUTS_SUBJECT=hospital
       - ORCA_TENANT_HOSPITAL_DEMO_FHIR_URL=http://fhirstore:8080/fhir
       - ORCA_TENANT_HOSPITAL_CPS_FHIR_URL=http://fhirstore:8080/fhir
+      - OTEL_SERVICE_NAME=hospital-orchestrator
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://aspire-dashboard:18889
+      - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+      - OTEL_RESOURCE_ATTRIBUTES=service.instance.id=hospital-1
       #   Uncomment and set the <...> values below to enable Zorgplatform integration - using zorgplatform production URLs as that is what their developer portal uses
       # - ORCA_CAREPLANCONTRIBUTOR_APPLAUNCH_ZORGPLATFORM_ENABLED=true
       # - ORCA_CAREPLANCONTRIBUTOR_APPLAUNCH_ZORGPLATFORM_CPSFHIRENDPOINT_URL=http://fhirstore:8080/fhir
@@ -111,6 +137,8 @@ services:
       # - ORCA_CAREPLANCONTRIBUTOR_APPLAUNCH_ZORGPLATFORM_X509_SIGNKEYFILE=/keys/zorgplatform/test-sign-zorgplatform.private.pem
       # - ORCA_CAREPLANCONTRIBUTOR_APPLAUNCH_ZORGPLATFORM_X509_DECRYPTCERTFILE=/keys/zorgplatform/test-decrypt-zorgplatform.private.pem
       # - ORCA_CAREPLANCONTRIBUTOR_APPLAUNCH_ZORGPLATFORM_X509_CLIENTCERTFILE=/keys/zorgplatform/test-tls-zorgplatform.private.pem
+    networks:
+      - orca-shared-services
   fhirstore:
     image: hapiproject/hapi:v7.2.0
     ports:
@@ -119,6 +147,8 @@ services:
       - hapi.fhir.fhir_version=R4
       - hapi.fhir.allow_external_references=true
       - hapi.fhir.server_address=http://fhirstore:8080/fhir
+    networks:
+      - orca-shared-services
   # The HAPI image has no binaries such as curl, so we use the curl image to perform the health check
   fhirstore-healthcheck:
     image: curlimages/curl:7.87.0
@@ -127,6 +157,8 @@ services:
     entrypoint: ["sh", "-c", "echo 'Starting fhirstore healthcheck...'; while ! curl -s -f http://fhirstore:8080/fhir/Task > /dev/null; do echo 'Waiting for fhirstore to be ready...'; sleep 5; done; echo 'fhirstore is up and running.'"]
     # Ensure the container exits successfully after the check
     restart: "no"
+    networks:
+      - orca-shared-services
   hospital_ehr:
     #image: ghcr.io/santeonnl/orca_hospitalsimulator:main
     build:
@@ -145,6 +177,8 @@ services:
       ORCA_PERFORMER_ORGANIZATION_NAME: Demo Clinic
       NEXT_ALLOWED_ORIGINS: localhost:8081
       FHIR_BASE_URL: http://fhirstore:8080/fhir
+    networks:
+      - orca-shared-services
     volumes:
       - ${orca_dev_base}/../../hospital_simulator:/app
       - /app/node_modules # do not mount node_modules from host, as it will cause issues with the NextJS build
@@ -155,6 +189,8 @@ services:
       - clinic_orchestrator
     ports:
       - "8082:8080"
+    networks:
+      - orca-shared-services
     volumes:
       - "${orca_dev_base}/clinic/config/nginx-proxy.conf:/etc/nginx/conf.d/nginx-proxy.conf:ro"
   clinic_orchestrator:
@@ -181,12 +217,18 @@ services:
       - ORCA_CAREPLANCONTRIBUTOR_STATICBEARERTOKEN=valid
       - ORCA_CAREPLANCONTRIBUTOR_HEALTHDATAVIEWENDPOINTENABLED=true
       - ORCA_CAREPLANCONTRIBUTOR_FHIR_URL=http://viewer:3000/viewer/api/fhir
+      - OTEL_SERVICE_NAME=clinic-orchestrator
+      - OTEL_EXPORTER_OTLP_ENDPOINT=aspire-dashboard:18889
+      - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+      - OTEL_RESOURCE_ATTRIBUTES=service.instance.id=clinic-1
       # Register an example web application for discovery by other SCP participants.
       - ORCA_CAREPLANCONTRIBUTOR_APPLAUNCH_EXTERNAL_0_NAME=Example Web Application
       - ORCA_CAREPLANCONTRIBUTOR_APPLAUNCH_EXTERNAL_0_URL=https://example.com
       - ORCA_CAREPLANCONTRIBUTOR_TASKFILLER_TASKACCEPTEDBUNDLEENDPOINT=http://host.docker.internal:5188/orca/v1/enroll
       - ORCA_CAREPLANCONTRIBUTOR_TASKFILLER_QUESTIONNAIRESYNCURLS=https://raw.githubusercontent.com/Zorgbijjou/scp-homemonitoring/refs/heads/main/fsh-generated/resources/Bundle-zbj-bundle-healthcareservices.json,https://raw.githubusercontent.com/Zorgbijjou/scp-homemonitoring/refs/heads/main/fsh-generated/resources/Bundle-zbj-bundle-questionnaires.json
       - ORCA_CAREPLANCONTRIBUTOR_TASKFILLER_STATUSNOTE_ACCEPTED=Work on the Task will start tomorrow.
+    networks:
+      - orca-shared-services
     volumes:
       # FHIR HealthcareService and Questionnaire resources that are loaded into the FHIR store on startup,
       # used by the Task Filler Engine
@@ -203,6 +245,8 @@ services:
       CLINIC_IDENTIFIER: http://fhir.nl/fhir/NamingSystem/ura|1234
       CLINIC_CPS_URL: http://hospital_orchestrator:8080/cps
       NEXT_ALLOWED_ORIGINS: localhost:8081
+    networks:
+      - orca-shared-services
     volumes:
       - ${orca_dev_base}/../../viewer_simulator:/app
       - /app/node_modules # do not mount node_modules from host, as it will cause issues with the NextJS build
@@ -210,7 +254,13 @@ services:
   # So, we use curl to force NextJS to make sure the receiving endpoint is compiled.
   clinic_viewer-init:
     image: curlimages/curl:7.87.0
+    networks:
+      - orca-shared-services
     depends_on:
       clinic_viewer:
         condition: service_healthy
     entrypoint: [ "sh", "-c", "curl -s -X POST -d '{}' http://clinic_viewer:3000/viewer/api/delivery/orca-enroll-patient" ]
+
+networks:
+  orca-shared-services:
+    driver: bridge


### PR DESCRIPTION
When running ORCA with docker-compose it will now spin up an aspire-dashboard service and export tracing to it.

It has been set up with a network such that ORCA can be run alongside other services that also make use of the aspire-dashboard and share a common tracing exporter endpoint and dashboard