### PR TITLE
[DEV] Refactor otel_lib package to observability

### DIFF
--- a/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
@@ -18,7 +18,7 @@ import (
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor/applaunch/session"
 	"github.com/SanteonNL/orca/orchestrator/cmd/tenants"
 	"github.com/SanteonNL/orca/orchestrator/lib/debug"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/observability"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -292,8 +292,8 @@ func (s *stsAccessTokenRoundTripper) RoundTrip(httpRequest *http.Request) (*http
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String(lib_otel.HTTPMethod, httpRequest.Method),
-			attribute.String(lib_otel.HTTPURL, httpRequest.URL.String()),
+			attribute.String(observability.HTTPMethod, httpRequest.Method),
+			attribute.String(observability.HTTPURL, httpRequest.URL.String()),
 		),
 	)
 	defer span.End()
@@ -391,8 +391,8 @@ func (s *Service) handleLaunch(response http.ResponseWriter, request *http.Reque
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String(lib_otel.HTTPMethod, request.Method),
-			attribute.String(lib_otel.HTTPURL, request.URL.String()),
+			attribute.String(observability.HTTPMethod, request.Method),
+			attribute.String(observability.HTTPURL, request.URL.String()),
 		),
 	)
 	defer span.End()

--- a/orchestrator/careplancontributor/batch.go
+++ b/orchestrator/careplancontributor/batch.go
@@ -7,7 +7,7 @@ import (
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
 	"github.com/SanteonNL/orca/orchestrator/lib/debug"
 	"github.com/SanteonNL/orca/orchestrator/lib/must"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/observability"
 	"github.com/SanteonNL/orca/orchestrator/lib/to"
 	"github.com/rs/zerolog/log"
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
@@ -33,10 +33,10 @@ func (s *Service) handleBatch(httpRequest *http.Request, requestBundle fhir.Bund
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String(lib_otel.HTTPMethod, httpRequest.Method),
-			attribute.String(lib_otel.HTTPURL, httpRequest.URL.String()),
-			attribute.String(lib_otel.FHIRBundleType, requestBundle.Type.String()),
-			attribute.Int(lib_otel.FHIRBundleEntryCount, len(requestBundle.Entry)),
+			attribute.String(observability.HTTPMethod, httpRequest.Method),
+			attribute.String(observability.HTTPURL, httpRequest.URL.String()),
+			attribute.String(observability.FHIRBundleType, requestBundle.Type.String()),
+			attribute.Int(observability.FHIRBundleEntryCount, len(requestBundle.Entry)),
 		),
 	)
 	defer span.End()

--- a/orchestrator/careplancontributor/ehr/notification_bundle.go
+++ b/orchestrator/careplancontributor/ehr/notification_bundle.go
@@ -7,7 +7,7 @@ import (
 	fhirclient "github.com/SanteonNL/go-fhir-client"
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
 	"github.com/SanteonNL/orca/orchestrator/lib/debug"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/observability"
 	"github.com/SanteonNL/orca/orchestrator/lib/to"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
@@ -42,7 +42,7 @@ func TaskNotificationBundleSet(ctx context.Context, cpsClient fhirclient.Client,
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRTaskID, taskId),
+			attribute.String(observability.FHIRTaskID, taskId),
 		),
 	)
 	defer span.End()
@@ -117,8 +117,8 @@ func TaskNotificationBundleSet(ctx context.Context, cpsClient fhirclient.Client,
 	bundles.addBundle(*questionnaireResponseBundles...)
 
 	span.SetAttributes(
-		attribute.Int(lib_otel.FHIRBundlesCount, len(bundles.Bundles)),
-		attribute.String(lib_otel.FHIRBundleSetId, bundles.Id),
+		attribute.Int(observability.FHIRBundlesCount, len(bundles.Bundles)),
+		attribute.String(observability.FHIRBundleSetId, bundles.Id),
 	)
 
 	return &bundles, nil
@@ -130,7 +130,7 @@ func fetchTasks(ctx context.Context, cpsClient fhirclient.Client, taskId string)
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRTaskID, taskId),
+			attribute.String(observability.FHIRTaskID, taskId),
 		),
 	)
 	defer span.End()
@@ -161,8 +161,8 @@ func fetchTasks(ctx context.Context, cpsClient fhirclient.Client, taskId string)
 	}
 
 	span.SetAttributes(
-		attribute.Int(lib_otel.FHIRTasksCount, len(tasks)),
-		attribute.Int(lib_otel.FHIRBundleEntryCount, len(taskBundle.Entry)),
+		attribute.Int(observability.FHIRTasksCount, len(tasks)),
+		attribute.Int(observability.FHIRBundleEntryCount, len(taskBundle.Entry)),
 	)
 
 	return &taskBundle, tasks, nil
@@ -174,7 +174,7 @@ func fetchCarePlan(ctx context.Context, cpsClient fhirclient.Client, tasks []fhi
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
-			attribute.Int(lib_otel.FHIRTasksCount, len(tasks)),
+			attribute.Int(observability.FHIRTasksCount, len(tasks)),
 		),
 	)
 	defer span.End()
@@ -235,7 +235,7 @@ func fetchServiceRequest(ctx context.Context, cpsClient fhirclient.Client, tasks
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
-			attribute.Int(lib_otel.FHIRTasksCount, len(tasks)),
+			attribute.Int(observability.FHIRTasksCount, len(tasks)),
 		),
 	)
 	defer span.End()
@@ -267,7 +267,7 @@ func fetchQuestionnaires(ctx context.Context, cpsClient fhirclient.Client, tasks
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
-			attribute.Int(lib_otel.FHIRTasksCount, len(tasks)),
+			attribute.Int(observability.FHIRTasksCount, len(tasks)),
 		),
 	)
 	defer span.End()
