### PR TITLE
DEV-2375: Epic encounter import

### DIFF
--- a/orchestrator/careplancontributor/importer/importer.go
+++ b/orchestrator/careplancontributor/importer/importer.go
@@ -15,7 +15,7 @@ import (
 
 func Import(ctx context.Context, cpsFHIRClient fhirclient.Client,
 	taskRequesterOrg fhir.Organization, taskPerformerOrg fhir.Organization, patientIdentifier fhir.Identifier, patient fhir.Patient,
-	externalIdentifier fhir.Identifier, serviceRequestCode fhir.Coding, conditionCode fhir.Coding, startDate time.Time) (*fhir.Bundle, error) {
+	externalIdentifier fhir.Identifier, encounterRef *fhir.Reference, serviceRequestCode fhir.Coding, conditionCode fhir.Coding, startDate time.Time) (*fhir.Bundle, error) {
 	serviceRequestId := uuid.NewString()
 	carePlanId := uuid.NewString()
 	taskId := uuid.NewString()
@@ -107,6 +107,7 @@ func Import(ctx context.Context, cpsFHIRClient fhirclient.Client,
 		Performer:  []fhir.Reference{performerOrgRef},
 		Requester:  requesterOrgRef,
 		Subject:    patientRef,
+		Encounter:  encounterRef,
 		ReasonCode: []fhir.CodeableConcept{
 			{
 				Coding: []fhir.Coding{conditionCode},

--- a/orchestrator/careplancontributor/importer/importer_test.go
+++ b/orchestrator/careplancontributor/importer/importer_test.go
@@ -71,6 +71,7 @@ func TestImportWithValidData(t *testing.T) {
 		patientIdentifier,
 		patient,
 		externalIdentifier,
+		nil,
 		serviceRequestCode,
 		conditionCode,
 		time.Now(),
@@ -137,6 +138,7 @@ func TestImportHandlesClientError(t *testing.T) {
 		patientIdentifier,
 		patient,
 		externalIdentifier,
+		nil,
 		serviceRequestCode,
 		conditionCode,
 		time.Now(),
@@ -303,6 +305,7 @@ func TestImportWithCompletePatientData(t *testing.T) {
 				System: to.Ptr("http://example.com"),
 				Value:  to.Ptr("ext-1"),
 			},
+			nil,
 			fhir.Coding{
 				System: to.Ptr("http://snomed.info/sct"),
 				Code:   to.Ptr("1"),
@@ -364,7 +367,7 @@ func TestImportWithContextCancellation(t *testing.T) {
 			CreatedResources: make(map[string][]any),
 		}
 
-		_, err := Import(ctx, mockClient, requesterOrg, performerOrg, patientId, patient, extId, srCode, condCode, time.Now())
+		_, err := Import(ctx, mockClient, requesterOrg, performerOrg, patientId, patient, extId, nil, srCode, condCode, time.Now())
 
 		// May or may not error depending on the client implementation
 		// Just verify the function handles it without panicking
@@ -400,6 +403,7 @@ func TestImportResourceGeneration(t *testing.T) {
 			fhir.Identifier{System: to.Ptr("http://example.com"), Value: to.Ptr("pat-1")},
 			fhir.Patient{Name: []fhir.HumanName{{Family: to.Ptr("Doe")}}},
 			fhir.Identifier{System: to.Ptr("http://example.com"), Value: to.Ptr("ext-1")},
+			nil,
 			fhir.Coding{System: to.Ptr("http://snomed.info/sct"), Code: to.Ptr("1")},
 			fhir.Coding{System: to.Ptr("http://snomed.info/sct"), Code: to.Ptr("2")},
 			time.Now(),
@@ -459,6 +463,7 @@ func TestImportWithMinimalData(t *testing.T) {
 			fhir.Identifier{System: to.Ptr("s"), Value: to.Ptr("v")},
 			fhir.Patient{},
 			fhir.Identifier{System: to.Ptr("s"), Value: to.Ptr("v")},
+			nil,
 			fhir.Coding{Code: to.Ptr("c1")},
 			fhir.Coding{Code: to.Ptr("c2")},
 			time.Now(),

--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -1238,6 +1238,10 @@ func (s Service) handleImport(httpRequest *http.Request) (*fhir.Bundle, error) {
 	if err != nil && !strings.HasPrefix(err.Error(), "missing parameter") {
 		return nil, otel.Error(span, err)
 	}
+	encounter, err := getIdentifierParameter(params, "epic_encounterid")
+	if err != nil && !strings.HasPrefix(err.Error(), "missing parameter") {
+		return nil, otel.Error(span, err)
+	}
 	serviceRequest, err := getCodingParameter(params, "servicerequest")
 	if err != nil {
 		return nil, otel.Error(span, err)
@@ -1265,8 +1269,9 @@ func (s Service) handleImport(httpRequest *http.Request) (*fhir.Bundle, error) {
 	var patientBundle fhir.Bundle
 	ehrFHIRClient := s.ehrFHIRClientByTenant[tenant.ID]
 	var externalIdentifier fhir.Identifier
-	if workflowID != nil {
-		// Zorgplatform
+	switch {
+	case workflowID != nil:
+		// Zorgplatform / HiX
 		reqHeadersOpts := fhirclient.RequestHeaders(map[string][]string{
 			"X-Scp-PatientID":  {*patientIdentifier.Value},
 			"X-Scp-WorkflowID": {*workflowID.Value},
@@ -1276,14 +1281,27 @@ func (s Service) handleImport(httpRequest *http.Request) (*fhir.Bundle, error) {
 			return nil, otel.Error(span, fmt.Errorf("unable to fetch Patient and Practitioner bundle: %w", err))
 		}
 		externalIdentifier = *workflowID
-	} else {
-		// Demo EHR
+	case encounter != nil:
+		// Epic — patient lookup via identifier search (Epic FHIR supports Patient?identifier=...)
+		if err = ehrFHIRClient.SearchWithContext(ctx, "Patient", url.Values{"identifier": []string{coolfhir.IdentifierToToken(*patientIdentifier)}}, &patientBundle); err != nil {
+			return nil, otel.Error(span, fmt.Errorf("unable to fetch Patient and Practitioner bundle: %w", err))
+		}
+		externalIdentifier = *encounter
+	default:
+		// Demo EHR / Faux Care
 		if err = ehrFHIRClient.SearchWithContext(ctx, "Patient", url.Values{"identifier": []string{coolfhir.IdentifierToToken(*patientIdentifier)}}, &patientBundle); err != nil {
 			return nil, otel.Error(span, fmt.Errorf("unable to fetch Patient and Practitioner bundle: %w", err))
 		}
 		externalIdentifier = fhir.Identifier{
 			System: to.Ptr("urn:ietf:rfc:4122"),
 			Value:  to.Ptr(uuid.New().String()),
+		}
+	}
+	var encounterRef *fhir.Reference
+	if encounter != nil {
+		encounterRef = &fhir.Reference{
+			Type:       to.Ptr("Encounter"),
+			Identifier: encounter,
 		}
 	}
 	if err := coolfhir.ResourceInBundle(&patientBundle, coolfhir.EntryIsOfType("Patient"), &patient); err != nil {
@@ -1304,7 +1322,7 @@ func (s Service) handleImport(httpRequest *http.Request) (*fhir.Bundle, error) {
 		"Invoking CPS $import operation",
 	)
 	cpsFHIRClient := fhirclient.New(tenant.URL(s.orcaPublicURL, careplanservice.FHIRBaseURL), s.httpClientForLocalCPS(tenant), coolfhir.Config())
-	result, err := importer.Import(ctx, cpsFHIRClient, taskRequester, principal.Organization, *patientIdentifier, patient, externalIdentifier, *serviceRequest, *condition, *startDate)
+	result, err := importer.Import(ctx, cpsFHIRClient, taskRequester, principal.Organization, *patientIdentifier, patient, externalIdentifier, encounterRef, *serviceRequest, *condition, *startDate)
 	if err != nil {
 		return nil, otel.Error(span, fmt.Errorf("import failed: %w", err))
 	}

--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -1266,9 +1266,9 @@ func (s Service) handleImport(httpRequest *http.Request) (*fhir.Bundle, error) {
 
 	// Read patient information from EHR or Zorgplatform
 	var patient fhir.Patient
-	var patientBundle fhir.Bundle
 	ehrFHIRClient := s.ehrFHIRClientByTenant[tenant.ID]
 	var externalIdentifier fhir.Identifier
+	var encounterRef *fhir.Reference
 	switch {
 	case workflowID != nil:
 		// Zorgplatform / HiX
@@ -1277,35 +1277,38 @@ func (s Service) handleImport(httpRequest *http.Request) (*fhir.Bundle, error) {
 			"X-Scp-WorkflowID": {*workflowID.Value},
 		})
 		// Fetch patient from EHR according to BgZ (the general-practitioner is not needed, but added for conformance).
+		var patientBundle fhir.Bundle
 		if err = ehrFHIRClient.SearchWithContext(ctx, "Patient", url.Values{"_include": []string{"Patient:general-practitioner"}}, &patientBundle, reqHeadersOpts); err != nil {
 			return nil, otel.Error(span, fmt.Errorf("unable to fetch Patient and Practitioner bundle: %w", err))
 		}
+		if err := coolfhir.ResourceInBundle(&patientBundle, coolfhir.EntryIsOfType("Patient"), &patient); err != nil {
+			return nil, otel.Error(span, fmt.Errorf("unable to find Patient resource in Bundle: %w", err))
+		}
 		externalIdentifier = *workflowID
 	case encounter != nil:
-		// Epic — patient lookup via identifier search (Epic FHIR supports Patient?identifier=...)
+		// Epic / SMART on FHIR — we cannot call the EHR, construct a minimal Patient
+		// from the supplied identifier (BSN). The importer assigns the Patient.Id.
+		patient = fhir.Patient{
+			Identifier: []fhir.Identifier{*patientIdentifier},
+		}
+		externalIdentifier = *encounter
+		encounterRef = &fhir.Reference{
+			Type:       to.Ptr("Encounter"),
+			Identifier: encounter,
+		}
+	default:
+		// Demo EHR / Faux Care
+		var patientBundle fhir.Bundle
 		if err = ehrFHIRClient.SearchWithContext(ctx, "Patient", url.Values{"identifier": []string{coolfhir.IdentifierToToken(*patientIdentifier)}}, &patientBundle); err != nil {
 			return nil, otel.Error(span, fmt.Errorf("unable to fetch Patient and Practitioner bundle: %w", err))
 		}
-		externalIdentifier = *encounter
-	default:
-		// Demo EHR / Faux Care
-		if err = ehrFHIRClient.SearchWithContext(ctx, "Patient", url.Values{"identifier": []string{coolfhir.IdentifierToToken(*patientIdentifier)}}, &patientBundle); err != nil {
-			return nil, otel.Error(span, fmt.Errorf("unable to fetch Patient and Practitioner bundle: %w", err))
+		if err := coolfhir.ResourceInBundle(&patientBundle, coolfhir.EntryIsOfType("Patient"), &patient); err != nil {
+			return nil, otel.Error(span, fmt.Errorf("unable to find Patient resource in Bundle: %w", err))
 		}
 		externalIdentifier = fhir.Identifier{
 			System: to.Ptr("urn:ietf:rfc:4122"),
 			Value:  to.Ptr(uuid.New().String()),
 		}
-	}
-	var encounterRef *fhir.Reference
-	if encounter != nil {
-		encounterRef = &fhir.Reference{
-			Type:       to.Ptr("Encounter"),
-			Identifier: encounter,
-		}
-	}
-	if err := coolfhir.ResourceInBundle(&patientBundle, coolfhir.EntryIsOfType("Patient"), &patient); err != nil {
-		return nil, otel.Error(span, fmt.Errorf("unable to find Patient resource in Bundle: %w", err))
 	}
 
 	taskRequesterCandidates, err := s.profile.Identities(ctx)

--- a/orchestrator/careplancontributor/service_test.go
+++ b/orchestrator/careplancontributor/service_test.go
@@ -1253,6 +1253,83 @@ func TestService_Import(t *testing.T) {
 			})
 		})
 	})
+	t.Run("ok - Epic", func(t *testing.T) {
+		t.Log("In this test, test org 2 imports data into org 1's CPS with an Epic encounter ID")
+		cpsFHIRClient := &test.StubFHIRClient{}
+		globals.RegisterCPSFHIRClient(tenant.ID, cpsFHIRClient)
+
+		const encounterSystem = "urn:oid:1.2.840.114350.1.13.487.3.7.3.698084.8"
+		const encounterValue = "72264970"
+
+		start := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+		requestBody := fhir.Parameters{
+			Parameter: []fhir.ParametersParameter{
+				{
+					Name: "patient",
+					ValueIdentifier: &fhir.Identifier{
+						System: to.Ptr("http://fhir.nl/fhir/NamingSystem/bsn"),
+						Value:  to.Ptr("123456789"),
+					},
+				},
+				{
+					Name: "servicerequest",
+					ValueCoding: &fhir.Coding{
+						System:  to.Ptr("http://example.com/servicerequest"),
+						Code:    to.Ptr("sr1"),
+						Display: to.Ptr("ServiceRequestDisplay"),
+					},
+				},
+				{
+					Name: "condition",
+					ValueCoding: &fhir.Coding{
+						System:  to.Ptr("http://example.com/condition"),
+						Code:    to.Ptr("c1"),
+						Display: to.Ptr("ConditionDisplay"),
+					},
+				},
+				{
+					Name: "epic_encounterid",
+					ValueIdentifier: &fhir.Identifier{
+						System: to.Ptr(encounterSystem),
+						Value:  to.Ptr(encounterValue),
+					},
+				},
+				{
+					Name:          "start",
+					ValueDateTime: to.Ptr(start.Format(time.RFC3339)),
+				},
+			},
+		}
+		requestBodyJSON := must.MarshalJSON(requestBody)
+		httpRequest, _ := http.NewRequest("POST", httpServer.URL+"/cpc/test/fhir/$import", bytes.NewReader(requestBodyJSON))
+		httpRequest.Header.Set("Content-Type", "application/fhir+json")
+		httpResponse, err := httpClient.Do(httpRequest)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, httpResponse.StatusCode)
+
+		// Assert ServiceRequest carries the encounter and the encounter identifier on its Identifier list
+		var serviceRequests []fhir.ServiceRequest
+		err = coolfhir.ResourcesInBundle(&capturedBundle, coolfhir.EntryIsOfType("ServiceRequest"), &serviceRequests)
+		require.NoError(t, err)
+		require.Len(t, serviceRequests, 1)
+		sr := serviceRequests[0]
+		require.NotNil(t, sr.Encounter)
+		require.NotNil(t, sr.Encounter.Identifier)
+		assert.Equal(t, encounterSystem, *sr.Encounter.Identifier.System)
+		assert.Equal(t, encounterValue, *sr.Encounter.Identifier.Value)
+		require.NotNil(t, sr.Encounter.Type)
+		assert.Equal(t, "Encounter", *sr.Encounter.Type)
+		require.Len(t, sr.Identifier, 1)
+		assert.Equal(t, encounterSystem+"|"+encounterValue, coolfhir.IdentifierToToken(sr.Identifier[0]))
+
+		// Assert Task identifier mirrors the encounter identifier
+		var tasks []fhir.Task
+		err = coolfhir.ResourcesInBundle(&capturedBundle, coolfhir.EntryIsOfType("Task"), &tasks)
+		require.NoError(t, err)
+		require.Len(t, tasks, 1)
+		require.Len(t, tasks[0].Identifier, 1)
+		assert.Equal(t, encounterSystem+"|"+encounterValue, coolfhir.IdentifierToToken(tasks[0].Identifier[0]))
+	})
 	t.Run("$import operation not enabled for this tenant", func(t *testing.T) {
 		httpResponse, err := httpClient.PostForm(httpServer.URL+"/cpc/other_tenant/fhir/$import", url.Values{
 			"patient_identifier": []string{"123456789"},


### PR DESCRIPTION
Adds support for a `epic_encounterid` field in the import data that can be used to store the epic encounter id on the ServiceRequest that is created.