### PR TITLE
[DEV] Refactor otel_lib package usage

### DIFF
--- a/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
+++ b/orchestrator/careplancontributor/applaunch/zorgplatform/service.go
@@ -18,8 +18,8 @@ import (
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor/applaunch/session"
 	"github.com/SanteonNL/orca/orchestrator/cmd/tenants"
 	"github.com/SanteonNL/orca/orchestrator/lib/debug"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
-	"go.opentelemetry.io/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/otel"
+	baseotel "go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -50,7 +50,7 @@ const zorgplatformWorkflowIdSystem = "http://sts.zorgplatform.online/ws/claims/2
 const accessTokenCacheTTL = time.Minute * 5
 
 var sleep = time.Sleep
-var tracer = otel.Tracer("zorgplatform")
+var tracer = baseotel.Tracer("zorgplatform")
 
 type workflowContext struct {
 	workflowId string
@@ -292,8 +292,8 @@ func (s *stsAccessTokenRoundTripper) RoundTrip(httpRequest *http.Request) (*http
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String(lib_otel.HTTPMethod, httpRequest.Method),
-			attribute.String(lib_otel.HTTPURL, httpRequest.URL.String()),
+			attribute.String(otel.HTTPMethod, httpRequest.Method),
+			attribute.String(otel.HTTPURL, httpRequest.URL.String()),
 		),
 	)
 	defer span.End()
@@ -391,8 +391,8 @@ func (s *Service) handleLaunch(response http.ResponseWriter, request *http.Reque
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String(lib_otel.HTTPMethod, request.Method),
-			attribute.String(lib_otel.HTTPURL, request.URL.String()),
+			attribute.String(otel.HTTPMethod, request.Method),
+			attribute.String(otel.HTTPURL, request.URL.String()),
 		),
 	)
 	defer span.End()

--- a/orchestrator/careplancontributor/batch.go
+++ b/orchestrator/careplancontributor/batch.go
@@ -7,7 +7,7 @@ import (
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
 	"github.com/SanteonNL/orca/orchestrator/lib/debug"
 	"github.com/SanteonNL/orca/orchestrator/lib/must"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/otel"
 	"github.com/SanteonNL/orca/orchestrator/lib/to"
 	"github.com/rs/zerolog/log"
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
@@ -33,10 +33,10 @@ func (s *Service) handleBatch(httpRequest *http.Request, requestBundle fhir.Bund
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String(lib_otel.HTTPMethod, httpRequest.Method),
-			attribute.String(lib_otel.HTTPURL, httpRequest.URL.String()),
-			attribute.String(lib_otel.FHIRBundleType, requestBundle.Type.String()),
-			attribute.Int(lib_otel.FHIRBundleEntryCount, len(requestBundle.Entry)),
+			attribute.String(otel.HTTPMethod, httpRequest.Method),
+			attribute.String(otel.HTTPURL, httpRequest.URL.String()),
+			attribute.String(otel.FHIRBundleType, requestBundle.Type.String()),
+			attribute.Int(otel.FHIRBundleEntryCount, len(requestBundle.Entry)),
 		),
 	)
 	defer span.End()

--- a/orchestrator/careplancontributor/ehr/notification_bundle.go
+++ b/orchestrator/careplancontributor/ehr/notification_bundle.go
@@ -7,12 +7,12 @@ import (
 	fhirclient "github.com/SanteonNL/go-fhir-client"
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
 	"github.com/SanteonNL/orca/orchestrator/lib/debug"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/otel"
 	"github.com/SanteonNL/orca/orchestrator/lib/to"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
-	"go.opentelemetry.io/otel"
+	baseotel "go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -22,7 +22,7 @@ import (
 	"strings"
 )
 
-var tracer = otel.Tracer("careplancontributor.ehr")
+var tracer = baseotel.Tracer("careplancontributor.ehr")
 
 // BundleSet represents a collection of FHIR bundles associated with a specific task, identified by an ID.
 type BundleSet struct {
@@ -42,7 +42,7 @@ func TaskNotificationBundleSet(ctx context.Context, cpsClient fhirclient.Client,
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRTaskID, taskId),
+			attribute.String(otel.FHIRTaskID, taskId),
 		),
 	)
 	defer span.End()
@@ -117,8 +117,8 @@ func TaskNotificationBundleSet(ctx context.Context, cpsClient fhirclient.Client,
 	bundles.addBundle(*questionnaireResponseBundles...)
 
 	span.SetAttributes(
-		attribute.Int(lib_otel.FHIRBundlesCount, len(bundles.Bundles)),
-		attribute.String(lib_otel.FHIRBundleSetId, bundles.Id),
+		attribute.Int(otel.FHIRBundlesCount, len(bundles.Bundles)),
+		attribute.String(otel.FHIRBundleSetId, bundles.Id),
 	)
 
 	return &bundles, nil
@@ -130,7 +130,7 @@ func fetchTasks(ctx context.Context, cpsClient fhirclient.Client, taskId string)
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRTaskID, taskId),
+			attribute.String(otel.FHIRTaskID, taskId),
 		),
 	)
 	defer span.End()
@@ -161,8 +161,8 @@ func fetchTasks(ctx context.Context, cpsClient fhirclient.Client, taskId string)
 	}
 
 	span.SetAttributes(
-		attribute.Int(lib_otel.FHIRTasksCount, len(tasks)),
-		attribute.Int(lib_otel.FHIRBundleEntryCount, len(taskBundle.Entry)),
+		attribute.Int(otel.FHIRTasksCount, len(tasks)),
+		attribute.Int(otel.FHIRBundleEntryCount, len(taskBundle.Entry)),
 	)
 
 	return &taskBundle, tasks, nil
@@ -174,7 +174,7 @@ func fetchCarePlan(ctx context.Context, cpsClient fhirclient.Client, tasks []fhi
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
-			attribute.Int(lib_otel.FHIRTasksCount, len(tasks)),
+			attribute.Int(otel.FHIRTasksCount, len(tasks)),
 		),
 	)
 	defer span.End()
@@ -235,7 +235,7 @@ func fetchServiceRequest(ctx context.Context, cpsClient fhirclient.Client, tasks
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
-			attribute.Int(lib_otel.FHIRTasksCount, len(tasks)),
+			attribute.Int(otel.FHIRTasksCount, len(tasks)),
 		),
 	)
 	defer span.End()