@@ -290,7 +290,7 @@ func fetchQuestionnaireResponses(ctx context.Context, cpsClient fhirclient.Clien
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
-			attribute.Int(lib_otel.FHIRTasksCount, len(tasks)),
+			attribute.Int(observability.FHIRTasksCount, len(tasks)),
 		),
 	)
 	defer span.End()
@@ -361,7 +361,7 @@ func fetchRef(ctx context.Context, cpsClient fhirclient.Client, ref string) (*fh
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRResourceReference, ref),
+			attribute.String(observability.FHIRResourceReference, ref),
 		),
 	)
 	defer span.End()

--- a/orchestrator/careplancontributor/ehr/notifier.go
+++ b/orchestrator/careplancontributor/ehr/notifier.go
@@ -9,7 +9,7 @@ import (
 	"github.com/SanteonNL/orca/orchestrator/cmd/tenants"
 	"github.com/SanteonNL/orca/orchestrator/events"
 	"github.com/SanteonNL/orca/orchestrator/lib/debug"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/observability"
 	"github.com/SanteonNL/orca/orchestrator/messaging"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
@@ -74,9 +74,9 @@ func (n *notifier) NotifyTaskAccepted(ctx context.Context, fhirBaseURL string, t
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRBaseURL, fhirBaseURL),
-			attribute.String(lib_otel.FHIRTaskID, *task.Id),
-			attribute.String(lib_otel.FHIRTaskStatus, task.Status.Code()),
+			attribute.String(observability.FHIRBaseURL, fhirBaseURL),
+			attribute.String(observability.FHIRTaskID, *task.Id),
+			attribute.String(observability.FHIRTaskStatus, task.Status.Code()),
 		),
 	)
 	defer span.End()
@@ -106,9 +106,9 @@ func (n *notifier) processTaskAcceptedEvent(ctx context.Context, event *TaskAcce
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRBaseURL, event.FHIRBaseURL),
-			attribute.String(lib_otel.FHIRTaskID, *event.Task.Id),
-			attribute.String(lib_otel.FHIRTaskStatus, event.Task.Status.Code()),
+			attribute.String(observability.FHIRBaseURL, event.FHIRBaseURL),
+			attribute.String(observability.FHIRTaskID, *event.Task.Id),
+			attribute.String(observability.FHIRTaskStatus, event.Task.Status.Code()),
 		),
 	)
 	defer span.End()
@@ -189,9 +189,9 @@ func sendBundle(ctx context.Context, taskAcceptedBundleEndpoint string, set Bund
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindProducer),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRBundleSetId, set.Id),
+			attribute.String(observability.FHIRBundleSetId, set.Id),
 			attribute.String("bundle_set.task", set.task),
-			attribute.Int(lib_otel.FHIRBundlesCount, len(set.Bundles)),
+			attribute.Int(observability.FHIRBundlesCount, len(set.Bundles)),
 		),
 	)
 	defer span.End()

--- a/orchestrator/careplancontributor/handle_taskfiller.go
+++ b/orchestrator/careplancontributor/handle_taskfiller.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"github.com/SanteonNL/orca/orchestrator/cmd/tenants"
 	"github.com/SanteonNL/orca/orchestrator/lib/debug"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/observability"
 	"github.com/SanteonNL/orca/orchestrator/lib/slices"
 	"strings"
 
@@ -59,8 +59,8 @@ func (s *Service) handleTaskNotification(ctx context.Context, cpsClient fhirclie
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRTaskID, to.Value(task.Id)),
-			attribute.String(lib_otel.FHIRTaskStatus, task.Status.Code()),
+			attribute.String(observability.FHIRTaskID, to.Value(task.Id)),
+			attribute.String(observability.FHIRTaskStatus, task.Status.Code()),
 		),
 	)
 	defer span.End()
@@ -157,8 +157,8 @@ func (s *Service) handleSubtaskNotification(ctx context.Context, cpsClient fhirc
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRTaskID, to.Value(task.Id)),
-			attribute.String(lib_otel.FHIRTaskStatus, task.Status.Code()),
+			attribute.String(observability.FHIRTaskID, to.Value(task.Id)),
+			attribute.String(observability.FHIRTaskStatus, task.Status.Code()),
 			attribute.String("fhir.primary_task_ref", primaryTaskRef),
 		),
 	)
@@ -211,8 +211,8 @@ func (s *Service) acceptPrimaryTask(ctx context.Context, cpsClient fhirclient.Cl
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRTaskID, to.Value(primaryTask.Id)),
-			attribute.String(lib_otel.FHIRTaskStatus, primaryTask.Status.Code()),
+			attribute.String(observability.FHIRTaskID, to.Value(primaryTask.Id)),
+			attribute.String(observability.FHIRTaskStatus, primaryTask.Status.Code()),
 		),
 	)
 	defer span.End()
@@ -307,7 +307,7 @@ func (s *Service) createSubTaskOrAcceptPrimaryTask(ctx context.Context, cpsClien
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRTaskID, to.Value(task.Id)),
+			attribute.String(observability.FHIRTaskID, to.Value(task.Id)),
 			attribute.String("fhir.primary_task_id", to.Value(primaryTask.Id)),
 		),
 	)
@@ -467,7 +467,7 @@ func (s *Service) selectWorkflow(ctx context.Context, cpsClient fhirclient.Clien
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRTaskID, to.Value(task.Id)),
+			attribute.String(observability.FHIRTaskID, to.Value(task.Id)),
 			attribute.String("fhir.task_focus_reference", to.Value(task.Focus.Reference)),
 		),
 	)

