### PR TITLE
DEV-2846: set condition context for SMART on FHIR launches

### DIFF
--- a/frontend/__tests__/app/applaunch.test.ts
+++ b/frontend/__tests__/app/applaunch.test.ts
@@ -1,7 +1,7 @@
 /**
  * @jest-environment node
  */
-import {getLaunchableApps} from '@/app/applaunch';
+import {getLaunchableApps, setTaskLaunchContext} from '@/app/applaunch';
 import type {Identifier, Bundle, Endpoint} from 'fhir/r4';
 
 
@@ -303,5 +303,36 @@ describe('getLaunchableApps', () => {
                 'X-Scp-Entity-Identifier': 'https://example.com/orgs|org-with-special@chars#123'
             }
         });
+    });
+});
+
+describe('setTaskLaunchContext', () => {
+    const mockFetch = jest.fn();
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        global.fetch = mockFetch as any;
+    });
+
+    it('posts the selected task to the orchestrator', async () => {
+        mockFetch.mockResolvedValue({ok: true});
+
+        await setTaskLaunchContext('task-123');
+
+        expect(mockFetch).toHaveBeenCalledWith('/orca/cpc/context/task/task-123', {method: 'POST'});
+    });
+
+    it('encodes the task id', async () => {
+        mockFetch.mockResolvedValue({ok: true});
+
+        await setTaskLaunchContext('task/../other');
+
+        expect(mockFetch).toHaveBeenCalledWith('/orca/cpc/context/task/task%2F..%2Fother', {method: 'POST'});
+    });
+
+    it('throws when the orchestrator rejects the request, so the caller can fall back', async () => {
+        mockFetch.mockResolvedValue({ok: false, statusText: 'Forbidden'});
+
+        await expect(setTaskLaunchContext('task-123')).rejects.toThrow('Failed to set launch context: Forbidden');
     });
 });

--- a/frontend/app/applaunch.ts
+++ b/frontend/app/applaunch.ts
@@ -7,6 +7,16 @@ export interface LaunchableApp {
     URL: string;
 }
 