@@ -267,7 +267,7 @@ func fetchQuestionnaires(ctx context.Context, cpsClient fhirclient.Client, tasks
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
-			attribute.Int(lib_otel.FHIRTasksCount, len(tasks)),
+			attribute.Int(otel.FHIRTasksCount, len(tasks)),
 		),
 	)
 	defer span.End()
@@ -290,7 +290,7 @@ func fetchQuestionnaireResponses(ctx context.Context, cpsClient fhirclient.Clien
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
-			attribute.Int(lib_otel.FHIRTasksCount, len(tasks)),
+			attribute.Int(otel.FHIRTasksCount, len(tasks)),
 		),
 	)
 	defer span.End()
@@ -361,7 +361,7 @@ func fetchRef(ctx context.Context, cpsClient fhirclient.Client, ref string) (*fh
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRResourceReference, ref),
+			attribute.String(otel.FHIRResourceReference, ref),
 		),
 	)
 	defer span.End()

--- a/orchestrator/careplancontributor/ehr/notifier.go
+++ b/orchestrator/careplancontributor/ehr/notifier.go
@@ -9,7 +9,7 @@ import (
 	"github.com/SanteonNL/orca/orchestrator/cmd/tenants"
 	"github.com/SanteonNL/orca/orchestrator/events"
 	"github.com/SanteonNL/orca/orchestrator/lib/debug"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/otel"
 	"github.com/SanteonNL/orca/orchestrator/messaging"
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
@@ -74,9 +74,9 @@ func (n *notifier) NotifyTaskAccepted(ctx context.Context, fhirBaseURL string, t
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRBaseURL, fhirBaseURL),
-			attribute.String(lib_otel.FHIRTaskID, *task.Id),
-			attribute.String(lib_otel.FHIRTaskStatus, task.Status.Code()),
+			attribute.String(otel.FHIRBaseURL, fhirBaseURL),
+			attribute.String(otel.FHIRTaskID, *task.Id),
+			attribute.String(otel.FHIRTaskStatus, task.Status.Code()),
 		),
 	)
 	defer span.End()
@@ -106,9 +106,9 @@ func (n *notifier) processTaskAcceptedEvent(ctx context.Context, event *TaskAcce
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRBaseURL, event.FHIRBaseURL),
-			attribute.String(lib_otel.FHIRTaskID, *event.Task.Id),
-			attribute.String(lib_otel.FHIRTaskStatus, event.Task.Status.Code()),
+			attribute.String(otel.FHIRBaseURL, event.FHIRBaseURL),
+			attribute.String(otel.FHIRTaskID, *event.Task.Id),
+			attribute.String(otel.FHIRTaskStatus, event.Task.Status.Code()),
 		),
 	)
 	defer span.End()
@@ -189,9 +189,9 @@ func sendBundle(ctx context.Context, taskAcceptedBundleEndpoint string, set Bund
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindProducer),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRBundleSetId, set.Id),
+			attribute.String(otel.FHIRBundleSetId, set.Id),
 			attribute.String("bundle_set.task", set.task),
-			attribute.Int(lib_otel.FHIRBundlesCount, len(set.Bundles)),
+			attribute.Int(otel.FHIRBundlesCount, len(set.Bundles)),
 		),
 	)
 	defer span.End()

--- a/orchestrator/careplancontributor/handle_taskfiller.go
+++ b/orchestrator/careplancontributor/handle_taskfiller.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"github.com/SanteonNL/orca/orchestrator/cmd/tenants"
 	"github.com/SanteonNL/orca/orchestrator/lib/debug"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/otel"
 	"github.com/SanteonNL/orca/orchestrator/lib/slices"
 	"strings"
 
@@ -59,8 +59,8 @@ func (s *Service) handleTaskNotification(ctx context.Context, cpsClient fhirclie
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRTaskID, to.Value(task.Id)),
-			attribute.String(lib_otel.FHIRTaskStatus, task.Status.Code()),
+			attribute.String(otel.FHIRTaskID, to.Value(task.Id)),
+			attribute.String(otel.FHIRTaskStatus, task.Status.Code()),
 		),
 	)
 	defer span.End()
@@ -157,8 +157,8 @@ func (s *Service) handleSubtaskNotification(ctx context.Context, cpsClient fhirc
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRTaskID, to.Value(task.Id)),
-			attribute.String(lib_otel.FHIRTaskStatus, task.Status.Code()),
+			attribute.String(otel.FHIRTaskID, to.Value(task.Id)),
+			attribute.String(otel.FHIRTaskStatus, task.Status.Code()),
 			attribute.String("fhir.primary_task_ref", primaryTaskRef),
 		),
 	)
@@ -211,8 +211,8 @@ func (s *Service) acceptPrimaryTask(ctx context.Context, cpsClient fhirclient.Cl
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRTaskID, to.Value(primaryTask.Id)),
-			attribute.String(lib_otel.FHIRTaskStatus, primaryTask.Status.Code()),
+			attribute.String(otel.FHIRTaskID, to.Value(primaryTask.Id)),
+			attribute.String(otel.FHIRTaskStatus, primaryTask.Status.Code()),
 		),
 	)
 	defer span.End()
@@ -307,7 +307,7 @@ func (s *Service) createSubTaskOrAcceptPrimaryTask(ctx context.Context, cpsClien
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRTaskID, to.Value(task.Id)),
+			attribute.String(otel.FHIRTaskID, to.Value(task.Id)),
 			attribute.String("fhir.primary_task_id", to.Value(primaryTask.Id)),
 		),
 	)
@@ -467,7 +467,7 @@ func (s *Service) selectWorkflow(ctx context.Context, cpsClient fhirclient.Clien
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRTaskID, to.Value(task.Id)),
+			attribute.String(otel.FHIRTaskID, to.Value(task.Id)),
 			attribute.String("fhir.task_focus_reference", to.Value(task.Focus.Reference)),
 		),
 	)

