### PR TITLE
DEV-2847: add authenticated verification app launch

### DIFF
--- a/orchestrator/careplancontributor/applaunch/applaunch.go
+++ b/orchestrator/careplancontributor/applaunch/applaunch.go
@@ -5,6 +5,7 @@ import (
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor/applaunch/demo"
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor/applaunch/external"
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor/applaunch/smartonfhir"
+	"github.com/SanteonNL/orca/orchestrator/careplancontributor/applaunch/verification"
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor/applaunch/zorgplatform"
 	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
 	"net/http"
@@ -20,9 +21,13 @@ type Config struct {
 	Demo         demo.Config                `koanf:"demo"`
 	ZorgPlatform zorgplatform.Config        `koanf:"zorgplatform"`
 	External     map[string]external.Config `koanf:"external"`
+	Verification verification.Config        `koanf:"verification"`
 }
 
 func (c Config) Validate() error {
+	if err := c.Verification.Validate(); err != nil {
+		return err
+	}
 	return c.SmartOnFhir.Validate()
 }
 

--- a/orchestrator/careplancontributor/applaunch/verification/config.go
+++ b/orchestrator/careplancontributor/applaunch/verification/config.go
@@ -1,0 +1,29 @@
+package verification
+
+import (
+	"errors"
+
+	"github.com/SanteonNL/orca/orchestrator/careplancontributor/oidc/rp"
+)
+
+type Config struct {
+	Enabled bool `koanf:"enabled"`
+	// OIDC configures which identity provider's tokens may initiate a verification launch
+	// (e.g. Entra ID: issuer https://login.microsoftonline.com/{tenant}/v2.0, audience = app registration).
+	// It is only needed on the node a workforce application calls directly; launches delegated by
+	// another SCP node are authenticated through Shared Care Planning itself.
+	OIDC rp.Config `koanf:"oidc"`
+}
+
+func (c Config) Validate() error {
+	if !c.Enabled || !c.OIDC.Enabled {
+		return nil
+	}
+	if c.OIDC.ClientID == "" {
+		return errors.New("verification app launch: OIDC audience (clientid) is required")
+	}
+	if len(c.OIDC.TrustedIssuers) == 0 {
+		return errors.New("verification app launch: at least one trusted OIDC issuer is required")
+	}
+	return nil
+}

--- a/orchestrator/careplancontributor/applaunch/verification/config_test.go
+++ b/orchestrator/careplancontributor/applaunch/verification/config_test.go
@@ -1,0 +1,33 @@
+package verification
+
+import (
+	"testing"
+
+	"github.com/SanteonNL/orca/orchestrator/careplancontributor/oidc/rp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_Validate(t *testing.T) {
+	issuers := map[string]rp.TrustedIssuer{
+		"entra": {IssuerURL: "https://login.microsoftonline.com/tenant/v2.0", DiscoveryURL: "https://login.microsoftonline.com/tenant/v2.0/.well-known/openid-configuration"},
+	}
+
+	t.Run("disabled needs no OIDC", func(t *testing.T) {
+		require.NoError(t, Config{}.Validate())
+	})
+	t.Run("enabled without OIDC is valid: the node only accepts delegated launches", func(t *testing.T) {
+		require.NoError(t, Config{Enabled: true}.Validate())
+	})
+	t.Run("OIDC without audience is rejected", func(t *testing.T) {
+		err := Config{Enabled: true, OIDC: rp.Config{Enabled: true, TrustedIssuers: issuers}}.Validate()
+		assert.ErrorContains(t, err, "clientid")
+	})
+	t.Run("OIDC without trusted issuers is rejected", func(t *testing.T) {
+		err := Config{Enabled: true, OIDC: rp.Config{Enabled: true, ClientID: "audience"}}.Validate()
+		assert.ErrorContains(t, err, "trusted OIDC issuer")
+	})
+	t.Run("fully configured OIDC is valid", func(t *testing.T) {
+		require.NoError(t, Config{Enabled: true, OIDC: rp.Config{Enabled: true, ClientID: "audience", TrustedIssuers: issuers}}.Validate())
+	})
+}

--- a/orchestrator/careplancontributor/applaunch/verification/noncestore.go
+++ b/orchestrator/careplancontributor/applaunch/verification/noncestore.go
@@ -1,0 +1,37 @@
+package verification
+
+import (
+	"time"
+
+	"github.com/SanteonNL/orca/orchestrator/careplancontributor/applaunch/session"
+	"github.com/google/uuid"
+	"github.com/jellydator/ttlcache/v3"
+)
+
+// nonceStore holds prepared launch sessions until the browser redeems them. A nonce is single-use and
+// short-lived, so the launch URL behaves like an authorization code: the authenticated POST proves who
+// asked, the unauthenticated GET only converts that proof into a session cookie.
+type nonceStore struct {
+	cache *ttlcache.Cache[string, session.Data]
+}
+
+func newNonceStore(ttl time.Duration) *nonceStore {
+	cache := ttlcache.New[string, session.Data](ttlcache.WithTTL[string, session.Data](ttl))
+	go cache.Start()
+	return &nonceStore{cache: cache}
+}
+
+func (s *nonceStore) Put(data session.Data) string {
+	nonce := uuid.NewString()
+	s.cache.Set(nonce, data, ttlcache.DefaultTTL)
+	return nonce
+}
+
+// Take returns the session for a nonce exactly once; expired or unknown nonces return false.
+func (s *nonceStore) Take(nonce string) (session.Data, bool) {
+	item, ok := s.cache.GetAndDelete(nonce)
+	if !ok {
+		return session.Data{}, false
+	}
+	return item.Value(), true
+}

--- a/orchestrator/careplancontributor/applaunch/verification/service.go
+++ b/orchestrator/careplancontributor/applaunch/verification/service.go
@@ -1,0 +1,437 @@
+package verification
+
+import (
+	"bytes"
+	"cmp"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"path"
+	"strings"
+	"time"
+
+	fhirclient "github.com/SanteonNL/go-fhir-client"
+	"github.com/SanteonNL/orca/orchestrator/careplancontributor/applaunch/clients"
+	"github.com/SanteonNL/orca/orchestrator/careplancontributor/applaunch/session"
+	"github.com/SanteonNL/orca/orchestrator/careplancontributor/oidc/rp"
+	"github.com/SanteonNL/orca/orchestrator/careplanservice"
+	"github.com/SanteonNL/orca/orchestrator/cmd/profile"
+	"github.com/SanteonNL/orca/orchestrator/cmd/tenants"
+	"github.com/SanteonNL/orca/orchestrator/globals"
+	"github.com/SanteonNL/orca/orchestrator/lib/auth"
+	"github.com/SanteonNL/orca/orchestrator/lib/coolfhir"
+	"github.com/SanteonNL/orca/orchestrator/lib/logging"
+	"github.com/SanteonNL/orca/orchestrator/lib/to"
+	"github.com/SanteonNL/orca/orchestrator/user"
+	"github.com/google/uuid"
+	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
+)
+
+const fhirLauncherKey = "verification"
+const launchURLTTL = time.Minute
+
+const contentTypeJSON = "application/json"
+
+// fhirBaseURLIdentifierSystem addresses an SCP node by its FHIR base URL, which the profile resolves
+// to an authorization server through the node's CapabilityStatement.
+const fhirBaseURLIdentifierSystem = "https://build.fhir.org/http.html#root"
+
+func init() {
+	// Fallback only: every resource the frontend needs is cached in the session, so this client should
+	// never be exercised. It points at the local CPS so a miss fails loudly against real data.
+	clients.Factories[fhirLauncherKey] = func(properties map[string]string) clients.ClientProperties {
+		baseURL, _ := url.Parse(properties["cps"])
+		return clients.ClientProperties{
+			BaseURL: baseURL,
+			Client:  http.DefaultTransport,
+		}
+	}
+}
+
+// tokenValidator is the seam for OIDC token validation, satisfied by rp.Client.
+type tokenValidator interface {
+	ValidateToken(ctx context.Context, tokenString string, options ...rp.ValidateTokenOption) (*rp.TokenClaims, error)
+}
+
+// Service implements an authenticated app launch used to verify the EHR flow without a hospital:
+// a workforce user proves who they are with an OIDC token (Entra), the launch session is built from
+// the local CPS's own Task/Patient — mirroring a real launch — and a single-use URL bridges the
+// authenticated call into a browser session. Unlike the demo launch this can be enabled in production.
+type Service struct {
+	sessionManager     *user.SessionManager[session.Data]
+	config             Config
+	tenants            tenants.Config
+	orcaPublicURL      *url.URL
+	frontendLandingUrl *url.URL
+	profile            profile.Provider
+	tokenValidator     tokenValidator
+	nonces             *nonceStore
+}
+
+func New(
+	ctx context.Context,
+	config Config,
+	sessionManager *user.SessionManager[session.Data],
+	tenantsConfig tenants.Config,
+	orcaPublicURL *url.URL,
+	frontendLandingUrl *url.URL,
+	profile profile.Provider,
+) (*Service, error) {
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+	var oidcClient tokenValidator
+	if config.OIDC.Enabled {
+		client, err := rp.NewClient(ctx, &config.OIDC)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create OIDC client for verification app launch: %w", err)
+		}
+		oidcClient = client
+	}
+	return &Service{
+		sessionManager:     sessionManager,
+		config:             config,
+		tenants:            tenantsConfig,
+		orcaPublicURL:      orcaPublicURL,
+		frontendLandingUrl: frontendLandingUrl,
+		profile:            profile,
+		tokenValidator:     oidcClient,
+		nonces:             newNonceStore(launchURLTTL),
+	}, nil
+}
+
+func (s *Service) RegisterHandlers(mux *http.ServeMux) {
+	// Entrypoint for our own workforce application, authenticated with an OIDC token. Only registered
+	// where that application can reach us; the launch is delegated when another node owns the Task.
+	if s.tokenValidator != nil {
+		mux.HandleFunc("POST /verification-launch", s.handleCreate)
+	}
+	// Entrypoint for another SCP node delegating a launch, authenticated over Shared Care Planning's
+	// existing trust: no identity provider of the calling party has to be trusted here.
+	mux.HandleFunc("POST /verification-launch/scp", s.profile.Authenticator(s.handleCreateForNode))
+	mux.HandleFunc("GET /verification-launch/{nonce}", s.handleRedeem)
+}
+
+func (s *Service) CreateEHRProxies() (map[string]coolfhir.HttpProxy, map[string]fhirclient.Client) {
+	// there is no EHR behind a verification launch; external SCP nodes have nothing to query here
+	return map[string]coolfhir.HttpProxy{}, map[string]fhirclient.Client{}
+}
+
+type createLaunchRequest struct {
+	Tenant string `json:"tenant"`
+	TaskID string `json:"taskId"`
+	// TaskReference is the absolute URL of the enrollment Task. When it belongs to another SCP node
+	// the launch is delegated there, so the session, frontend and OIDC issuer stay with the care
+	// organization that owns the enrollment — exactly as in a launch from its own EHR.
+	TaskReference string `json:"taskReference"`
+	// PractitionerName is asserted by the caller: app tokens (client credentials) carry no user
+	// claims, so the calling system passes along who initiated the launch.
+	PractitionerName string `json:"practitionerName"`
+}
+
+type createLaunchResponse struct {
+	LaunchURL        string `json:"launchUrl"`
+	ExpiresInSeconds int    `json:"expiresInSeconds"`
+}
+
+func (s *Service) handleCreate(response http.ResponseWriter, request *http.Request) {
+	claims, ok := s.authenticate(response, request)
+	if !ok {
+		return
+	}
+	launchRequest, ok := decodeLaunchRequest(response, request)
+	if !ok {
+		return
+	}
+	launchRequest.PractitionerName = cmp.Or(launchRequest.PractitionerName, claims.Name, "Backoffice verification")
+	s.createLaunch(response, request, launchRequest, claims.Subject, true)
+}
+
+// handleCreateForNode serves a launch delegated by another SCP node. It never delegates onwards, so a
+// launch can't be bounced between nodes, and it trusts the calling node for the practitioner's name
+// the same way the rest of Shared Care Planning trusts it for the data it sends.
+func (s *Service) handleCreateForNode(response http.ResponseWriter, request *http.Request) {
+	principal, err := auth.PrincipalFromContext(request.Context())
+	if err != nil {
+		http.Error(response, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+		return
+	}
+	launchRequest, ok := decodeLaunchRequest(response, request)
+	if !ok {
+		return
+	}
+	launchRequest.PractitionerName = cmp.Or(launchRequest.PractitionerName, "Verification launch")
+	s.createLaunch(response, request, launchRequest, to.EmptyString(principal.Organization.Name), false)
+}
+
+func decodeLaunchRequest(response http.ResponseWriter, request *http.Request) (createLaunchRequest, bool) {
+	var launchRequest createLaunchRequest
+	if err := json.NewDecoder(request.Body).Decode(&launchRequest); err != nil {
+		http.Error(response, "Invalid request body", http.StatusBadRequest)
+		return launchRequest, false
+	}
+	if launchRequest.TaskReference == "" && (launchRequest.Tenant == "" || launchRequest.TaskID == "") {
+		http.Error(response, "taskReference, or tenant and taskId, are required", http.StatusBadRequest)
+		return launchRequest, false
+	}
+	return launchRequest, true
+}
+
+func (s *Service) createLaunch(response http.ResponseWriter, request *http.Request, launchRequest createLaunchRequest, initiatedBy string, mayDelegate bool) {
+	ctx := request.Context()
+
+	tenant, taskID, remoteCPSURL, err := s.resolveTask(launchRequest)
+	if err != nil {
+		http.Error(response, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	if remoteCPSURL != nil {
+		if !mayDelegate {
+			http.Error(response, "Task is not held by this node", http.StatusBadRequest)
+			return
+		}
+		// Delegating acquires an access token as one of our own care organizations, so the tenant we
+		// act as has to be in context.
+		actingTenant, err := s.actingTenant(launchRequest.Tenant)
+		if err != nil {
+			http.Error(response, err.Error(), http.StatusBadRequest)
+			return
+		}
+		s.delegateLaunch(tenants.WithTenant(ctx, *actingTenant), response, remoteCPSURL, launchRequest)
+		return
+	}
+
+	ctx = tenants.WithTenant(ctx, *tenant)
+	sessionData, err := s.buildSession(ctx, *tenant, taskID, launchRequest.PractitionerName)
+	if err != nil {
+		slog.ErrorContext(ctx, "Verification launch failed", slog.String(logging.FieldError, err.Error()))
+		http.Error(response, "Failed to prepare launch", http.StatusUnprocessableEntity)
+		return
+	}
+
+	nonce := s.nonces.Put(*sessionData)
+	slog.InfoContext(ctx, "Verification launch prepared",
+		slog.String("tenant", tenant.ID),
+		slog.String("task_id", taskID),
+		slog.String("initiated_by", initiatedBy),
+		slog.String("initiated_by_name", launchRequest.PractitionerName))
+
+	response.Header().Set("Content-Type", contentTypeJSON)
+	_ = json.NewEncoder(response).Encode(createLaunchResponse{
+		LaunchURL:        s.orcaPublicURL.JoinPath("verification-launch", nonce).String(),
+		ExpiresInSeconds: int(launchURLTTL.Seconds()),
+	})
+}
+
+// actingTenant picks the local care organization to delegate as: the requested one, or the only one
+// this node serves.
+func (s *Service) actingTenant(requested string) (*tenants.Properties, error) {
+	if requested != "" {
+		tenant, err := s.tenants.Get(requested)
+		if err != nil {
+			return nil, errors.New("Invalid tenant")
+		}
+		return tenant, nil
+	}
+	if len(s.tenants) != 1 {
+		return nil, errors.New("tenant is required to delegate this launch")
+	}
+	for _, tenant := range s.tenants {
+		return &tenant, nil
+	}
+	return nil, errors.New("tenant is required to delegate this launch")
+}
+
+// resolveTask determines which CarePlanService holds the Task. It returns either a local tenant, or
+// the FHIR base URL of the remote CarePlanService that does.
+func (s *Service) resolveTask(launchRequest createLaunchRequest) (*tenants.Properties, string, *url.URL, error) {
+	if launchRequest.TaskReference == "" {
+		tenant, err := s.tenants.Get(launchRequest.Tenant)
+		if err != nil {
+			return nil, "", nil, errors.New("Invalid tenant")
+		}
+		return tenant, launchRequest.TaskID, nil, nil
+	}
+
+	cpsBaseURL, taskID, err := splitTaskReference(launchRequest.TaskReference)
+	if err != nil {
+		return nil, "", nil, err
+	}
+	for _, tenant := range s.tenants {
+		if tenant.URL(s.orcaPublicURL, careplanservice.FHIRBaseURL).String() == cpsBaseURL.String() {
+			return &tenant, taskID, nil, nil
+		}
+	}
+	return nil, taskID, cpsBaseURL, nil
+}
+
+func splitTaskReference(taskReference string) (*url.URL, string, error) {
+	baseURL, reference, err := coolfhir.ParseExternalLiteralReference(taskReference, "Task")
+	if err != nil {
+		return nil, "", errors.New("taskReference must point at a Task")
+	}
+	if baseURL.Scheme != "https" || baseURL.Host == "" {
+		return nil, "", errors.New("taskReference must be an absolute https URL")
+	}
+	return baseURL, strings.TrimPrefix(reference, "Task/"), nil
+}
+
+// delegateLaunch asks the node holding the Task to create the launch, and relays its response: the
+// returned URL lives on that node, so redeeming it lands the user in its frontend and its OIDC flow.
+func (s *Service) delegateLaunch(ctx context.Context, response http.ResponseWriter, cpsBaseURL *url.URL, launchRequest createLaunchRequest) {
+	httpClient, err := s.profile.HttpClient(ctx, fhir.Identifier{
+		System: to.Ptr(fhirBaseURLIdentifierSystem),
+		Value:  to.Ptr(cpsBaseURL.String()),
+	})
+	if err != nil {
+		slog.ErrorContext(ctx, "Verification launch delegation failed: no client for remote node",
+			slog.String("cps", cpsBaseURL.String()), slog.String(logging.FieldError, err.Error()))
+		http.Error(response, "Failed to reach the node holding this Task", http.StatusBadGateway)
+		return
+	}
+
+	body, _ := json.Marshal(createLaunchRequest{
+		TaskReference:    launchRequest.TaskReference,
+		PractitionerName: launchRequest.PractitionerName,
+	})
+	targetURL := nodeBaseURL(cpsBaseURL).JoinPath("verification-launch", "scp").String()
+	remoteResponse, err := httpClient.Post(targetURL, contentTypeJSON, bytes.NewReader(body))
+	if err != nil {
+		slog.ErrorContext(ctx, "Verification launch delegation failed",
+			slog.String("target", targetURL), slog.String(logging.FieldError, err.Error()))
+		http.Error(response, "Failed to reach the node holding this Task", http.StatusBadGateway)
+		return
+	}
+	defer remoteResponse.Body.Close()
+
+	if remoteResponse.StatusCode != http.StatusOK {
+		slog.ErrorContext(ctx, "Verification launch rejected by remote node",
+			slog.String("target", targetURL), slog.Int("status", remoteResponse.StatusCode))
+		http.Error(response, "The node holding this Task rejected the launch", http.StatusBadGateway)
+		return
+	}
+
+	var launch createLaunchResponse
+	if err := json.NewDecoder(remoteResponse.Body).Decode(&launch); err != nil || launch.LaunchURL == "" {
+		http.Error(response, "The node holding this Task returned an invalid launch", http.StatusBadGateway)
+		return
+	}
+
+	slog.InfoContext(ctx, "Verification launch delegated",
+		slog.String("cps", cpsBaseURL.String()),
+		slog.String("initiated_by_name", launchRequest.PractitionerName))
+
+	response.Header().Set("Content-Type", contentTypeJSON)
+	_ = json.NewEncoder(response).Encode(launch)
+}
+
+// nodeBaseURL strips the "/cps/{tenant}" suffix a CarePlanService FHIR base URL carries, leaving the
+// node's public base URL.
+func nodeBaseURL(cpsBaseURL *url.URL) *url.URL {
+	base := *cpsBaseURL
+	base.Path = path.Dir(path.Dir(strings.TrimSuffix(base.Path, "/")))
+	return &base
+}
+
+func (s *Service) handleRedeem(response http.ResponseWriter, request *http.Request) {
+	sessionData, ok := s.nonces.Take(request.PathValue("nonce"))
+	if !ok {
+		http.Error(response, "Launch URL is invalid or expired", http.StatusNotFound)
+		return
+	}
+	s.sessionManager.Create(response, sessionData)
+	redirectURL := s.frontendLandingUrl
+	if taskResource := sessionData.GetByType("Task"); taskResource != nil {
+		redirectURL = redirectURL.JoinPath("task", strings.Split(taskResource.Path, "/")[1])
+	}
+	http.Redirect(response, request, redirectURL.String(), http.StatusFound)
+}
+
+func (s *Service) authenticate(response http.ResponseWriter, request *http.Request) (*rp.TokenClaims, bool) {
+	token := strings.TrimPrefix(request.Header.Get("Authorization"), "Bearer ")
+	if token == "" || token == request.Header.Get("Authorization") {
+		http.Error(response, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+		return nil, false
+	}
+	claims, err := s.tokenValidator.ValidateToken(request.Context(), token)
+	if err != nil {
+		slog.WarnContext(request.Context(), "Verification launch token rejected", slog.String(logging.FieldError, err.Error()))
+		http.Error(response, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+		return nil, false
+	}
+	return claims, true
+}
+
+// buildSession mirrors what a real launch leaves behind: Patient, Practitioner, Organization,
+// ServiceRequest and Condition, all cached in the session so the frontend needs no EHR. Everything is
+// derived server-side from the Task — the caller only chooses which enrollment to launch.
+func (s *Service) buildSession(ctx context.Context, tenant tenants.Properties, taskID string, practitionerName string) (*session.Data, error) {
+	cpsFHIRClient, err := globals.CreateCPSFHIRClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	var task fhir.Task
+	if err := cpsFHIRClient.ReadWithContext(ctx, "Task/"+taskID, &task); err != nil {
+		return nil, fmt.Errorf("failed to read Task: %w", err)
+	}
+	if task.For == nil || task.For.Reference == nil || !strings.HasPrefix(*task.For.Reference, "Patient/") {
+		return nil, fmt.Errorf("task %s has no patient reference", taskID)
+	}
+
+	var patient fhir.Patient
+	if err := cpsFHIRClient.ReadWithContext(ctx, *task.For.Reference, &patient); err != nil {
+		return nil, fmt.Errorf("failed to read Patient: %w", err)
+	}
+
+	sessionData := session.Data{
+		FHIRLauncher: fhirLauncherKey,
+		TenantID:     tenant.ID,
+		LauncherProperties: map[string]string{
+			"cps": tenant.URL(s.orcaPublicURL, careplanservice.FHIRBaseURL).String(),
+		},
+	}
+	sessionData.Set(*task.For.Reference, patient)
+	sessionData.Set("Task/"+taskID, task)
+
+	practitioner := fhir.Practitioner{
+		Id:   to.Ptr("magic-" + uuid.NewString()),
+		Name: []fhir.HumanName{{Text: to.Ptr(practitionerName)}},
+	}
+	sessionData.Set("Practitioner/"+*practitioner.Id, practitioner)
+
+	organizations, err := s.profile.Identities(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to determine organization: %w", err)
+	}
+	if len(organizations) != 1 {
+		return nil, fmt.Errorf("expected 1 organization, found %d", len(organizations))
+	}
+	sessionData.Set("Organization/magic-"+uuid.NewString(), organizations[0])
+
+	if task.Focus != nil && task.Focus.Reference != nil && strings.HasPrefix(*task.Focus.Reference, "ServiceRequest/") {
+		var serviceRequest fhir.ServiceRequest
+		if err := cpsFHIRClient.ReadWithContext(ctx, *task.Focus.Reference, &serviceRequest); err == nil {
+			sessionData.Set(*task.Focus.Reference, serviceRequest)
+		}
+	}
+
+	if task.ReasonCode != nil && len(task.ReasonCode.Coding) > 0 {
+		condition := fhir.Condition{
+			Id:   to.Ptr("magic-" + uuid.NewString()),
+			Code: task.ReasonCode,
+		}
+		sessionData.Set("Condition/"+*condition.Id, condition)
+	}
+
+	if len(task.Identifier) > 0 {
+		sessionData.TaskIdentifier = to.Ptr(coolfhir.ToString(&task.Identifier[0]))
+	}
+
+	return &sessionData, nil
+}

--- a/orchestrator/careplancontributor/applaunch/verification/service_test.go
+++ b/orchestrator/careplancontributor/applaunch/verification/service_test.go
@@ -1,0 +1,385 @@
+package verification
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/SanteonNL/orca/orchestrator/careplancontributor/applaunch/session"
+	"github.com/SanteonNL/orca/orchestrator/careplancontributor/oidc/rp"
+	"github.com/SanteonNL/orca/orchestrator/cmd/profile"
+	"github.com/SanteonNL/orca/orchestrator/cmd/tenants"
+	"github.com/SanteonNL/orca/orchestrator/globals"
+	"github.com/SanteonNL/orca/orchestrator/lib/auth"
+	"github.com/SanteonNL/orca/orchestrator/lib/must"
+	"github.com/SanteonNL/orca/orchestrator/lib/test"
+	"github.com/SanteonNL/orca/orchestrator/lib/to"
+	"github.com/SanteonNL/orca/orchestrator/user"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/zorgbijjou/golang-fhir-models/fhir-models/fhir"
+)
+
+func testService(t *testing.T) (*Service, *rp.TestTokenGenerator, *user.SessionManager[session.Data], tenants.Properties) {
+	t.Helper()
+
+	generator, err := rp.NewTestTokenGenerator()
+	require.NoError(t, err)
+	validator, err := rp.NewMockClient(context.Background(), generator)
+	require.NoError(t, err)
+
+	tenantCfg := tenants.Test()
+	tenant := tenantCfg.Sole()
+
+	globals.RegisterCPSFHIRClient(tenant.ID, &test.StubFHIRClient{
+		Resources: []interface{}{
+			fhir.Task{
+				Id:         to.Ptr("task-1"),
+				Status:     fhir.TaskStatusInProgress,
+				Intent:     "order",
+				For:        &fhir.Reference{Reference: to.Ptr("Patient/patient-1")},
+				Focus:      &fhir.Reference{Reference: to.Ptr("ServiceRequest/sr-1")},
+				Identifier: []fhir.Identifier{{System: to.Ptr("unit-test-system"), Value: to.Ptr("10")}},
+				ReasonCode: &fhir.CodeableConcept{
+					Coding: []fhir.Coding{{System: to.Ptr("http://snomed.info/sct"), Code: to.Ptr("13645005")}},
+				},
+			},
+			fhir.Patient{Id: to.Ptr("patient-1")},
+			fhir.ServiceRequest{Id: to.Ptr("sr-1"), Status: fhir.RequestStatusActive, Intent: fhir.RequestIntentOrder},
+			fhir.Task{
+				Id:     to.Ptr("task-no-patient"),
+				Status: fhir.TaskStatusInProgress,
+				Intent: "order",
+			},
+		},
+	})
+
+	sessionManager := user.NewSessionManager[session.Data](time.Minute)
+	service := &Service{
+		sessionManager:     sessionManager,
+		config:             Config{Enabled: true},
+		tenants:            tenantCfg,
+		orcaPublicURL:      must.ParseURL("https://orca.example.com/orca"),
+		frontendLandingUrl: must.ParseURL("/frontend/enrollment"),
+		profile:            profile.TestProfile{Principal: auth.TestPrincipal1},
+		tokenValidator:     validator,
+		nonces:             newNonceStore(launchURLTTL),
+	}
+	return service, generator, sessionManager, tenant
+}
+
+func createLaunch(t *testing.T, service *Service, token string, body string) *httptest.ResponseRecorder {
+	t.Helper()
+	request := httptest.NewRequest("POST", "/verification-launch", strings.NewReader(body))
+	if token != "" {
+		request.Header.Set("Authorization", "Bearer "+token)
+	}
+	response := httptest.NewRecorder()
+	service.handleCreate(response, request)
+	return response
+}
+
+func TestService_VerificationLaunch(t *testing.T) {
+	t.Run("full flow: create, redeem once, session mirrors a real launch", func(t *testing.T) {
+		service, generator, sessionManager, tenant := testService(t)
+		token, err := generator.CreateToken(map[string]interface{}{"name": "Wiebe (verification)"})
+		require.NoError(t, err)
+
+		response := createLaunch(t, service, token, `{"tenant":"`+tenant.ID+`","taskId":"task-1","practitionerName":"Dr. Verification"}`)
+		require.Equal(t, http.StatusOK, response.Code)
+
+		var launch createLaunchResponse
+		require.NoError(t, json.Unmarshal(response.Body.Bytes(), &launch))
+		require.Contains(t, launch.LaunchURL, "https://orca.example.com/orca/verification-launch/")
+
+		nonce := launch.LaunchURL[strings.LastIndex(launch.LaunchURL, "/")+1:]
+		redeemRequest := httptest.NewRequest("GET", "/verification-launch/"+nonce, nil)
+		redeemRequest.SetPathValue("nonce", nonce)
+		redeemResponse := httptest.NewRecorder()
+		service.handleRedeem(redeemResponse, redeemRequest)
+
+		require.Equal(t, http.StatusFound, redeemResponse.Code)
+		assert.Equal(t, "/frontend/enrollment/task/task-1", redeemResponse.Header().Get("Location"))
+
+		sessionData := user.SessionFromHttpResponse(sessionManager, redeemResponse.Result())
+		require.NotNil(t, sessionData)
+		assert.Equal(t, fhirLauncherKey, sessionData.FHIRLauncher)
+		assert.Equal(t, tenant.ID, sessionData.TenantID)
+		assert.Equal(t, "Patient/patient-1", sessionData.GetByType("Patient").Path)
+		assert.Equal(t, "ServiceRequest/sr-1", sessionData.GetByType("ServiceRequest").Path)
+		assert.Equal(t, "unit-test-system|10", *sessionData.TaskIdentifier)
+
+		practitioner := session.Get[fhir.Practitioner](sessionData)
+		require.NotNil(t, practitioner)
+		assert.Equal(t, "Dr. Verification", *practitioner.Name[0].Text)
+
+		condition := session.Get[fhir.Condition](sessionData)
+		require.NotNil(t, condition)
+		assert.Equal(t, "13645005", *condition.Code.Coding[0].Code)
+
+		require.NotNil(t, session.Get[fhir.Organization](sessionData))
+
+		// single use
+		secondRedeem := httptest.NewRecorder()
+		retryRequest := httptest.NewRequest("GET", "/verification-launch/"+nonce, nil)
+		retryRequest.SetPathValue("nonce", nonce)
+		service.handleRedeem(secondRedeem, retryRequest)
+		assert.Equal(t, http.StatusNotFound, secondRedeem.Code)
+	})
+
+	t.Run("practitioner falls back to token claims when not asserted", func(t *testing.T) {
+		service, generator, sessionManager, tenant := testService(t)
+		token, err := generator.CreateToken(map[string]interface{}{"name": "Wiebe (verification)"})
+		require.NoError(t, err)
+
+		response := createLaunch(t, service, token, `{"tenant":"`+tenant.ID+`","taskId":"task-1"}`)
+		require.Equal(t, http.StatusOK, response.Code)
+
+		var launch createLaunchResponse
+		require.NoError(t, json.Unmarshal(response.Body.Bytes(), &launch))
+		nonce := launch.LaunchURL[strings.LastIndex(launch.LaunchURL, "/")+1:]
+		redeemRequest := httptest.NewRequest("GET", "/verification-launch/"+nonce, nil)
+		redeemRequest.SetPathValue("nonce", nonce)
+		redeemResponse := httptest.NewRecorder()
+		service.handleRedeem(redeemResponse, redeemRequest)
+
+		sessionData := user.SessionFromHttpResponse(sessionManager, redeemResponse.Result())
+		require.NotNil(t, sessionData)
+		practitioner := session.Get[fhir.Practitioner](sessionData)
+		require.NotNil(t, practitioner)
+		assert.Equal(t, "Wiebe (verification)", *practitioner.Name[0].Text)
+	})
+
+	t.Run("missing token is rejected", func(t *testing.T) {
+		service, _, _, tenant := testService(t)
+		response := createLaunch(t, service, "", `{"tenant":"`+tenant.ID+`","taskId":"task-1"}`)
+		assert.Equal(t, http.StatusUnauthorized, response.Code)
+	})
+
+	t.Run("token for another audience is rejected", func(t *testing.T) {
+		service, generator, _, tenant := testService(t)
+		token, err := generator.CreateInvalidAudienceToken()
+		require.NoError(t, err)
+		response := createLaunch(t, service, token, `{"tenant":"`+tenant.ID+`","taskId":"task-1"}`)
+		assert.Equal(t, http.StatusUnauthorized, response.Code)
+	})
+
+	t.Run("expired token is rejected", func(t *testing.T) {
+		service, generator, _, tenant := testService(t)
+		token, err := generator.CreateExpiredToken()
+		require.NoError(t, err)
+		response := createLaunch(t, service, token, `{"tenant":"`+tenant.ID+`","taskId":"task-1"}`)
+		assert.Equal(t, http.StatusUnauthorized, response.Code)
+	})
+
+	t.Run("unknown tenant is rejected", func(t *testing.T) {
+		service, generator, _, _ := testService(t)
+		token, err := generator.CreateToken(nil)
+		require.NoError(t, err)
+		response := createLaunch(t, service, token, `{"tenant":"nope","taskId":"task-1"}`)
+		assert.Equal(t, http.StatusBadRequest, response.Code)
+	})
+
+	t.Run("task without a patient is rejected", func(t *testing.T) {
+		service, generator, _, tenant := testService(t)
+		token, err := generator.CreateToken(nil)
+		require.NoError(t, err)
+		response := createLaunch(t, service, token, `{"tenant":"`+tenant.ID+`","taskId":"task-no-patient"}`)
+		assert.Equal(t, http.StatusUnprocessableEntity, response.Code)
+	})
+
+	t.Run("unknown nonce is rejected", func(t *testing.T) {
+		service, _, _, _ := testService(t)
+		request := httptest.NewRequest("GET", "/verification-launch/nope", nil)
+		request.SetPathValue("nonce", "nope")
+		response := httptest.NewRecorder()
+		service.handleRedeem(response, request)
+		assert.Equal(t, http.StatusNotFound, response.Code)
+	})
+}
+
+// nodeCallingTestProfile hands out a client that trusts the test node's TLS certificate.
+type nodeCallingTestProfile struct {
+	profile.TestProfile
+	client *http.Client
+}
+
+func (p nodeCallingTestProfile) HttpClient(context.Context, fhir.Identifier) (*http.Client, error) {
+	return p.client, nil
+}
+
+func TestService_DelegatesToNodeHoldingTheTask(t *testing.T) {
+	t.Run("relays the launch URL of the node that owns the Task", func(t *testing.T) {
+		var receivedPath, receivedBody string
+		remoteNode := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+			receivedPath = request.URL.Path
+			body, _ := io.ReadAll(request.Body)
+			receivedBody = string(body)
+			response.Header().Set("Content-Type", "application/json")
+			_, _ = response.Write([]byte(`{"launchUrl":"https://hospital.example.com/orca/verification-launch/abc","expiresInSeconds":60}`))
+		}))
+		defer remoteNode.Close()
+
+		service, generator, _, _ := testService(t)
+		service.profile = nodeCallingTestProfile{TestProfile: profile.TestProfile{Principal: auth.TestPrincipal1}, client: remoteNode.Client()}
+		token, err := generator.CreateToken(nil)
+		require.NoError(t, err)
+
+		taskRef := remoteNode.URL + "/orca/cps/saz/Task/task-42"
+		response := createLaunch(t, service, token, `{"taskReference":"`+taskRef+`","practitionerName":"Wiebe"}`)
+
+		require.Equal(t, http.StatusOK, response.Code)
+		var launch createLaunchResponse
+		require.NoError(t, json.Unmarshal(response.Body.Bytes(), &launch))
+		// the URL must stay on the owning node, so its frontend and OIDC provider serve the launch
+		assert.Equal(t, "https://hospital.example.com/orca/verification-launch/abc", launch.LaunchURL)
+		assert.Equal(t, "/orca/verification-launch/scp", receivedPath)
+		assert.Contains(t, receivedBody, taskRef)
+		assert.Contains(t, receivedBody, "Wiebe")
+	})
+
+	t.Run("a delegated launch is not delegated onwards", func(t *testing.T) {
+		service, _, _, _ := testService(t)
+		request := httptest.NewRequest("POST", "/verification-launch/scp",
+			strings.NewReader(`{"taskReference":"https://elsewhere.example.com/orca/cps/saz/Task/task-1"}`))
+		request = request.WithContext(auth.WithPrincipal(request.Context(), *auth.TestPrincipal1))
+		response := httptest.NewRecorder()
+
+		service.handleCreateForNode(response, request)
+
+		assert.Equal(t, http.StatusBadRequest, response.Code)
+	})
+
+	t.Run("unauthenticated node request is rejected", func(t *testing.T) {
+		service, _, _, _ := testService(t)
+		request := httptest.NewRequest("POST", "/verification-launch/scp", strings.NewReader(`{}`))
+		response := httptest.NewRecorder()
+
+		service.handleCreateForNode(response, request)
+
+		assert.Equal(t, http.StatusUnauthorized, response.Code)
+	})
+}
+
+func TestService_WithoutOIDC_OnlyServesDelegatedLaunches(t *testing.T) {
+	// A node that no workforce application calls directly must not expose the token-authenticated
+	// entrypoint at all, so no identity provider of another party has to be trusted there.
+	service, err := New(
+		context.Background(),
+		Config{Enabled: true},
+		user.NewSessionManager[session.Data](time.Minute),
+		tenants.Test(),
+		must.ParseURL("https://orca.example.com/orca"),
+		must.ParseURL("/frontend/enrollment"),
+		profile.TestProfile{Principal: auth.TestPrincipal1},
+	)
+	require.NoError(t, err)
+
+	mux := http.NewServeMux()
+	service.RegisterHandlers(mux)
+
+	_, entraPattern := mux.Handler(httptest.NewRequest("POST", "/verification-launch", nil))
+	assert.Empty(t, entraPattern, "the OIDC entrypoint must not be registered without OIDC configuration")
+	_, scpPattern := mux.Handler(httptest.NewRequest("POST", "/verification-launch/scp", nil))
+	assert.Equal(t, "POST /verification-launch/scp", scpPattern)
+
+	proxies, clients := service.CreateEHRProxies()
+	assert.Empty(t, proxies)
+	assert.Empty(t, clients)
+}
+
+func TestService_LaunchRequestErrors(t *testing.T) {
+	token := func(t *testing.T, g *rp.TestTokenGenerator) string {
+		t.Helper()
+		tok, err := g.CreateToken(nil)
+		require.NoError(t, err)
+		return tok
+	}
+
+	t.Run("malformed body is rejected", func(t *testing.T) {
+		service, generator, _, _ := testService(t)
+		response := createLaunch(t, service, token(t, generator), `not json`)
+		assert.Equal(t, http.StatusBadRequest, response.Code)
+	})
+
+	t.Run("body without a Task is rejected", func(t *testing.T) {
+		service, generator, _, _ := testService(t)
+		response := createLaunch(t, service, token(t, generator), `{}`)
+		assert.Equal(t, http.StatusBadRequest, response.Code)
+	})
+
+	t.Run("delegating for an unknown tenant is rejected", func(t *testing.T) {
+		service, generator, _, _ := testService(t)
+		response := createLaunch(t, service, token(t, generator),
+			`{"tenant":"nope","taskReference":"https://hospital.example.com/orca/cps/saz/Task/task-1"}`)
+		assert.Equal(t, http.StatusBadRequest, response.Code)
+	})
+
+	for _, tc := range []struct {
+		name    string
+		handler http.HandlerFunc
+	}{
+		{"remote node rejects the launch", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusForbidden) }},
+		{"remote node returns an unreadable launch", func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte(`{`)) }},
+		{"remote node returns no launch URL", func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte(`{}`)) }},
+	} {
+		t.Run(tc.name+" surfaces as bad gateway", func(t *testing.T) {
+			remoteNode := httptest.NewTLSServer(tc.handler)
+			defer remoteNode.Close()
+
+			service, generator, _, _ := testService(t)
+			service.profile = nodeCallingTestProfile{TestProfile: profile.TestProfile{Principal: auth.TestPrincipal1}, client: remoteNode.Client()}
+
+			response := createLaunch(t, service, token(t, generator),
+				`{"taskReference":"`+remoteNode.URL+`/orca/cps/saz/Task/task-1"}`)
+			assert.Equal(t, http.StatusBadGateway, response.Code)
+		})
+	}
+}
+
+func TestSplitTaskReference(t *testing.T) {
+	t.Run("splits CPS base URL and Task ID", func(t *testing.T) {
+		base, taskID, err := splitTaskReference("https://hospital.example.com/orca/cps/saz/Task/abc")
+		require.NoError(t, err)
+		assert.Equal(t, "https://hospital.example.com/orca/cps/saz", base.String())
+		assert.Equal(t, "abc", taskID)
+		assert.Equal(t, "https://hospital.example.com/orca", nodeBaseURL(base).String())
+	})
+	for _, invalid := range []string{
+		"http://hospital.example.com/orca/cps/saz/Task/abc",
+		"/orca/cps/saz/Task/abc",
+		"https://hospital.example.com/orca/cps/saz/Task/abc/_history/1",
+		"https://hospital.example.com/orca/cps/saz/CarePlan/abc",
+	} {
+		t.Run("rejects "+invalid, func(t *testing.T) {
+			_, _, err := splitTaskReference(invalid)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestNonceStore(t *testing.T) {
+	t.Run("expired nonce cannot be redeemed", func(t *testing.T) {
+		store := newNonceStore(time.Millisecond)
+		nonce := store.Put(session.Data{TenantID: "test"})
+		time.Sleep(5 * time.Millisecond)
+
+		_, ok := store.Take(nonce)
+		assert.False(t, ok)
+	})
+
+	t.Run("nonce is single use", func(t *testing.T) {
+		store := newNonceStore(time.Minute)
+		nonce := store.Put(session.Data{TenantID: "test"})
+
+		_, first := store.Take(nonce)
+		_, second := store.Take(nonce)
+		assert.True(t, first)
+		assert.False(t, second)
+	})
+}

--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -18,6 +18,7 @@ import (
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor/applaunch/demo"
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor/applaunch/session"
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor/applaunch/smartonfhir"
+	"github.com/SanteonNL/orca/orchestrator/careplancontributor/applaunch/verification"
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor/applaunch/zorgplatform"
 	importer "github.com/SanteonNL/orca/orchestrator/careplancontributor/importer"
 	"github.com/SanteonNL/orca/orchestrator/careplancontributor/oidc/op"
@@ -390,6 +391,13 @@ func (s *Service) initializeAppLaunches(sessionManager *user.SessionManager[sess
 		service, err := zorgplatform.New(sessionManager, s.config.AppLaunch.ZorgPlatform, s.tenants, s.orcaPublicURL.String(), frontendUrl, s.profile)
 		if err != nil {
 			return fmt.Errorf("failed to create Zorgplatform AppLaunch service: %w", err)
+		}
+		s.appLaunches = append(s.appLaunches, service)
+	}
+	if s.config.AppLaunch.Verification.Enabled {
+		service, err := verification.New(context.Background(), s.config.AppLaunch.Verification, sessionManager, s.tenants, s.orcaPublicURL, frontendUrl, s.profile)
+		if err != nil {
+			return fmt.Errorf("failed to create Verification AppLaunch service: %w", err)
 		}
 		s.appLaunches = append(s.appLaunches, service)
 	}


### PR DESCRIPTION
## Summary

New `verification` app launch: opens the EHR viewer flow for an enrolled patient without a hospital, so the launch → session → OIDC → viewer chain can be verified in production. Config-gated (`applaunch.verification`), off by default. Existing launches (SMART on FHIR, Zorgplatform, demo) are untouched.

Two entrypoints:
- `POST /verification-launch` — for a workforce application, authenticated with an OIDC bearer token (existing `rp` client; Entra for us). Only registered where OIDC is configured.
- `POST /verification-launch/scp` — for another SCP node delegating a launch, authenticated over Shared Care Planning's own trust. Never delegates onwards.

The body only names the enrollment Task. When another node holds it, the launch is delegated there, so the session, frontend and OIDC issuer stay with the care organization that owns the enrollment — as in a launch from its own EHR. Patient, ServiceRequest and Condition are read server-side from that node's CPS; only the Practitioner name is caller-asserted.

The response is a single-use, 60s launch URL; `GET /verification-launch/{nonce}` creates the session cookie and redirects into the normal frontend flow. All resources are session-cached, so no EHR is needed.

## Context

ZBJ tracking: DEV-2847. Complements #1001 (the Condition ends up in the session, so the viewer receives the `condition` claim like a real launch).

Launch creation logs tenant, task and the initiating user for auditing.