+// Records which enrollment the app is launched from, so the launched app knows the care path. A SMART on
+// FHIR launch carries no condition context of its own — the user only picks an enrollment here — which
+// leaves apps guessing for patients enrolled on more than one care path.
+export async function setTaskLaunchContext(taskId: string): Promise<void> {
+    const response = await fetch(`/orca/cpc/context/task/${encodeURIComponent(taskId)}`, {method: "POST"});
+    if (!response.ok) {
+        throw new Error(`Failed to set launch context: ${response.statusText}`);
+    }
+}
+
 export async function getLaunchableApps(scpClient: Client, organization: Identifier) : Promise<LaunchableApp[]> {
     const testAppURL = await getPatientViewerTestUrl();
     if (testAppURL) {

--- a/frontend/app/enrollment/task/[taskId]/page.tsx
+++ b/frontend/app/enrollment/task/[taskId]/page.tsx
@@ -4,7 +4,7 @@ import {useParams} from 'next/navigation'
 import Loading from '@/app/enrollment/loading'
 import QuestionnaireRenderer from '../../components/questionnaire-renderer'
 import useEnrollment from "@/app/hooks/enrollment-hook";
-import {getLaunchableApps, LaunchableApp} from "@/app/applaunch";
+import {getLaunchableApps, LaunchableApp, setTaskLaunchContext} from "@/app/applaunch";
 import {Questionnaire, ServiceRequest, Task} from "fhir/r4";
 import { useClients } from '@/app/hooks/context-hook'
 import PatientDetails from "@/app/enrollment/task/components/patient-details";
@@ -97,7 +97,13 @@ export default function EnrollmentTaskPage() {
     // - Task.status is "in-progress"
     // - There is exactly one launchable app
     // - Auto-launch is enabled
-    const launchApp = (URL: string) => () => {
+    const launchApp = (URL: string) => async () => {
+        try {
+            await setTaskLaunchContext(task.id!);
+        } catch (error) {
+            // Best effort: the app still opens, it just falls back to its own care path selection.
+            console.error("Failed to set launch context for task", task.id, error);
+        }
         window.open(URL, "_self");
     }
 

--- a/orchestrator/careplancontributor/applaunch/session/data.go
+++ b/orchestrator/careplancontributor/applaunch/session/data.go
@@ -34,6 +34,22 @@ func (d *Data) Set(path string, resource any) {
 	d.ContextResources = append(d.ContextResources, res)
 }
 
+// Replace drops any resource of the same type before setting the new one. Set appends and GetByType
+// returns the first match, so without this a second resource of a type would be shadowed by the first.
+func (d *Data) Replace(path string, resource any) {
+	resourceType, _, _ := strings.Cut(path, "/")
+
+	var remaining []FHIRResource
+	for _, existing := range d.ContextResources {
+		if !strings.HasPrefix(existing.Path, resourceType+"/") {
+			remaining = append(remaining, existing)
+		}
+	}
+	d.ContextResources = remaining
+
+	d.Set(path, resource)
+}
+
 func (d *Data) GetByPath(resourcePath string) *FHIRResource {
 	for _, resource := range d.ContextResources {
 		if resource.Path == resourcePath {

--- a/orchestrator/careplancontributor/applaunch/session/data_test.go
+++ b/orchestrator/careplancontributor/applaunch/session/data_test.go
@@ -1,0 +1,51 @@
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
+)
+
+func TestData_Replace(t *testing.T) {
+	t.Run("replaces an existing resource of the same type", func(t *testing.T) {
+		data := Data{}
+		data.Set("Condition/first", fhir.Condition{Id: strPtr("first")})
+
+		data.Replace("Condition/second", fhir.Condition{Id: strPtr("second")})
+
+		condition := Get[fhir.Condition](&data)
+		require.NotNil(t, condition)
+		assert.Equal(t, "second", *condition.Id)
+		assert.Len(t, data.ContextResources, 1)
+	})
+
+	t.Run("leaves other resource types alone", func(t *testing.T) {
+		data := Data{}
+		data.Set("Patient/1", fhir.Patient{Id: strPtr("1")})
+		data.Set("Condition/first", fhir.Condition{Id: strPtr("first")})
+
+		data.Replace("Condition/second", fhir.Condition{Id: strPtr("second")})
+
+		patient := Get[fhir.Patient](&data)
+		require.NotNil(t, patient)
+		assert.Equal(t, "1", *patient.Id)
+		assert.Len(t, data.ContextResources, 2)
+	})
+
+	t.Run("sets when nothing of the type is present", func(t *testing.T) {
+		data := Data{}
+		data.Set("Patient/1", fhir.Patient{Id: strPtr("1")})
+
+		data.Replace("Condition/only", fhir.Condition{Id: strPtr("only")})
+
+		condition := Get[fhir.Condition](&data)
+		require.NotNil(t, condition)
+		assert.Equal(t, "only", *condition.Id)
+	})
+}
+
+func strPtr(value string) *string {
+	return &value
+}

--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -345,6 +345,15 @@ func (s *Service) RegisterHandlers(mux *http.ServeMux) {
 			),
 		},
 		{
+			Method:  "POST",
+			Path:    basePath + "/context/task/{id}",
+			Handler: s.withSession(s.handleSetTaskContext),
+			Middleware: httpserv.Chain(
+				otel.HandlerWithTracing(tracer, "SetTaskContext"),
+				s.withUserAuth,
+			),
+		},
+		{
 			Method:  "GET",
 			Path:    basePathWithTenant + "/ehr/fhir/{rest...}",
 			Handler: s.withSession(s.handleProxyAppRequestToEHR),
@@ -767,6 +776,86 @@ func (s Service) handleGetContext(response http.ResponseWriter, _ *http.Request,
 	response.Header().Add("Content-Type", "application/json")
 	response.WriteHeader(http.StatusOK)
 	_ = json.NewEncoder(response).Encode(contextData)
+}
+
+// handleSetTaskContext records the enrollment Task the user opened, so apps launched from it are told
+// which care path they were opened for. Zorgplatform resolves a Condition at launch, but a SMART on FHIR
+// launch has no such context — the user only picks an enrollment afterwards — which leaves apps guessing
+// for patients enrolled on more than one care path.
+func (s Service) handleSetTaskContext(response http.ResponseWriter, request *http.Request, sessionData *session.Data) {
+	ctx := request.Context()
+
+	tenant, err := s.tenants.Get(sessionData.TenantID)
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to resolve tenant for launch context", slog.String(logging.FieldError, err.Error()))
+		http.Error(response, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	cpsFHIRClient := fhirclient.New(tenant.URL(s.orcaPublicURL, careplanservice.FHIRBaseURL), s.httpClientForLocalCPS(*tenant), coolfhir.Config())
+
+	status := setTaskContext(ctx, cpsFHIRClient, request.PathValue("id"), sessionData)
+	if status != http.StatusNoContent {
+		http.Error(response, http.StatusText(status), status)
+		return
+	}
+	response.WriteHeader(http.StatusNoContent)
+}
+
+// setTaskContext reads the enrollment Task and records its condition on the session, returning the HTTP
+// status the caller should report.
+func setTaskContext(ctx context.Context, cpsFHIRClient fhirclient.Client, taskID string, sessionData *session.Data) int {
+	var task fhir.Task
+	if err := cpsFHIRClient.ReadWithContext(ctx, "Task/"+taskID, &task); err != nil {
+		slog.ErrorContext(ctx, "Failed to read Task for launch context", slog.String(logging.FieldError, err.Error()))
+		return http.StatusNotFound
+	}
+
+	// Never let a crafted request point the session at an unrelated patient's enrollment.
+	if !taskIsForSessionPatient(task, sessionData) {
+		slog.WarnContext(ctx, "Refusing launch context for a Task belonging to another patient")
+		return http.StatusForbidden
+	}
+
+	condition := conditionFromTask(task)
+	if condition == nil {
+		// Nothing to narrow the launch to; leave the session as-is rather than clearing what it has.
+		slog.InfoContext(ctx, "Task carries no reasonCode, launch context unchanged")
+		return http.StatusNoContent
+	}
+
+	sessionData.Replace("Condition/magic-"+uuid.NewString(), *condition)
+	return http.StatusNoContent
+}
+
+func taskIsForSessionPatient(task fhir.Task, sessionData *session.Data) bool {
+	patient := session.Get[fhir.Patient](sessionData)
+	if patient == nil || task.For == nil {
+		return false
+	}
+
+	if patient.Id != nil && task.For.Reference != nil && *task.For.Reference == "Patient/"+*patient.Id {
+		return true
+	}
+
+	// Zorgplatform-style sessions hold a patient minted by the launch, whose id the CPS does not know;
+	// those still match on a shared business identifier.
+	if task.For.Identifier == nil {
+		return false
+	}
+	return slices.ContainsFunc(patient.Identifier, func(identifier fhir.Identifier) bool {
+		return coolfhir.IdentifierEquals(&identifier, task.For.Identifier)
+	})
+}
+
+func conditionFromTask(task fhir.Task) *fhir.Condition {
+	if task.ReasonCode == nil || len(task.ReasonCode.Coding) == 0 {
+		return nil
+	}
+	return &fhir.Condition{
+		Id:   to.Ptr(uuid.NewString()),
+		Code: task.ReasonCode,
+	}
 }
 
 func (s Service) getAndValidateUserSession(request *http.Request) (*session.Data, error) {

--- a/orchestrator/careplancontributor/service_test.go
+++ b/orchestrator/careplancontributor/service_test.go
@@ -1615,3 +1615,177 @@ func TestService_HealthCheck(t *testing.T) {
 		require.Equal(t, http.StatusUnauthorized, httpResponse.StatusCode)
 	})
 }
+
+func TestTaskIsForSessionPatient(t *testing.T) {
+	bsn := fhir.Identifier{System: to.Ptr("http://fhir.nl/fhir/NamingSystem/bsn"), Value: to.Ptr("123456782")}
+
+	sessionWithPatient := func(patient fhir.Patient) *session.Data {
+		data := session.Data{}
+		data.Set("Patient/"+*patient.Id, patient)
+		return &data
+	}
+
+	t.Run("matches on the patient reference", func(t *testing.T) {
+		data := sessionWithPatient(fhir.Patient{Id: to.Ptr("epic-123")})
+		task := fhir.Task{For: &fhir.Reference{Reference: to.Ptr("Patient/epic-123")}}
+
+		assert.True(t, taskIsForSessionPatient(task, data))
+	})
+
+	t.Run("matches on a shared business identifier when the reference differs", func(t *testing.T) {
+		data := sessionWithPatient(fhir.Patient{Id: to.Ptr("locally-minted"), Identifier: []fhir.Identifier{bsn}})
+		task := fhir.Task{For: &fhir.Reference{Reference: to.Ptr("Patient/some-other-id"), Identifier: &bsn}}
+
+		assert.True(t, taskIsForSessionPatient(task, data))
+	})
+
+	t.Run("rejects a Task for another patient", func(t *testing.T) {
+		data := sessionWithPatient(fhir.Patient{Id: to.Ptr("epic-123"), Identifier: []fhir.Identifier{bsn}})
+		otherBsn := fhir.Identifier{System: bsn.System, Value: to.Ptr("987654321")}
+		task := fhir.Task{For: &fhir.Reference{Reference: to.Ptr("Patient/epic-999"), Identifier: &otherBsn}}
+
+		assert.False(t, taskIsForSessionPatient(task, data))
+	})
+
+	t.Run("rejects when the session holds no patient", func(t *testing.T) {
+		task := fhir.Task{For: &fhir.Reference{Reference: to.Ptr("Patient/epic-123")}}
+
+		assert.False(t, taskIsForSessionPatient(task, &session.Data{}))
+	})
+
+	t.Run("rejects a Task without a subject", func(t *testing.T) {
+		data := sessionWithPatient(fhir.Patient{Id: to.Ptr("epic-123")})
+
+		assert.False(t, taskIsForSessionPatient(fhir.Task{}, data))
+	})
+}
+
+func TestConditionFromTask(t *testing.T) {
+	t.Run("takes the code from Task.reasonCode", func(t *testing.T) {
+		task := fhir.Task{ReasonCode: &fhir.CodeableConcept{
+			Coding: []fhir.Coding{{System: to.Ptr("http://snomed.info/sct"), Code: to.Ptr("13645005")}},
+		}}
+
+		condition := conditionFromTask(task)
+
+		require.NotNil(t, condition)
+		require.Len(t, condition.Code.Coding, 1)
+		assert.Equal(t, "13645005", *condition.Code.Coding[0].Code)
+	})
+
+	t.Run("nil when the Task carries no reason", func(t *testing.T) {
+		assert.Nil(t, conditionFromTask(fhir.Task{}))
+		assert.Nil(t, conditionFromTask(fhir.Task{ReasonCode: &fhir.CodeableConcept{}}))
+	})
+}
+
+func TestSetTaskContext(t *testing.T) {
+	bsn := fhir.Identifier{System: to.Ptr("http://fhir.nl/fhir/NamingSystem/bsn"), Value: to.Ptr("123456782")}
+	copd := fhir.CodeableConcept{Coding: []fhir.Coding{{System: to.Ptr("http://snomed.info/sct"), Code: to.Ptr("13645005")}}}
+
+	sessionForPatient := func() *session.Data {
+		data := session.Data{}
+		data.Set("Patient/epic-123", fhir.Patient{Id: to.Ptr("epic-123"), Identifier: []fhir.Identifier{bsn}})
+		return &data
+	}
+
+	returnTask := func(client *mock.MockClient, task fhir.Task) {
+		client.EXPECT().ReadWithContext(gomock.Any(), "Task/task-1", gomock.Any(), gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ string, target any, _ ...fhirclient.Option) error {
+				*(target.(*fhir.Task)) = task
+				return nil
+			})
+	}
+
+	t.Run("records the Task's condition on the session", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		client := mock.NewMockClient(ctrl)
+		returnTask(client, fhir.Task{
+			For:        &fhir.Reference{Reference: to.Ptr("Patient/epic-123")},
+			ReasonCode: &copd,
+		})
+		sessionData := sessionForPatient()
+
+		status := setTaskContext(context.Background(), client, "task-1", sessionData)
+
+		assert.Equal(t, http.StatusNoContent, status)
+		condition := session.Get[fhir.Condition](sessionData)
+		require.NotNil(t, condition)
+		assert.Equal(t, "13645005", *condition.Code.Coding[0].Code)
+	})
+
+	t.Run("replaces a condition already on the session", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		client := mock.NewMockClient(ctrl)
+		returnTask(client, fhir.Task{
+			For:        &fhir.Reference{Reference: to.Ptr("Patient/epic-123")},
+			ReasonCode: &copd,
+		})
+		sessionData := sessionForPatient()
+		sessionData.Set("Condition/stale", fhir.Condition{
+			Code: &fhir.CodeableConcept{Coding: []fhir.Coding{{Code: to.Ptr("84114007")}}},
+		})
+
+		status := setTaskContext(context.Background(), client, "task-1", sessionData)
+
+		assert.Equal(t, http.StatusNoContent, status)
+		condition := session.Get[fhir.Condition](sessionData)
+		require.NotNil(t, condition)
+		assert.Equal(t, "13645005", *condition.Code.Coding[0].Code)
+	})
+
+	t.Run("404 when the Task cannot be read", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		client := mock.NewMockClient(ctrl)
+		client.EXPECT().ReadWithContext(gomock.Any(), "Task/task-1", gomock.Any(), gomock.Any()).
+			Return(assert.AnError)
+
+		status := setTaskContext(context.Background(), client, "task-1", sessionForPatient())
+
+		assert.Equal(t, http.StatusNotFound, status)
+	})
+
+	t.Run("403 when the Task is for another patient", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		client := mock.NewMockClient(ctrl)
+		returnTask(client, fhir.Task{
+			For:        &fhir.Reference{Reference: to.Ptr("Patient/someone-else")},
+			ReasonCode: &copd,
+		})
+		sessionData := sessionForPatient()
+
+		status := setTaskContext(context.Background(), client, "task-1", sessionData)
+
+		assert.Equal(t, http.StatusForbidden, status)
+		assert.Nil(t, session.Get[fhir.Condition](sessionData))
+	})
+
+	t.Run("leaves the session alone when the Task has no reasonCode", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+		client := mock.NewMockClient(ctrl)
+		returnTask(client, fhir.Task{For: &fhir.Reference{Reference: to.Ptr("Patient/epic-123")}})
+		sessionData := sessionForPatient()
+
+		status := setTaskContext(context.Background(), client, "task-1", sessionData)
+
+		assert.Equal(t, http.StatusNoContent, status)
+		assert.Nil(t, session.Get[fhir.Condition](sessionData))
+	})
+}
+
+func TestService_handleSetTaskContext_UnknownTenant(t *testing.T) {
+	service := Service{tenants: tenants.Test()}
+	httpResponse := httptest.NewRecorder()
+	httpRequest := httptest.NewRequest(http.MethodPost, "/cpc/context/task/task-1", nil)
+	sessionData := session.Data{TenantID: "no-such-tenant"}
+
+	service.handleSetTaskContext(httpResponse, httpRequest, &sessionData)
+
+	assert.Equal(t, http.StatusInternalServerError, httpResponse.Code)
+	assert.Nil(t, session.Get[fhir.Condition](&sessionData))
+}