--- a/orchestrator/careplancontributor/handle_taskfiller_test.go
+++ b/orchestrator/careplancontributor/handle_taskfiller_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
-	"go.opentelemetry.io/otel"
+	baseotel "go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.uber.org/mock/gomock"
@@ -42,15 +42,15 @@ func TestService_handleTaskFillerCreate(t *testing.T) {
 	var capturedTask fhir.Task
 
 	// Set up trace mocking
-	originalTP := otel.GetTracerProvider()
+	originalTP := baseotel.GetTracerProvider()
 	exporter := tracetest.NewInMemoryExporter()
 	tp := trace.NewTracerProvider(
 		trace.WithSyncer(exporter),
 	)
-	otel.SetTracerProvider(tp)
+	baseotel.SetTracerProvider(tp)
 	t.Cleanup(func() {
 		tp.Shutdown(context.Background())
-		otel.SetTracerProvider(originalTP)
+		baseotel.SetTracerProvider(originalTP)
 	})
 
 	// Helper function to assert spans are created

--- a/orchestrator/careplancontributor/integration_test.go
+++ b/orchestrator/careplancontributor/integration_test.go
@@ -5,7 +5,7 @@ import (
 	"github.com/SanteonNL/orca/orchestrator/cmd/tenants"
 	events "github.com/SanteonNL/orca/orchestrator/events"
 	"github.com/SanteonNL/orca/orchestrator/lib/must"
-	"go.opentelemetry.io/otel"
+	baseotel "go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"net/http"
@@ -31,16 +31,16 @@ import (
 )
 
 func Test_Integration_CPCFHIRProxy(t *testing.T) {
-	originalTP := otel.GetTracerProvider()
+	originalTP := baseotel.GetTracerProvider()
 	// Set up trace mocking
 	exporter := tracetest.NewInMemoryExporter()
 	tp := trace.NewTracerProvider(
 		trace.WithSyncer(exporter),
 	)
-	otel.SetTracerProvider(tp)
+	baseotel.SetTracerProvider(tp)
 	t.Cleanup(func() {
 		tp.Shutdown(context.Background())
-		otel.SetTracerProvider(originalTP)
+		baseotel.SetTracerProvider(originalTP)
 	})
 
 	notificationEndpoint := setupNotificationEndpoint(t)

--- a/orchestrator/careplancontributor/taskengine/workflow.go
+++ b/orchestrator/careplancontributor/taskengine/workflow.go
@@ -13,7 +13,7 @@ import (
 	fhirclient "github.com/SanteonNL/go-fhir-client"
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
-	"go.opentelemetry.io/otel"
+	baseotel "go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -21,7 +21,7 @@ import (
 
 var ErrWorkflowNotFound = errors.New("workflow not found")
 
-var tracer = otel.Tracer("careplancontributor")
+var tracer = baseotel.Tracer("careplancontributor")
 
 // WorkflowProvider provides workflows (a set of questionnaires required for accepting a Task) to the Task Filler.
 type WorkflowProvider interface {

--- a/orchestrator/careplanservice/handle_createtask.go
+++ b/orchestrator/careplanservice/handle_createtask.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/SanteonNL/orca/orchestrator/lib/debug"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/otel"
 	"net/http"
 	"strings"
 
@@ -30,7 +30,7 @@ func (s *Service) handleCreateTask(ctx context.Context, request FHIRHandlerReque
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRResourceType, "Task"),
+			attribute.String(otel.FHIRResourceType, "Task"),
 		),
 	)
 	defer span.End()
@@ -314,7 +314,7 @@ func (s *Service) handleCreateTask(ctx context.Context, request FHIRHandlerReque
 
 		// Different validation logic for an SCP subtask
 		if len(task.PartOf) > 0 {
-			span.SetAttributes(attribute.String(lib_otel.FHIRTaskType, "subtask"))
+			span.SetAttributes(attribute.String(otel.FHIRTaskType, "subtask"))
 
 			if len(task.PartOf) != 1 {
 				err := coolfhir.NewErrorWithCode("SCP subtask must have exactly one parent task", http.StatusBadRequest)
@@ -352,7 +352,7 @@ func (s *Service) handleCreateTask(ctx context.Context, request FHIRHandlerReque
 				return nil, err
 			}
 		} else {
-			span.SetAttributes(attribute.String(lib_otel.FHIRTaskType, "primary"))
+			span.SetAttributes(attribute.String(otel.FHIRTaskType, "primary"))
 
 			careTeam, err := coolfhir.CareTeamFromCarePlan(&carePlan)
 			if err != nil {

--- a/orchestrator/careplanservice/handle_updatetask.go
+++ b/orchestrator/careplanservice/handle_updatetask.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/SanteonNL/orca/orchestrator/lib/debug"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/otel"
 	"strings"
 
 	fhirclient "github.com/SanteonNL/go-fhir-client"
@@ -28,7 +28,7 @@ func (s *Service) handleUpdateTask(ctx context.Context, request FHIRHandlerReque
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRResourceType, "Task"),
+			attribute.String(otel.FHIRResourceType, "Task"),
 		),
 	)
 	defer span.End()
@@ -114,7 +114,7 @@ func (s *Service) handleUpdateTask(ctx context.Context, request FHIRHandlerReque
 		// Direct ID lookup
 		span.SetAttributes(
 			attribute.String("fhir.task.lookup_method", "id"),
-			attribute.String(lib_otel.FHIRTaskID, request.ResourceId),
+			attribute.String(otel.FHIRTaskID, request.ResourceId),
 		)
 
 		if (task.Id != nil && request.ResourceId != "") && request.ResourceId != *task.Id {

--- a/orchestrator/careplanservice/integration_test.go
+++ b/orchestrator/careplanservice/integration_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/SanteonNL/orca/orchestrator/cmd/tenants"
 	events "github.com/SanteonNL/orca/orchestrator/events"
 	"github.com/SanteonNL/orca/orchestrator/messaging"
-	"go.opentelemetry.io/otel"
+	baseotel "go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"io"
@@ -53,16 +53,16 @@ func Test_Integration(t *testing.T) {
 	t.Log("This test creates a new CarePlan and Task, then runs the Task through requested->accepted->completed lifecycle.")
 
 	// Set up trace mocking
-	originalTP := otel.GetTracerProvider()
+	originalTP := baseotel.GetTracerProvider()
 	exporter := tracetest.NewInMemoryExporter()
 	tp := trace.NewTracerProvider(
 		trace.WithSyncer(exporter),
 	)
 
-	otel.SetTracerProvider(tp)
+	baseotel.SetTracerProvider(tp)
 	t.Cleanup(func() {
 		tp.Shutdown(context.Background())
-		otel.SetTracerProvider(originalTP)
+		baseotel.SetTracerProvider(originalTP)
 	})
 
 	var cpc1Notifications []coolfhir.SubscriptionNotification

--- a/orchestrator/careplanservice/operation_read.go
+++ b/orchestrator/careplanservice/operation_read.go
@@ -8,7 +8,7 @@ import (
 	"github.com/SanteonNL/orca/orchestrator/lib/audit"
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
 	"github.com/SanteonNL/orca/orchestrator/lib/debug"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/otel"
 	"github.com/SanteonNL/orca/orchestrator/lib/to"
 	"github.com/rs/zerolog/log"
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
@@ -36,9 +36,9 @@ func (h FHIRReadOperationHandler[T]) Handle(ctx context.Context, request FHIRHan
 
 	resourceType := getResourceType(request.ResourcePath)
 	span.SetAttributes(
-		attribute.String(lib_otel.FHIRResourceType, resourceType),
-		attribute.String(lib_otel.FHIRResourceID, request.ResourceId),
-		attribute.String(lib_otel.OperationName, "Read"),
+		attribute.String(otel.FHIRResourceType, resourceType),
+		attribute.String(otel.FHIRResourceID, request.ResourceId),
+		attribute.String(otel.OperationName, "Read"),
 	)
 
 	var resource T

--- a/orchestrator/careplanservice/operation_search.go
+++ b/orchestrator/careplanservice/operation_search.go
@@ -9,7 +9,7 @@ import (
 	"github.com/SanteonNL/orca/orchestrator/lib/auth"
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
 	"github.com/SanteonNL/orca/orchestrator/lib/debug"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/otel"
 	"github.com/SanteonNL/orca/orchestrator/lib/to"
 	"github.com/rs/zerolog/log"
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
@@ -38,8 +38,8 @@ func (h FHIRSearchOperationHandler[T]) Handle(ctx context.Context, request FHIRH
 
 	resourceType := getResourceType(request.ResourcePath)
 	span.SetAttributes(
-		attribute.String(lib_otel.FHIRResourceType, resourceType),
-		attribute.String(lib_otel.OperationName, "Search"),
+		attribute.String(otel.FHIRResourceType, resourceType),
+		attribute.String(otel.OperationName, "Search"),
 	)
 
 	log.Ctx(ctx).Info().Msgf("Searching for %s", resourceType)
@@ -117,7 +117,7 @@ func (h FHIRSearchOperationHandler[T]) searchAndFilter(ctx context.Context, quer
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindInternal),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRResourceType, resourceType),
+			attribute.String(otel.FHIRResourceType, resourceType),
 		),
 	)
 	defer span.End()
@@ -169,7 +169,7 @@ func searchResources[T any](ctx context.Context, fhirClientFactory FHIRClientFac
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRResourceType, resourceType),
+			attribute.String(otel.FHIRResourceType, resourceType),
 		),
 	)
 	defer span.End()

--- a/orchestrator/careplanservice/operation_update.go
+++ b/orchestrator/careplanservice/operation_update.go
@@ -8,7 +8,7 @@ import (
 	"github.com/SanteonNL/orca/orchestrator/cmd/profile"
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
 	"github.com/SanteonNL/orca/orchestrator/lib/debug"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/otel"
 	"github.com/SanteonNL/orca/orchestrator/lib/to"
 	"github.com/rs/zerolog/log"
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
@@ -40,8 +40,8 @@ func (h FHIRUpdateOperationHandler[T]) Handle(ctx context.Context, request FHIRH
 
 	resourceType := getResourceType(request.ResourcePath)
 	span.SetAttributes(
-		attribute.String(lib_otel.FHIRResourceType, resourceType),
-		attribute.String(lib_otel.OperationName, "Update"),
+		attribute.String(otel.FHIRResourceType, resourceType),
+		attribute.String(otel.OperationName, "Update"),
 	)
 
 	var resource T
@@ -53,7 +53,7 @@ func (h FHIRUpdateOperationHandler[T]) Handle(ctx context.Context, request FHIRH
 
 	resourceID := coolfhir.ResourceID(resource)
 	if resourceID != nil {
-		span.SetAttributes(attribute.String(lib_otel.FHIRResourceID, *resourceID))
+		span.SetAttributes(attribute.String(otel.FHIRResourceID, *resourceID))
 	}
 
 	// Check we're only allowing secure external literal references

--- a/orchestrator/careplanservice/service.go
+++ b/orchestrator/careplanservice/service.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/SanteonNL/orca/orchestrator/cmd/tenants"
 	"github.com/SanteonNL/orca/orchestrator/lib/debug"
-	"go.opentelemetry.io/otel"
+	baseotel "go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -36,7 +36,7 @@ import (
 	"github.com/SanteonNL/orca/orchestrator/careplanservice/subscriptions"
 	"github.com/SanteonNL/orca/orchestrator/cmd/profile"
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/otel"
 	"github.com/rs/zerolog/log"
 	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
 )
@@ -47,7 +47,7 @@ type FHIROperation interface {
 	Handle(context.Context, FHIRHandlerRequest, *coolfhir.BundleBuilder) (FHIRHandlerResult, error)
 }
 
-var tracer = otel.Tracer("careplanservice")
+var tracer = baseotel.Tracer("careplanservice")
 
 func TracedHandlerWrapper(operationName string, handler func(context.Context, FHIRHandlerRequest, *coolfhir.BundleBuilder) (FHIRHandlerResult, error),
 ) func(context.Context, FHIRHandlerRequest, *coolfhir.BundleBuilder) (FHIRHandlerResult, error) {
@@ -57,15 +57,15 @@ func TracedHandlerWrapper(operationName string, handler func(context.Context, FH
 			operationName,
 			trace.WithSpanKind(trace.SpanKindServer),
 			trace.WithAttributes(
-				attribute.String(lib_otel.FHIRResourceType, getResourceType(request.ResourcePath)),
-				attribute.String(lib_otel.FHIRResourceID, request.ResourceId),
-				attribute.String(lib_otel.HTTPMethod, request.HttpMethod),
+				attribute.String(otel.FHIRResourceType, getResourceType(request.ResourcePath)),
+				attribute.String(otel.FHIRResourceID, request.ResourceId),
+				attribute.String(otel.HTTPMethod, request.HttpMethod),
 			),
 		)
 		defer span.End()
 
 		if request.Tenant.ID != "" {
-			span.SetAttributes(attribute.String(lib_otel.TenantID, request.Tenant.ID))
+			span.SetAttributes(attribute.String(otel.TenantID, request.Tenant.ID))
 		}
 
 		result, err := handler(ctx, request, tx)
@@ -257,41 +257,41 @@ func (s *Service) RegisterHandlers(mux *http.ServeMux) {
 		coolfhir.SendResponse(httpResponse, http.StatusOK, md)
 	}))
 	// Creating a resource
-	mux.HandleFunc("POST "+basePathWithTenant+"/{type}", lib_otel.HandlerWithTracing(tracer, "CarePlanService/FHIR Create Resource", s.tenants.HttpHandler(s.profile.Authenticator(func(httpResponse http.ResponseWriter, request *http.Request) {
+	mux.HandleFunc("POST "+basePathWithTenant+"/{type}", otel.HandlerWithTracing(tracer, "CarePlanService/FHIR Create Resource", s.tenants.HttpHandler(s.profile.Authenticator(func(httpResponse http.ResponseWriter, request *http.Request) {
 		resourceType := request.PathValue("type")
 		s.handleModification(request, httpResponse, resourceType, "CarePlanService/Create"+resourceType)
 	}))))
 	// Searching for a resource via POST
-	mux.HandleFunc("POST "+basePathWithTenant+"/{type}/_search", lib_otel.HandlerWithTracing(tracer, "CarePlanService/FHIR Search Resource", s.tenants.HttpHandler(s.profile.Authenticator(func(httpResponse http.ResponseWriter, request *http.Request) {
+	mux.HandleFunc("POST "+basePathWithTenant+"/{type}/_search", otel.HandlerWithTracing(tracer, "CarePlanService/FHIR Search Resource", s.tenants.HttpHandler(s.profile.Authenticator(func(httpResponse http.ResponseWriter, request *http.Request) {
 		resourceType := request.PathValue("type")
 		s.handleSearchRequest(request, httpResponse, resourceType, "CarePlanService/Search"+resourceType)
 	}))))
 	// Handle bundle
-	mux.HandleFunc("POST "+basePathWithTenant+"/", lib_otel.HandlerWithTracing(tracer, "CarePlanService/FHIR Create Bundle", s.tenants.HttpHandler(s.profile.Authenticator(func(httpResponse http.ResponseWriter, request *http.Request) {
+	mux.HandleFunc("POST "+basePathWithTenant+"/", otel.HandlerWithTracing(tracer, "CarePlanService/FHIR Create Bundle", s.tenants.HttpHandler(s.profile.Authenticator(func(httpResponse http.ResponseWriter, request *http.Request) {
 		s.handleBundle(request, httpResponse)
 	}))))
-	mux.HandleFunc("POST "+basePathWithTenant, lib_otel.HandlerWithTracing(tracer, "CarePlanService/FHIR Create Bundle", s.tenants.HttpHandler(s.profile.Authenticator(func(httpResponse http.ResponseWriter, request *http.Request) {
+	mux.HandleFunc("POST "+basePathWithTenant, otel.HandlerWithTracing(tracer, "CarePlanService/FHIR Create Bundle", s.tenants.HttpHandler(s.profile.Authenticator(func(httpResponse http.ResponseWriter, request *http.Request) {
 		s.handleBundle(request, httpResponse)
 	}))))
 	// Updating a resource by ID
-	mux.HandleFunc("PUT "+basePathWithTenant+"/{type}/{id}", lib_otel.HandlerWithTracing(tracer, "CarePlanService/FHIR Update Resource", s.tenants.HttpHandler(s.profile.Authenticator(func(httpResponse http.ResponseWriter, request *http.Request) {
+	mux.HandleFunc("PUT "+basePathWithTenant+"/{type}/{id}", otel.HandlerWithTracing(tracer, "CarePlanService/FHIR Update Resource", s.tenants.HttpHandler(s.profile.Authenticator(func(httpResponse http.ResponseWriter, request *http.Request) {
 		resourceType := request.PathValue("type")
 		resourceId := request.PathValue("id")
 		s.handleModification(request, httpResponse, resourceType+"/"+resourceId, "CarePlanService/Update"+resourceType)
 	}))))
 	// Updating a resource by selecting it based on query params
-	mux.HandleFunc("PUT "+basePathWithTenant+"/{type}", lib_otel.HandlerWithTracing(tracer, "CarePlanService/FHIR Update Resource", s.tenants.HttpHandler(s.profile.Authenticator(func(httpResponse http.ResponseWriter, request *http.Request) {
+	mux.HandleFunc("PUT "+basePathWithTenant+"/{type}", otel.HandlerWithTracing(tracer, "CarePlanService/FHIR Update Resource", s.tenants.HttpHandler(s.profile.Authenticator(func(httpResponse http.ResponseWriter, request *http.Request) {
 		resourceType := request.PathValue("type")
 		s.handleModification(request, httpResponse, resourceType, "CarePlanService/Update"+resourceType)
 	}))))
 	// Handle reading a specific resource instance
-	mux.HandleFunc("GET "+basePathWithTenant+"/{type}/{id}", lib_otel.HandlerWithTracing(tracer, "CarePlanService/FHIR Read Resource", s.tenants.HttpHandler(s.profile.Authenticator(func(httpResponse http.ResponseWriter, request *http.Request) {
+	mux.HandleFunc("GET "+basePathWithTenant+"/{type}/{id}", otel.HandlerWithTracing(tracer, "CarePlanService/FHIR Read Resource", s.tenants.HttpHandler(s.profile.Authenticator(func(httpResponse http.ResponseWriter, request *http.Request) {
 		resourceType := request.PathValue("type")
 		resourceId := request.PathValue("id")
 		s.handleGet(request, httpResponse, resourceId, resourceType, "CarePlanService/Get"+resourceType)
 	}))))
 	// Custom operations
-	mux.HandleFunc("POST "+basePathWithTenant+"/$import", lib_otel.HandlerWithTracing(tracer, "CarePlanService/FHIR Import", s.tenants.HttpHandler(s.profile.Authenticator(func(httpResponse http.ResponseWriter, request *http.Request) {
+	mux.HandleFunc("POST "+basePathWithTenant+"/$import", otel.HandlerWithTracing(tracer, "CarePlanService/FHIR Import", s.tenants.HttpHandler(s.profile.Authenticator(func(httpResponse http.ResponseWriter, request *http.Request) {
 		tenant, err := tenants.FromContext(request.Context())
 		if err != nil {
 			coolfhir.WriteOperationOutcomeFromError(request.Context(), err, "CarePlanService/Import", httpResponse)
@@ -318,8 +318,8 @@ func (s *Service) commitTransaction(fhirClient fhirclient.Client, request *http.
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String(lib_otel.FHIRBundleType, tx.Bundle().Type.String()),
-			attribute.Int(lib_otel.FHIRBundleEntryCount, len(tx.Bundle().Entry)),
+			attribute.String(otel.FHIRBundleType, tx.Bundle().Type.String()),
+			attribute.Int(otel.FHIRBundleEntryCount, len(tx.Bundle().Entry)),
 		),
 	)
 	defer span.End()
@@ -371,8 +371,8 @@ func (s *Service) commitTransaction(fhirClient fhirclient.Client, request *http.
 
 	span.SetStatus(codes.Ok, "")
 	span.SetAttributes(
-		attribute.Int(lib_otel.FHIRTransactionResultEntries, len(resultBundle.Entry)),
-		attribute.Int(lib_otel.NotificationResources, len(notificationResources)),
+		attribute.Int(otel.FHIRTransactionResultEntries, len(resultBundle.Entry)),
+		attribute.Int(otel.NotificationResources, len(notificationResources)),
 	)
 
 	return &resultBundle, nil
@@ -481,8 +481,8 @@ func (s *Service) handleModification(httpRequest *http.Request, httpResponse htt
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String(lib_otel.HTTPMethod, httpRequest.Method),
-			attribute.String(lib_otel.FHIRResourceType, resourcePath),
+			attribute.String(otel.HTTPMethod, httpRequest.Method),
+			attribute.String(otel.FHIRResourceType, resourcePath),
 		),
 	)
 	defer span.End()
@@ -559,9 +559,9 @@ func (s *Service) handleGet(httpRequest *http.Request, httpResponse http.Respons
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String(lib_otel.HTTPMethod, httpRequest.Method),
-			attribute.String(lib_otel.FHIRResourceType, resourceType),
-			attribute.String(lib_otel.FHIRResourceID, resourceId),
+			attribute.String(otel.HTTPMethod, httpRequest.Method),
+			attribute.String(otel.FHIRResourceType, resourceType),
+			attribute.String(otel.FHIRResourceID, resourceId),
 		),
 	)
 	defer span.End()
@@ -895,8 +895,8 @@ func (s *Service) handleSearchRequest(httpRequest *http.Request, httpResponse ht
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String(lib_otel.HTTPMethod, httpRequest.Method),
-			attribute.String(lib_otel.FHIRResourceType, resourceType),
+			attribute.String(otel.HTTPMethod, httpRequest.Method),
+			attribute.String(otel.FHIRResourceType, resourceType),
 		),
 	)
 	defer span.End()
@@ -939,7 +939,7 @@ func (s *Service) handleSearchRequest(httpRequest *http.Request, httpResponse ht
 	}
 	queryParams := httpRequest.PostForm
 
-	span.SetAttributes(attribute.Int(lib_otel.FHIRSearchParamCount, len(queryParams)))
+	span.SetAttributes(attribute.Int(otel.FHIRSearchParamCount, len(queryParams)))
 
 	// Set up the transaction and handler request
 	tx := coolfhir.Transaction()
@@ -1003,7 +1003,7 @@ func (s *Service) handleBundle(httpRequest *http.Request, httpResponse http.Resp
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindServer),
 		trace.WithAttributes(
-			attribute.String(lib_otel.HTTPMethod, httpRequest.Method),
+			attribute.String(otel.HTTPMethod, httpRequest.Method),
 		),
 	)
 	defer span.End()
@@ -1020,8 +1020,8 @@ func (s *Service) handleBundle(httpRequest *http.Request, httpResponse http.Resp
 
 	// Add bundle metadata to span
 	span.SetAttributes(
-		attribute.String(lib_otel.FHIRBundleType, bundle.Type.String()),
-		attribute.Int(lib_otel.FHIRBundleEntryCount, len(bundle.Entry)),
+		attribute.String(otel.FHIRBundleType, bundle.Type.String()),
+		attribute.Int(otel.FHIRBundleEntryCount, len(bundle.Entry)),
 	)
 
 	if bundle.Type != fhir.BundleTypeTransaction {
@@ -1141,8 +1141,8 @@ func (s *Service) handleBundle(httpRequest *http.Request, httpResponse http.Resp
 		return
 	}
 	span.SetAttributes(
-		attribute.Int(lib_otel.FHIRBundleResultEntries, len(resultBundle.Entry)),
-		attribute.String(lib_otel.TenantID, tenant.ID),
+		attribute.Int(otel.FHIRBundleResultEntries, len(resultBundle.Entry)),
+		attribute.String(otel.TenantID, tenant.ID),
 	)
 	span.SetStatus(codes.Ok, "")
 	tenant, _ = tenants.FromContext(ctx)
@@ -1178,8 +1178,8 @@ func (s Service) notifySubscribers(ctx context.Context, resource interface{}) {
 	ctx, span := tracer.Start(ctx,
 		debug.GetCallerName(),
 		trace.WithAttributes(
-			attribute.String(lib_otel.NotificationResourceType, coolfhir.ResourceType(resource)),
-			attribute.Bool(lib_otel.NotificationShouldNotify, shouldNotify(resource)),
+			attribute.String(otel.NotificationResourceType, coolfhir.ResourceType(resource)),
+			attribute.Bool(otel.NotificationShouldNotify, shouldNotify(resource)),
 		),
 	)
 	defer span.End()
@@ -1191,16 +1191,16 @@ func (s Service) notifySubscribers(ctx context.Context, resource interface{}) {
 		if err := s.subscriptionManager.Notify(notifyCtx, resource); err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
-			span.SetAttributes(attribute.String(lib_otel.NotificationStatus, "failed"))
+			span.SetAttributes(attribute.String(otel.NotificationStatus, "failed"))
 			log.Ctx(ctx).Error().Err(err).Msgf("Failed to notify subscribers for %T", resource)
 		} else {
 			span.SetAttributes(
-				attribute.String(lib_otel.NotificationStatus, "success"),
+				attribute.String(otel.NotificationStatus, "success"),
 			)
 			span.SetStatus(codes.Ok, "")
 		}
 	} else {
-		span.SetAttributes(attribute.String(lib_otel.NotificationStatus, "skipped"))
+		span.SetAttributes(attribute.String(otel.NotificationStatus, "skipped"))
 		span.SetStatus(codes.Ok, "skipped - resource type not eligible for notification")
 	}
 }

--- a/orchestrator/careplanservice/subscriptions/manager.go
+++ b/orchestrator/careplanservice/subscriptions/manager.go
@@ -8,9 +8,9 @@ import (
 	"fmt"
 	"github.com/SanteonNL/orca/orchestrator/cmd/tenants"
 	"github.com/SanteonNL/orca/orchestrator/lib/debug"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/otel"
 	"github.com/SanteonNL/orca/orchestrator/messaging"
-	"go.opentelemetry.io/otel"
+	baseotel "go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -29,7 +29,7 @@ var SendNotificationQueue = messaging.Entity{
 	Prefix: true,
 }
 
-var tracer = otel.Tracer("careplanservice.subscriptions")
+var tracer = baseotel.Tracer("careplanservice.subscriptions")
 
 var timeFunc = time.Now
 
@@ -104,7 +104,7 @@ func (r RetryableManager) Notify(ctx context.Context, resource interface{}) erro
 			Type:      to.Ptr("Task"),
 		}
 
-		span.SetAttributes(attribute.String(lib_otel.FHIRResourceID, *task.Id))
+		span.SetAttributes(attribute.String(otel.FHIRResourceID, *task.Id))
 
 		if task.Owner != nil {
 			if coolfhir.IsLogicalIdentifier(task.Owner.Identifier) {
@@ -124,7 +124,7 @@ func (r RetryableManager) Notify(ctx context.Context, resource interface{}) erro
 			Type:      to.Ptr("CareTeam"),
 		}
 
-		span.SetAttributes(attribute.String(lib_otel.FHIRResourceID, *careTeam.Id))
+		span.SetAttributes(attribute.String(otel.FHIRResourceID, *careTeam.Id))
 
 		for _, participant := range careTeam.Participant {
 			if coolfhir.IsLogicalIdentifier(participant.Member.Identifier) {
@@ -138,7 +138,7 @@ func (r RetryableManager) Notify(ctx context.Context, resource interface{}) erro
 			Type:      to.Ptr("CarePlan"),
 		}
 
-		span.SetAttributes(attribute.String(lib_otel.FHIRResourceID, *carePlan.Id))
+		span.SetAttributes(attribute.String(otel.FHIRResourceID, *carePlan.Id))
 
 		careTeam, err := coolfhir.CareTeamFromCarePlan(carePlan)
 		if err != nil {

--- a/orchestrator/cmd/server_test.go
+++ b/orchestrator/cmd/server_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/SanteonNL/orca/orchestrator/lib/otel"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	otelapi "go.opentelemetry.io/otel"
+	baseotel "go.opentelemetry.io/otel"
 	"net"
 	"net/http"
 	"os"
@@ -145,7 +145,7 @@ func TestStart_OpenTelemetry(t *testing.T) {
 		assertServerStarted(t, cfg.Public.Address)
 
 		// Verify OpenTelemetry is initialized (even when disabled, we should have a provider)
-		globalProvider := otelapi.GetTracerProvider()
+		globalProvider := baseotel.GetTracerProvider()
 		assert.NotNil(t, globalProvider)
 
 		// Create a tracer to verify it works
@@ -185,7 +185,7 @@ func TestStart_OpenTelemetry(t *testing.T) {
 		assertServerStarted(t, cfg.Public.Address)
 
 		// Verify OpenTelemetry is properly initialized
-		globalProvider := otelapi.GetTracerProvider()
+		globalProvider := baseotel.GetTracerProvider()
 		assert.NotNil(t, globalProvider)
 
 		// Verify we can create spans
@@ -227,7 +227,7 @@ func TestStart_OpenTelemetry(t *testing.T) {
 		assertServerStarted(t, cfg.Public.Address)
 
 		// Verify OpenTelemetry is properly initialized
-		globalProvider := otelapi.GetTracerProvider()
+		globalProvider := baseotel.GetTracerProvider()
 		assert.NotNil(t, globalProvider)
 
 		// Verify we can create spans (they just won't be exported)
@@ -289,7 +289,7 @@ func TestOpenTelemetryInitialization(t *testing.T) {
 		require.NotNil(t, provider)
 
 		// Verify global provider is set
-		globalProvider := otelapi.GetTracerProvider()
+		globalProvider := baseotel.GetTracerProvider()
 		assert.NotNil(t, globalProvider)
 
 		// Test creating a span (basic functionality test)
@@ -355,7 +355,7 @@ func TestOpenTelemetryServerIntegration(t *testing.T) {
 		assertServerStarted(t, cfg.Public.Address)
 
 		// Verify OpenTelemetry global state
-		globalProvider := otelapi.GetTracerProvider()
+		globalProvider := baseotel.GetTracerProvider()
 		assert.NotNil(t, globalProvider)
 
 		// Verify we can create and use tracers

--- a/orchestrator/lib/coolfhir/azure.go
+++ b/orchestrator/lib/coolfhir/azure.go
@@ -8,7 +8,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	fhirclient "github.com/SanteonNL/go-fhir-client"
 	"github.com/SanteonNL/orca/orchestrator/lib/must"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/otel"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -136,7 +136,7 @@ func NewAuthRoundTripper(config ClientConfig, fhirClientConfig *fhirclient.Confi
 			otelhttp.WithSpanOptions(
 				trace.WithSpanKind(trace.SpanKindClient),
 				trace.WithAttributes(
-					attribute.String(lib_otel.FHIRBaseURL, fhirURL.String()),
+					attribute.String(otel.FHIRBaseURL, fhirURL.String()),
 					attribute.String("fhir.auth_type", string(config.Auth.Type)),
 					attribute.String("service.component", "fhir-client"),
 				),
@@ -160,7 +160,7 @@ func NewAuthRoundTripper(config ClientConfig, fhirClientConfig *fhirclient.Confi
 			otelhttp.WithSpanOptions(
 				trace.WithSpanKind(trace.SpanKindClient),
 				trace.WithAttributes(
-					attribute.String(lib_otel.FHIRBaseURL, fhirURL.String()),
+					attribute.String(otel.FHIRBaseURL, fhirURL.String()),
 					attribute.String("fhir.auth_type", string(config.Auth.Type)),
 					attribute.String("service.component", "fhir-client"),
 				),

--- a/orchestrator/lib/coolfhir/azure_test.go
+++ b/orchestrator/lib/coolfhir/azure_test.go
@@ -6,7 +6,7 @@ import (
 	fhirclient "github.com/SanteonNL/go-fhir-client"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel"
+	baseotel "go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"net/http"
@@ -243,7 +243,7 @@ func TestNewAuthRoundTripper_OpenTelemetry_Debug(t *testing.T) {
 	tracerProvider := trace.NewTracerProvider(
 		trace.WithSpanProcessor(spanRecorder),
 	)
-	otel.SetTracerProvider(tracerProvider)
+	baseotel.SetTracerProvider(tracerProvider)
 	defer tracerProvider.Shutdown(context.Background())
 
 	t.Logf("Initial spans count: %d", len(spanRecorder.Ended()))
@@ -300,7 +300,7 @@ func TestNewAuthRoundTripper_OpenTelemetry_Debug(t *testing.T) {
 
 	// Try creating a manual span to verify the tracer provider works
 	t.Logf("Creating manual span...")
-	tracer := otel.GetTracerProvider().Tracer("test")
+	tracer := baseotel.GetTracerProvider().Tracer("test")
 	_, manualSpan := tracer.Start(context.Background(), "manual-test-span")
 	manualSpan.End()
 

--- a/orchestrator/lib/coolfhir/traced_fhir_client.go
+++ b/orchestrator/lib/coolfhir/traced_fhir_client.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	fhirclient "github.com/SanteonNL/go-fhir-client"
 	"github.com/SanteonNL/orca/orchestrator/lib/debug"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -29,7 +29,7 @@ func (t *TracedFHIRClient) CreateWithContext(ctx context.Context, resource inter
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
 			attribute.String("fhir.operation", "create"),
-			attribute.String(lib_otel.FHIRResourceType, ResourceType(resource)),
+			attribute.String(otel.FHIRResourceType, ResourceType(resource)),
 		),
 	)
 	defer span.End()
@@ -79,7 +79,7 @@ func (t *TracedFHIRClient) UpdateWithContext(ctx context.Context, path string, r
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
 			attribute.String("fhir.operation", "update"),
-			attribute.String(lib_otel.FHIRResourceType, ResourceType(resource)),
+			attribute.String(otel.FHIRResourceType, ResourceType(resource)),
 		),
 	)
 	defer span.End()
@@ -129,7 +129,7 @@ func (t *TracedFHIRClient) SearchWithContext(ctx context.Context, resourceType s
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
 			attribute.String("fhir.operation", "search"),
-			attribute.String(lib_otel.FHIRResourceType, resourceType),
+			attribute.String(otel.FHIRResourceType, resourceType),
 			attribute.Int("fhir.search.param_count", len(params)),
 		),
 	)

--- a/orchestrator/lib/coolfhir/traced_http_transport.go
+++ b/orchestrator/lib/coolfhir/traced_http_transport.go
@@ -3,8 +3,8 @@ package coolfhir
 import (
 	"fmt"
 	"github.com/SanteonNL/orca/orchestrator/lib/debug"
-	lib_otel "github.com/SanteonNL/orca/orchestrator/lib/otel"
-	"go.opentelemetry.io/otel"
+	"github.com/SanteonNL/orca/orchestrator/lib/otel"
+	baseotel "go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/propagation"
@@ -32,8 +32,8 @@ func (t *TracedHTTPTransport) RoundTrip(req *http.Request) (*http.Response, erro
 		debug.GetCallerName(),
 		trace.WithSpanKind(trace.SpanKindClient),
 		trace.WithAttributes(
-			attribute.String(lib_otel.HTTPMethod, req.Method),
-			attribute.String(lib_otel.HTTPURL, req.URL.String()),
+			attribute.String(otel.HTTPMethod, req.Method),
+			attribute.String(otel.HTTPURL, req.URL.String()),
 			attribute.String("http.scheme", req.URL.Scheme),
 			attribute.String("http.host", req.URL.Host),
 			attribute.String("http.target", req.URL.Path),
@@ -43,7 +43,7 @@ func (t *TracedHTTPTransport) RoundTrip(req *http.Request) (*http.Response, erro
 	defer span.End()
 
 	// Inject trace context into HTTP headers
-	otel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
+	baseotel.GetTextMapPropagator().Inject(ctx, propagation.HeaderCarrier(req.Header))
 
 	// Execute the request with traced context
 	req = req.WithContext(ctx)

--- a/orchestrator/lib/otel/config.go
+++ b/orchestrator/lib/otel/config.go
@@ -3,7 +3,7 @@ package otel
 import (
 	"context"
 	"fmt"
-	"go.opentelemetry.io/otel"
+	baseotel "go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
@@ -161,7 +161,7 @@ func Initialize(ctx context.Context, config Config) (*TracerProvider, error) {
 	if !config.Enabled {
 		// Set up a no-op tracer provider
 		noopProvider := trace.NewTracerProvider()
-		otel.SetTracerProvider(noopProvider)
+		baseotel.SetTracerProvider(noopProvider)
 		return &TracerProvider{
 			provider: noopProvider,
 			cleanup:  func(context.Context) error { return nil },
@@ -245,10 +245,10 @@ func Initialize(ctx context.Context, config Config) (*TracerProvider, error) {
 	tp := trace.NewTracerProvider(opts...)
 
 	// Set global tracer provider
-	otel.SetTracerProvider(tp)
+	baseotel.SetTracerProvider(tp)
 
 	// Set global propagator to tracecontext (W3C Trace Context)
-	otel.SetTextMapPropagator(propagation.TraceContext{})
+	baseotel.SetTextMapPropagator(propagation.TraceContext{})
 
 	return &TracerProvider{
 		provider: tp,

--- a/orchestrator/lib/otel/config_test.go
+++ b/orchestrator/lib/otel/config_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel"
+	baseotel "go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/trace"
 )
 
@@ -142,7 +142,7 @@ func TestInitialize_Disabled(t *testing.T) {
 	require.NotNil(t, provider)
 
 	// Verify that the global tracer provider is set
-	globalProvider := otel.GetTracerProvider()
+	globalProvider := baseotel.GetTracerProvider()
 	assert.NotNil(t, globalProvider)
 
 	// Test shutdown
@@ -167,7 +167,7 @@ func TestInitialize_StdoutExporter(t *testing.T) {
 	require.NotNil(t, provider)
 
 	// Verify that the global tracer provider is set and is not a no-op
-	globalProvider := otel.GetTracerProvider()
+	globalProvider := baseotel.GetTracerProvider()
 	assert.NotNil(t, globalProvider)
 
 	// Verify we can create a tracer
@@ -201,7 +201,7 @@ func TestInitialize_NoneExporter(t *testing.T) {
 	require.NotNil(t, provider)
 
 	// Verify that the global tracer provider is set
-	globalProvider := otel.GetTracerProvider()
+	globalProvider := baseotel.GetTracerProvider()
 	assert.NotNil(t, globalProvider)
 
 	// Verify we can create a tracer


### PR DESCRIPTION
Change import alias to use `otel` for our own internal package, and `baseotel` for the official package, since we use that import far less