### PR TITLE
[DEV] propagate incoming and outgoing tracing context

### DIFF
--- a/orchestrator/lib/otel/config.go
+++ b/orchestrator/lib/otel/config.go
@@ -248,7 +248,10 @@ func Initialize(ctx context.Context, config Config) (*TracerProvider, error) {
 	baseotel.SetTracerProvider(tp)
 
 	// Set global propagator to tracecontext (W3C Trace Context)
-	baseotel.SetTextMapPropagator(propagation.TraceContext{})
+	baseotel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
 
 	return &TracerProvider{
 		provider: tp,

--- a/orchestrator/lib/otel/tracing_middleware.go
+++ b/orchestrator/lib/otel/tracing_middleware.go
@@ -1,7 +1,9 @@
 package otel
 
 import (
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
 	semconv "go.opentelemetry.io/otel/semconv/v1.20.0"
 	"go.opentelemetry.io/otel/trace"
 	"net/http"
@@ -9,8 +11,11 @@ import (
 
 func HandlerWithTracing(tracer trace.Tracer, operationName string, handler http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		// Extract trace context from incoming HTTP headers
+		ctx := otel.GetTextMapPropagator().Extract(r.Context(), propagation.HeaderCarrier(r.Header))
+
 		ctx, span := tracer.Start(
-			r.Context(),
+			ctx,
 			operationName,
 			trace.WithSpanKind(trace.SpanKindServer),
 			trace.WithAttributes(


### PR DESCRIPTION
Uses incoming request context and adds outgoing request context for otel tracing, which groups cross-system operations under the same trace in the dashboard