### PR DESCRIPTION
## Summary

- SMART on FHIR launches carry no condition context, so apps launched from them cannot tell which care path they were opened for. `zorgplatform/service.go:786` sets a Condition on the session; `smartonfhir/service.go:250-252` sets only Patient, Practitioner and Organization, and nothing adds one later — so `oidc/op/storage.go` never emits the `condition` claim.
- New `POST /cpc/context/task/{id}` records the enrollment the user opened: it reads the Task from the local CPS, derives a Condition from `Task.reasonCode`, and puts it on the session. The frontend calls it from the task page before opening a launchable app, best effort — a failure logs and still launches.
- `session.Data.Replace` drops an existing resource of the same type first, since `Set` appends and `GetByType` returns the first match; without it, re-selecting an enrollment would leave the earlier one shadowing the new one.

The Task is read server-side and checked against the session patient (by reference, falling back to a shared business identifier) so a crafted request cannot point the session at another patient's enrollment.

## Context

ZBJ's MSC viewer picks the care path from the `condition` claim. Without it, a patient enrolled on more than one care path opens an arbitrary one — 17 such patients exist in St. Antonius production today (heart failure `84114007` + COPD `13645005`). Zorgplatform/CWZ launches are unaffected.

Rejected alternative: reading Epic's `encounter` from the SMART token response in `loadContext`. The launch is not necessarily scoped to the enrollment's encounter, and at launch the enrollment may not exist yet.

Tracked as DEV-2846.