--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -24,7 +24,7 @@ import (
 	"github.com/SanteonNL/orca/orchestrator/careplanservice"
 	"github.com/SanteonNL/orca/orchestrator/cmd/tenants"
 	"github.com/SanteonNL/orca/orchestrator/lib/debug"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/observability"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -186,7 +186,7 @@ type Service struct {
 
 func (s *Service) RegisterHandlers(mux *http.ServeMux) {
 	if s.oidcProvider != nil {
-		mux.HandleFunc(basePath+"/login", lib_otel.HandlerWithTracing(tracer, "Login", s.withSession(s.oidcProvider.HandleLogin)))
+		mux.HandleFunc(basePath+"/login", observability.HandlerWithTracing(tracer, "Login", s.withSession(s.oidcProvider.HandleLogin)))
 		mux.Handle(basePath+"/", http.StripPrefix(basePath, s.oidcProvider))
 	}
 
@@ -230,14 +230,14 @@ func (s *Service) RegisterHandlers(mux *http.ServeMux) {
 		}
 		return nil, coolfhir.BadRequest("bundle type not supported: %s", bundle.Type.String())
 	}
-	mux.HandleFunc("POST "+basePathWithTenant+"/fhir", lib_otel.HandlerWithTracing(tracer, "ProcessBundle", s.tenants.HttpHandler(s.profile.Authenticator(func(writer http.ResponseWriter, request *http.Request) {
+	mux.HandleFunc("POST "+basePathWithTenant+"/fhir", observability.HandlerWithTracing(tracer, "ProcessBundle", s.tenants.HttpHandler(s.profile.Authenticator(func(writer http.ResponseWriter, request *http.Request) {
 		if bundle, err := handleBundle(request); err != nil {
 			coolfhir.WriteOperationOutcomeFromError(request.Context(), err, "CarePlanContributor/CreateBundle", writer)
 		} else {
 			coolfhir.SendResponse(writer, http.StatusOK, bundle)
 		}
 	}))))
-	mux.HandleFunc("POST "+basePathWithTenant+"/fhir/{$}", lib_otel.HandlerWithTracing(tracer, "ProcessBundle", s.tenants.HttpHandler(s.profile.Authenticator(func(writer http.ResponseWriter, request *http.Request) {
+	mux.HandleFunc("POST "+basePathWithTenant+"/fhir/{$}", observability.HandlerWithTracing(tracer, "ProcessBundle", s.tenants.HttpHandler(s.profile.Authenticator(func(writer http.ResponseWriter, request *http.Request) {
 		if bundle, err := handleBundle(request); err != nil {
 			coolfhir.WriteOperationOutcomeFromError(request.Context(), err, "CarePlanContributor/CreateBundle", writer)
 		} else {
@@ -248,7 +248,7 @@ func (s *Service) RegisterHandlers(mux *http.ServeMux) {
 	//
 	// This is a special endpoint, used by other SCP-nodes to discovery applications.
 	//
-	mux.HandleFunc("GET "+basePathWithTenant+"/fhir/Endpoint", lib_otel.HandlerWithTracing(tracer, "DiscoverEndpoints", s.tenants.HttpHandler(s.profile.Authenticator(func(writer http.ResponseWriter, request *http.Request) {
+	mux.HandleFunc("GET "+basePathWithTenant+"/fhir/Endpoint", observability.HandlerWithTracing(tracer, "DiscoverEndpoints", s.tenants.HttpHandler(s.profile.Authenticator(func(writer http.ResponseWriter, request *http.Request) {
 		if len(request.URL.Query()) > 0 {
 			coolfhir.WriteOperationOutcomeFromError(request.Context(), coolfhir.BadRequest("search parameters are not supported on this endpoint"), fmt.Sprintf("CarePlanContributor/%s %s", request.Method, request.URL.Path), writer)
 		}
@@ -310,11 +310,11 @@ func (s *Service) RegisterHandlers(mux *http.ServeMux) {
 			return
 		}
 	})
-	mux.HandleFunc("GET "+basePathWithTenant+"/fhir/{resourceType}/{id}", lib_otel.HandlerWithTracing(tracer, "ProxyFHIRRead", s.tenants.HttpHandler(s.profile.Authenticator(proxyGetOrSearchHandler))))
-	mux.HandleFunc("POST "+basePathWithTenant+"/fhir/{resourceType}/_search", lib_otel.HandlerWithTracing(tracer, "ProxyFHIRSearch", s.tenants.HttpHandler(s.profile.Authenticator(proxyGetOrSearchHandler))))
-	mux.HandleFunc("GET "+basePathWithTenant+"/fhir/{resourceType}", lib_otel.HandlerWithTracing(tracer, "ProxyFHIRSearch", s.tenants.HttpHandler(s.profile.Authenticator(proxyGetOrSearchHandler))))
+	mux.HandleFunc("GET "+basePathWithTenant+"/fhir/{resourceType}/{id}", observability.HandlerWithTracing(tracer, "ProxyFHIRRead", s.tenants.HttpHandler(s.profile.Authenticator(proxyGetOrSearchHandler))))
+	mux.HandleFunc("POST "+basePathWithTenant+"/fhir/{resourceType}/_search", observability.HandlerWithTracing(tracer, "ProxyFHIRSearch", s.tenants.HttpHandler(s.profile.Authenticator(proxyGetOrSearchHandler))))
+	mux.HandleFunc("GET "+basePathWithTenant+"/fhir/{resourceType}", observability.HandlerWithTracing(tracer, "ProxyFHIRSearch", s.tenants.HttpHandler(s.profile.Authenticator(proxyGetOrSearchHandler))))
 	// Custom operations
-	mux.HandleFunc("POST "+basePathWithTenant+"/fhir/$import", lib_otel.HandlerWithTracing(tracer, "CarePlanContributor/FHIR Import", s.tenants.HttpHandler(s.profile.Authenticator(func(httpResponse http.ResponseWriter, request *http.Request) {
+	mux.HandleFunc("POST "+basePathWithTenant+"/fhir/$import", observability.HandlerWithTracing(tracer, "CarePlanContributor/FHIR Import", s.tenants.HttpHandler(s.profile.Authenticator(func(httpResponse http.ResponseWriter, request *http.Request) {
 		result, err := s.handleImport(request)
 		if err != nil {
 			coolfhir.WriteOperationOutcomeFromError(request.Context(), err, "CarePlanContributor/Import", httpResponse)
@@ -329,7 +329,7 @@ func (s *Service) RegisterHandlers(mux *http.ServeMux) {
 	// This endpoint is used by the EHR and ORCA Frontend to query the FHIR API of a remote SCP-node.
 	// The remote SCP-node to query can be specified using the following HTTP headers:
 	// - X-Scp-Entity-Identifier: Uses the identifier of the SCP-node to query (in the form of <system>|<value>), to resolve the registered FHIR base URL
-	mux.HandleFunc(basePathWithTenant+"/external/fhir/{rest...}", lib_otel.HandlerWithTracing(tracer, "ProxyExternalFHIR", s.tenants.HttpHandler(s.withUserAuth(func(writer http.ResponseWriter, request *http.Request) {
+	mux.HandleFunc(basePathWithTenant+"/external/fhir/{rest...}", observability.HandlerWithTracing(tracer, "ProxyExternalFHIR", s.tenants.HttpHandler(s.withUserAuth(func(writer http.ResponseWriter, request *http.Request) {
 		// TODO: Extract relevant data from the bearer JWT
 		fhirBaseURL, httpClient, err := s.createFHIRClientForExternalRequest(request.Context(), request)
 		if err != nil {
@@ -345,11 +345,11 @@ func (s *Service) RegisterHandlers(mux *http.ServeMux) {
 		fhirProxy := coolfhir.NewProxy("EHR(local)->EHR(external) FHIR proxy", fhirBaseURL, proxyBasePath, s.orcaPublicURL.JoinPath(proxyBasePath), coolfhir.NewTracedHTTPTransport(httpClient.Transport, tracer), true, true)
 		fhirProxy.ServeHTTP(writer, request)
 	}))))
-	mux.HandleFunc("GET "+basePath+"/context", lib_otel.HandlerWithTracing(tracer, "GetContext", s.withSession(s.handleGetContext)))
-	mux.HandleFunc(basePathWithTenant+"/ehr/fhir/{rest...}", lib_otel.HandlerWithTracing(tracer, "ProxyAppToEHR", s.tenants.HttpHandler(s.withSession(s.handleProxyAppRequestToEHR))))
+	mux.HandleFunc("GET "+basePath+"/context", observability.HandlerWithTracing(tracer, "GetContext", s.withSession(s.handleGetContext)))
+	mux.HandleFunc(basePathWithTenant+"/ehr/fhir/{rest...}", observability.HandlerWithTracing(tracer, "ProxyAppToEHR", s.tenants.HttpHandler(s.withSession(s.handleProxyAppRequestToEHR))))
 
 	// Logout endpoint
-	mux.HandleFunc("/logout", lib_otel.HandlerWithTracing(tracer, "Logout", s.withSession(func(writer http.ResponseWriter, request *http.Request, _ *session.Data) {
+	mux.HandleFunc("/logout", observability.HandlerWithTracing(tracer, "Logout", s.withSession(func(writer http.ResponseWriter, request *http.Request, _ *session.Data) {
 		s.SessionManager.Destroy(writer, request)
 		// If there is a 'Referer' value in the header, redirect to that URL
 		if referer := request.Header.Get("Referer"); referer != "" {
@@ -426,8 +426,8 @@ func (s Service) handleProxyAppRequestToEHR(writer http.ResponseWriter, request 
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String(lib_otel.HTTPMethod, request.Method),
-			attribute.String(lib_otel.HTTPURL, request.URL.String()),
+			attribute.String(observability.HTTPMethod, request.Method),
+			attribute.String(observability.HTTPURL, request.URL.String()),
 		),
 	)
 	defer span.End()
@@ -467,8 +467,8 @@ func (s Service) handleProxyExternalRequestToEHR(writer http.ResponseWriter, req
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String(lib_otel.HTTPMethod, request.Method),
-			attribute.String(lib_otel.HTTPURL, request.URL.String()),
+			attribute.String(observability.HTTPMethod, request.Method),
+			attribute.String(observability.HTTPURL, request.URL.String()),
 		),
 	)
 	defer span.End()
@@ -704,7 +704,7 @@ func (s Service) handleNotification(ctx context.Context, resource any) error {
 
 	// Add resource metadata to span
 	span.SetAttributes(
-		attribute.String(lib_otel.FHIRResourceType, *focusReference.Type),
+		attribute.String(observability.FHIRResourceType, *focusReference.Type),
 		attribute.String("fhir.resource_reference", *focusReference.Reference),
 	)
 
@@ -845,7 +845,7 @@ func (s Service) createFHIRClientForExternalRequest(ctx context.Context, request
 				}
 				httpClient = s.httpClientForLocalCPS(tenant)
 				fhirBaseURL = localCPSURL
-				span.SetAttributes(attribute.String(lib_otel.FHIRClientType, "local-cps"))
+				span.SetAttributes(attribute.String(observability.FHIRClientType, "local-cps"))
 			} else {
 				fhirBaseURL, err = s.parseFHIRBaseURL(headerValue)
 				if err != nil {
@@ -861,7 +861,7 @@ func (s Service) createFHIRClientForExternalRequest(ctx context.Context, request
 					span.SetStatus(codes.Error, err.Error())
 					return nil, nil, err
 				}
-				span.SetAttributes(attribute.String(lib_otel.FHIRClientType, "external"))
+				span.SetAttributes(attribute.String(observability.FHIRClientType, "external"))
 			}
 			break
 		case scpEntityIdentifierHeaderKey:
@@ -901,7 +901,7 @@ func (s Service) createFHIRClientForExternalRequest(ctx context.Context, request
 				return nil, nil, err
 			}
 			span.SetAttributes(
-				attribute.String(lib_otel.FHIRClientType, "identifier-based"),
+				attribute.String(observability.FHIRClientType, "identifier-based"),
 				attribute.String("fhir.identifier_system", to.Value(identifier.System)),
 			)
 			break
@@ -915,7 +915,7 @@ func (s Service) createFHIRClientForExternalRequest(ctx context.Context, request
 	}
 
 	span.SetAttributes(
-		attribute.String(lib_otel.FHIRBaseURL, fhirBaseURL.String()),
+		attribute.String(observability.FHIRBaseURL, fhirBaseURL.String()),
 	)
 	span.SetStatus(codes.Ok, "")
 	return fhirBaseURL, httpClient, nil

--- a/orchestrator/careplanservice/handle_createtask.go
+++ b/orchestrator/careplanservice/handle_createtask.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/SanteonNL/orca/orchestrator/lib/debug"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/observability"
 	"net/http"
 	"strings"
 
@@ -30,7 +30,7 @@ func (s *Service) handleCreateTask(ctx context.Context, request FHIRHandlerReque
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRResourceType, "Task"),
+			attribute.String(observability.FHIRResourceType, "Task"),
 		),
 	)
 	defer span.End()
@@ -314,7 +314,7 @@ func (s *Service) handleCreateTask(ctx context.Context, request FHIRHandlerReque
 
 		// Different validation logic for an SCP subtask
 		if len(task.PartOf) > 0 {
-			span.SetAttributes(attribute.String(lib_otel.FHIRTaskType, "subtask"))
+			span.SetAttributes(attribute.String(observability.FHIRTaskType, "subtask"))
 
 			if len(task.PartOf) != 1 {
 				err := coolfhir.NewErrorWithCode("SCP subtask must have exactly one parent task", http.StatusBadRequest)
@@ -352,7 +352,7 @@ func (s *Service) handleCreateTask(ctx context.Context, request FHIRHandlerReque
 				return nil, err
 			}
 		} else {
-			span.SetAttributes(attribute.String(lib_otel.FHIRTaskType, "primary"))
+			span.SetAttributes(attribute.String(observability.FHIRTaskType, "primary"))
 
 			careTeam, err := coolfhir.CareTeamFromCarePlan(&carePlan)
 			if err != nil {

--- a/orchestrator/careplanservice/handle_updatetask.go
+++ b/orchestrator/careplanservice/handle_updatetask.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/SanteonNL/orca/orchestrator/lib/debug"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/observability"
 	"strings"
 
 	fhirclient "github.com/SanteonNL/go-fhir-client"
@@ -28,7 +28,7 @@ func (s *Service) handleUpdateTask(ctx context.Context, request FHIRHandlerReque
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRResourceType, "Task"),
+			attribute.String(observability.FHIRResourceType, "Task"),
 		),
 	)
 	defer span.End()
@@ -114,7 +114,7 @@ func (s *Service) handleUpdateTask(ctx context.Context, request FHIRHandlerReque
 		// Direct ID lookup
 		span.SetAttributes(
 			attribute.String("fhir.task.lookup_method", "id"),
-			attribute.String(lib_otel.FHIRTaskID, request.ResourceId),
+			attribute.String(observability.FHIRTaskID, request.ResourceId),
 		)
 
 		if (task.Id != nil && request.ResourceId != "") && request.ResourceId != *task.Id {

--- a/orchestrator/careplanservice/operation_create.go
+++ b/orchestrator/careplanservice/operation_create.go
@@ -8,7 +8,7 @@ import (
 	"github.com/SanteonNL/orca/orchestrator/cmd/profile"
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
 	"github.com/SanteonNL/orca/orchestrator/lib/debug"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/observability"
 	"github.com/SanteonNL/orca/orchestrator/lib/to"
 	"github.com/SanteonNL/orca/orchestrator/lib/validation"
 	"github.com/google/uuid"
@@ -40,8 +40,8 @@ func (h FHIRCreateOperationHandler[T]) Handle(ctx context.Context, request FHIRH
 
 	resourceType := getResourceType(request.ResourcePath)
 	span.SetAttributes(
-		attribute.String(lib_otel.FHIRResourceType, resourceType),
-		attribute.String(lib_otel.OperationName, "Create"),
+		attribute.String(observability.FHIRResourceType, resourceType),
+		attribute.String(observability.OperationName, "Create"),
 	)
 
 	var resource T
@@ -56,7 +56,7 @@ func (h FHIRCreateOperationHandler[T]) Handle(ctx context.Context, request FHIRH
 
 	resourceID := coolfhir.ResourceID(resource)
 	if resourceID != nil {
-		span.SetAttributes(attribute.String(lib_otel.FHIRResourceID, *resourceID))
+		span.SetAttributes(attribute.String(observability.FHIRResourceID, *resourceID))
 	}
 
 	// Check we're only allowing secure external literal references
@@ -85,8 +85,8 @@ func (h FHIRCreateOperationHandler[T]) Handle(ctx context.Context, request FHIRH
 
 	// Add authorization decision details to span
 	span.SetAttributes(
-		attribute.Bool(lib_otel.AuthZAllowed, authzDecision.Allowed),
-		attribute.StringSlice(lib_otel.AuthZReasons, authzDecision.Reasons),
+		attribute.Bool(observability.AuthZAllowed, authzDecision.Allowed),
+		attribute.StringSlice(observability.AuthZReasons, authzDecision.Reasons),
 	)
 
 	log.Ctx(ctx).Info().Msgf("Creating %s (authz=%s)", resourceType, strings.Join(authzDecision.Reasons, ";"))
@@ -96,7 +96,7 @@ func (h FHIRCreateOperationHandler[T]) Handle(ctx context.Context, request FHIRH
 		if done {
 			return result, err2
 		}
-		span.SetAttributes(attribute.String(lib_otel.ValidationResult, "passed"))
+		span.SetAttributes(attribute.String(observability.ValidationResult, "passed"))
 	} else {
 		span.SetAttributes(attribute.Bool("validation.enabled", false))
 	}
@@ -165,7 +165,7 @@ func (h FHIRCreateOperationHandler[T]) validate(ctx context.Context, resource T,
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRResourceType, resourceType),
+			attribute.String(observability.FHIRResourceType, resourceType),
 		),
 	)
 	defer span.End()
@@ -173,7 +173,7 @@ func (h FHIRCreateOperationHandler[T]) validate(ctx context.Context, resource T,
 	if errs := h.validator.Validate(resource); errs != nil {
 		span.SetAttributes(
 			attribute.Int("validation.error_count", len(errs)),
-			attribute.String(lib_otel.ValidationResult, "failed"),
+			attribute.String(observability.ValidationResult, "failed"),
 		)
 
 		var issues []fhir.OperationOutcomeIssue
@@ -209,7 +209,7 @@ func (h FHIRCreateOperationHandler[T]) validate(ctx context.Context, resource T,
 	}
 
 	span.SetAttributes(
-		attribute.String(lib_otel.ValidationResult, "passed"),
+		attribute.String(observability.ValidationResult, "passed"),
 	)
 	span.SetStatus(codes.Ok, "")
 	return nil, nil, false

--- a/orchestrator/careplanservice/operation_read.go
+++ b/orchestrator/careplanservice/operation_read.go
@@ -8,7 +8,7 @@ import (
 	"github.com/SanteonNL/orca/orchestrator/lib/audit"
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
 	"github.com/SanteonNL/orca/orchestrator/lib/debug"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/observability"
 	"github.com/SanteonNL/orca/orchestrator/lib/to"
 	"github.com/rs/zerolog/log"
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
@@ -36,9 +36,9 @@ func (h FHIRReadOperationHandler[T]) Handle(ctx context.Context, request FHIRHan
 
 	resourceType := getResourceType(request.ResourcePath)
 	span.SetAttributes(
-		attribute.String(lib_otel.FHIRResourceType, resourceType),
-		attribute.String(lib_otel.FHIRResourceID, request.ResourceId),
-		attribute.String(lib_otel.OperationName, "Read"),
+		attribute.String(observability.FHIRResourceType, resourceType),
+		attribute.String(observability.FHIRResourceID, request.ResourceId),
+		attribute.String(observability.OperationName, "Read"),
 	)
 
 	var resource T

--- a/orchestrator/careplanservice/operation_search.go
+++ b/orchestrator/careplanservice/operation_search.go
@@ -9,7 +9,7 @@ import (
 	"github.com/SanteonNL/orca/orchestrator/lib/auth"
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
 	"github.com/SanteonNL/orca/orchestrator/lib/debug"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/observability"
 	"github.com/SanteonNL/orca/orchestrator/lib/to"
 	"github.com/rs/zerolog/log"
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
@@ -38,8 +38,8 @@ func (h FHIRSearchOperationHandler[T]) Handle(ctx context.Context, request FHIRH
 
 	resourceType := getResourceType(request.ResourcePath)
 	span.SetAttributes(
-		attribute.String(lib_otel.FHIRResourceType, resourceType),
-		attribute.String(lib_otel.OperationName, "Search"),
+		attribute.String(observability.FHIRResourceType, resourceType),
+		attribute.String(observability.OperationName, "Search"),
 	)
 
 	log.Ctx(ctx).Info().Msgf("Searching for %s", resourceType)
@@ -117,7 +117,7 @@ func (h FHIRSearchOperationHandler[T]) searchAndFilter(ctx context.Context, quer
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRResourceType, resourceType),
+			attribute.String(observability.FHIRResourceType, resourceType),
 		),
 	)
 	defer span.End()
@@ -169,7 +169,7 @@ func searchResources[T any](ctx context.Context, fhirClientFactory FHIRClientFac
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRResourceType, resourceType),
+			attribute.String(observability.FHIRResourceType, resourceType),
 		),
 	)
 	defer span.End()

--- a/orchestrator/careplanservice/operation_update.go
+++ b/orchestrator/careplanservice/operation_update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/SanteonNL/orca/orchestrator/cmd/profile"
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
 	"github.com/SanteonNL/orca/orchestrator/lib/debug"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/observability"
 	"github.com/SanteonNL/orca/orchestrator/lib/to"
 	"github.com/rs/zerolog/log"
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
@@ -40,8 +40,8 @@ func (h FHIRUpdateOperationHandler[T]) Handle(ctx context.Context, request FHIRH
 
 	resourceType := getResourceType(request.ResourcePath)
 	span.SetAttributes(
-		attribute.String(lib_otel.FHIRResourceType, resourceType),
-		attribute.String(lib_otel.OperationName, "Update"),
+		attribute.String(observability.FHIRResourceType, resourceType),
+		attribute.String(observability.OperationName, "Update"),
 	)
 
 	var resource T
@@ -53,7 +53,7 @@ func (h FHIRUpdateOperationHandler[T]) Handle(ctx context.Context, request FHIRH
 
 	resourceID := coolfhir.ResourceID(resource)
 	if resourceID != nil {
-		span.SetAttributes(attribute.String(lib_otel.FHIRResourceID, *resourceID))
+		span.SetAttributes(attribute.String(observability.FHIRResourceID, *resourceID))
 	}
 
 	// Check we're only allowing secure external literal references

--- a/orchestrator/careplanservice/subscriptions/manager.go
+++ b/orchestrator/careplanservice/subscriptions/manager.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"github.com/SanteonNL/orca/orchestrator/cmd/tenants"
 	"github.com/SanteonNL/orca/orchestrator/lib/debug"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/observability"
 	"github.com/SanteonNL/orca/orchestrator/messaging"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -104,7 +104,7 @@ func (r RetryableManager) Notify(ctx context.Context, resource interface{}) erro
 			Type:      to.Ptr("Task"),
 		}
 
-		span.SetAttributes(attribute.String(lib_otel.FHIRResourceID, *task.Id))
+		span.SetAttributes(attribute.String(observability.FHIRResourceID, *task.Id))
 
 		if task.Owner != nil {
 			if coolfhir.IsLogicalIdentifier(task.Owner.Identifier) {
@@ -124,7 +124,7 @@ func (r RetryableManager) Notify(ctx context.Context, resource interface{}) erro
 			Type:      to.Ptr("CareTeam"),
 		}
 
-		span.SetAttributes(attribute.String(lib_otel.FHIRResourceID, *careTeam.Id))
+		span.SetAttributes(attribute.String(observability.FHIRResourceID, *careTeam.Id))
 
 		for _, participant := range careTeam.Participant {
 			if coolfhir.IsLogicalIdentifier(participant.Member.Identifier) {
@@ -138,7 +138,7 @@ func (r RetryableManager) Notify(ctx context.Context, resource interface{}) erro
 			Type:      to.Ptr("CarePlan"),
 		}
 
-		span.SetAttributes(attribute.String(lib_otel.FHIRResourceID, *carePlan.Id))
+		span.SetAttributes(attribute.String(observability.FHIRResourceID, *carePlan.Id))
 
 		careTeam, err := coolfhir.CareTeamFromCarePlan(carePlan)
 		if err != nil {

--- a/orchestrator/cmd/config.go
+++ b/orchestrator/cmd/config.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"errors"
 	"fmt"
-	"github.com/SanteonNL/orca/orchestrator/lib/otel"
 	"github.com/SanteonNL/orca/orchestrator/cmd/tenants"
+	"github.com/SanteonNL/orca/orchestrator/lib/observability"
 	"github.com/SanteonNL/orca/orchestrator/messaging"
 	"github.com/rs/zerolog"
 
@@ -32,7 +32,7 @@ type Config struct {
 	LogLevel        zerolog.Level          `koanf:"loglevel"`
 	StrictMode      bool                   `koanf:"strictmode"`
 	// OpenTelemetry holds the configuration for observability
-	OpenTelemetry otel.Config `koanf:"opentelemetry"`
+	OpenTelemetry observability.Config `koanf:"opentelemetry"`
 }
 
 func (c Config) Validate() error {
@@ -131,6 +131,6 @@ func DefaultConfig() Config {
 		},
 		CarePlanContributor: careplancontributor.DefaultConfig(),
 		CarePlanService:     careplanservice.DefaultConfig(),
-		OpenTelemetry:       otel.DefaultConfig(),
+		OpenTelemetry:       observability.DefaultConfig(),
 	}
 }

--- a/orchestrator/cmd/server.go
+++ b/orchestrator/cmd/server.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor/applaunch/session"
 	"github.com/SanteonNL/orca/orchestrator/events"
-	"github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/observability"
 	"github.com/rs/zerolog/log"
 	"net/http"
 	"os"
@@ -37,7 +37,7 @@ func Start(ctx context.Context, config Config) error {
 		Str("exporter_type", config.OpenTelemetry.Exporter.Type).
 		Msg("Initializing OpenTelemetry")
 
-	tracerProvider, err := otel.Initialize(ctx, config.OpenTelemetry)
+	tracerProvider, err := observability.Initialize(ctx, config.OpenTelemetry)
 	if err != nil {
 		return fmt.Errorf("failed to initialize OpenTelemetry: %w", err)
 	}

--- a/orchestrator/cmd/server_test.go
+++ b/orchestrator/cmd/server_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"github.com/SanteonNL/orca/orchestrator/cmd/tenants"
 	"github.com/SanteonNL/orca/orchestrator/globals"
-	"github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/observability"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	otelapi "go.opentelemetry.io/otel"
@@ -274,17 +274,17 @@ func TestStart_OpenTelemetry(t *testing.T) {
 
 func TestOpenTelemetryInitialization(t *testing.T) {
 	t.Run("successful initialization and cleanup", func(t *testing.T) {
-		config := otel.Config{
+		config := observability.Config{
 			Enabled:        true,
 			ServiceName:    "test-service",
 			ServiceVersion: "1.0.0",
-			Exporter: otel.ExporterConfig{
+			Exporter: observability.ExporterConfig{
 				Type: "stdout",
 			},
 		}
 
 		ctx := context.Background()
-		provider, err := otel.Initialize(ctx, config)
+		provider, err := observability.Initialize(ctx, config)
 		require.NoError(t, err)
 		require.NotNil(t, provider)
 
@@ -304,16 +304,16 @@ func TestOpenTelemetryInitialization(t *testing.T) {
 	})
 
 	t.Run("initialization failure", func(t *testing.T) {
-		config := otel.Config{
+		config := observability.Config{
 			Enabled:     true,
 			ServiceName: "test-service",
-			Exporter: otel.ExporterConfig{
+			Exporter: observability.ExporterConfig{
 				Type: "invalid-type",
 			},
 		}
 
 		ctx := context.Background()
-		provider, err := otel.Initialize(ctx, config)
+		provider, err := observability.Initialize(ctx, config)
 		assert.Error(t, err)
 		assert.Nil(t, provider)
 		assert.Contains(t, err.Error(), "unsupported exporter type")

--- a/orchestrator/lib/coolfhir/azure.go
+++ b/orchestrator/lib/coolfhir/azure.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	fhirclient "github.com/SanteonNL/go-fhir-client"
 	"github.com/SanteonNL/orca/orchestrator/lib/must"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/observability"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -136,7 +136,7 @@ func NewAuthRoundTripper(config ClientConfig, fhirClientConfig *fhirclient.Confi
 			otelhttp.WithSpanOptions(
 				trace.WithSpanKind(trace.SpanKindClient),
 				trace.WithAttributes(
-					attribute.String(lib_otel.FHIRBaseURL, fhirURL.String()),
+					attribute.String(observability.FHIRBaseURL, fhirURL.String()),
 					attribute.String("fhir.auth_type", string(config.Auth.Type)),
 					attribute.String("service.component", "fhir-client"),
 				),
@@ -160,7 +160,7 @@ func NewAuthRoundTripper(config ClientConfig, fhirClientConfig *fhirclient.Confi
 			otelhttp.WithSpanOptions(
 				trace.WithSpanKind(trace.SpanKindClient),
 				trace.WithAttributes(
-					attribute.String(lib_otel.FHIRBaseURL, fhirURL.String()),
+					attribute.String(observability.FHIRBaseURL, fhirURL.String()),
 					attribute.String("fhir.auth_type", string(config.Auth.Type)),
 					attribute.String("service.component", "fhir-client"),
 				),

--- a/orchestrator/lib/coolfhir/traced_fhir_client.go
+++ b/orchestrator/lib/coolfhir/traced_fhir_client.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	fhirclient "github.com/SanteonNL/go-fhir-client"
 	"github.com/SanteonNL/orca/orchestrator/lib/debug"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/observability"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -29,7 +29,7 @@ func (t *TracedFHIRClient) CreateWithContext(ctx context.Context, resource inter
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
 			attribute.String("fhir.operation", "create"),
-			attribute.String(lib_otel.FHIRResourceType, ResourceType(resource)),
+			attribute.String(observability.FHIRResourceType, ResourceType(resource)),
 		),
 	)
 	defer span.End()
@@ -79,7 +79,7 @@ func (t *TracedFHIRClient) UpdateWithContext(ctx context.Context, path string, r
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
 			attribute.String("fhir.operation", "update"),
-			attribute.String(lib_otel.FHIRResourceType, ResourceType(resource)),
+			attribute.String(observability.FHIRResourceType, ResourceType(resource)),
 		),
 	)
 	defer span.End()
@@ -129,7 +129,7 @@ func (t *TracedFHIRClient) SearchWithContext(ctx context.Context, resourceType s
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
 			attribute.String("fhir.operation", "search"),
-			attribute.String(lib_otel.FHIRResourceType, resourceType),
+			attribute.String(observability.FHIRResourceType, resourceType),
 			attribute.Int("fhir.search.param_count", len(params)),
 		),
 	)

--- a/orchestrator/lib/coolfhir/traced_http_transport.go
+++ b/orchestrator/lib/coolfhir/traced_http_transport.go
@@ -3,7 +3,7 @@ package coolfhir
 import (
 	"fmt"
 	"github.com/SanteonNL/orca/orchestrator/lib/debug"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/observability"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -32,8 +32,8 @@ func (t *TracedHTTPTransport) RoundTrip(req *http.Request) (*http.Response, erro
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String(lib_otel.HTTPMethod, req.Method),
-			attribute.String(lib_otel.HTTPURL, req.URL.String()),
+			attribute.String(observability.HTTPMethod, req.Method),
+			attribute.String(observability.HTTPURL, req.URL.String()),
 			attribute.String("http.scheme", req.URL.Scheme),
 			attribute.String("http.host", req.URL.Host),
 			attribute.String("http.target", req.URL.Path),

--- a/orchestrator/lib/observability/attributes.go
+++ b/orchestrator/lib/observability/attributes.go
@@ -1,4 +1,4 @@
-package otel
+package observability
 
 // TraceAttributes contains standardized attribute keys for OpenTelemetry tracing
 type TraceAttributes struct{}

--- a/orchestrator/lib/observability/config.go
+++ b/orchestrator/lib/observability/config.go
@@ -1,4 +1,4 @@
-package otel
+package observability
 
 import (
 	"context"

--- a/orchestrator/lib/observability/config_test.go
+++ b/orchestrator/lib/observability/config_test.go
@@ -1,4 +1,4 @@
-package otel
+package observability
 
 import (
 	"context"

--- a/orchestrator/lib/observability/tracing_middleware.go
+++ b/orchestrator/lib/observability/tracing_middleware.go
@@ -1,4 +1,4 @@
-package otel
+package observability
 
 import (
 	"go.opentelemetry.io/otel/codes"


### PR DESCRIPTION
Change package name for ease of import, and expanded scope in the future for logging enhancements.

`otel` was conflicting with the official otel package name as well