### PR TITLE
Never write an OperationOutcome without issues

### DIFF
--- a/orchestrator/lib/coolfhir/error.go
+++ b/orchestrator/lib/coolfhir/error.go
@@ -41,6 +41,18 @@ func SanitizeOperationOutcome(in fhir.OperationOutcome) fhir.OperationOutcome {
 			result.Issue = append(result.Issue, issue)
 		}
 	}
+	// OperationOutcome.issue is 1..*; upstream servers (e.g. Azure FHIR on 410 Gone) may return an
+	// OperationOutcome without issues, and a nil slice marshals as "issue": null, which strict FHIR
+	// parsers reject.
+	if len(result.Issue) == 0 {
+		result.Issue = []fhir.OperationOutcomeIssue{
+			{
+				Severity:    fhir.IssueSeverityError,
+				Code:        fhir.IssueTypeProcessing,
+				Diagnostics: to.Ptr("upstream FHIR server error"),
+			},
+		}
+	}
 	return result
 }
 
@@ -95,42 +107,52 @@ func CreateOperationOutcomeBundleEntryFromError(err error, desc string) fhir.Bun
 func WriteOperationOutcomeFromError(ctx context.Context, err error, desc string, httpResponse http.ResponseWriter) {
 	slog.ErrorContext(ctx, fmt.Sprintf("%s failed: %v", desc, err))
 
-	statusCode := http.StatusInternalServerError
-	var operationOutcome fhir.OperationOutcome
+	statusCode, operationOutcome := operationOutcomeFromError(err, desc)
+	SendResponse(httpResponse, statusCode, operationOutcome)
+}
 
+func operationOutcomeFromError(err error, desc string) (int, fhir.OperationOutcome) {
 	// Error type: fhirclient.OperationOutcomeError
 	var operationOutcomeErr = new(fhirclient.OperationOutcomeError)
-	if errors.As(err, operationOutcomeErr) || errors.As(err, &operationOutcomeErr) {
-		if operationOutcomeErr.HttpStatusCode > 0 {
-			statusCode = operationOutcomeErr.HttpStatusCode
-		}
-		operationOutcome = operationOutcomeErr.OperationOutcome
-		if statusCode != http.StatusBadRequest {
-			operationOutcome = SanitizeOperationOutcome(operationOutcome)
-		}
-	} else {
-		// Error type: ErrorWithCode
-		var errorWithCode = new(ErrorWithCode)
-		if errors.As(err, errorWithCode) || errors.As(err, &errorWithCode) {
-			if errorWithCode.StatusCode > 0 {
-				statusCode = errorWithCode.StatusCode
-			}
-		}
+	if !errors.As(err, operationOutcomeErr) && !errors.As(err, &operationOutcomeErr) {
+		return operationOutcomeFromGenericError(err, desc)
+	}
 
-		diagnostics := http.StatusText(statusCode)
-		// Include error message for bad requests
-		if statusCode == http.StatusBadRequest {
-			diagnostics = err.Error()
-		}
-		operationOutcome = fhir.OperationOutcome{
-			Issue: []fhir.OperationOutcomeIssue{
-				{
-					Severity:    fhir.IssueSeverityError,
-					Code:        fhir.IssueTypeProcessing,
-					Diagnostics: to.Ptr(fmt.Sprintf("%s failed: %s", desc, diagnostics)),
-				},
-			},
+	statusCode := http.StatusInternalServerError
+	if operationOutcomeErr.HttpStatusCode > 0 {
+		statusCode = operationOutcomeErr.HttpStatusCode
+	}
+	operationOutcome := operationOutcomeErr.OperationOutcome
+	// Bad requests pass their validation detail through; anything else is sanitized, as is an
+	// outcome that carries no issues at all.
+	if statusCode != http.StatusBadRequest || len(operationOutcome.Issue) == 0 {
+		operationOutcome = SanitizeOperationOutcome(operationOutcome)
+	}
+	return statusCode, operationOutcome
+}
+
+func operationOutcomeFromGenericError(err error, desc string) (int, fhir.OperationOutcome) {
+	statusCode := http.StatusInternalServerError
+	// Error type: ErrorWithCode
+	var errorWithCode = new(ErrorWithCode)
+	if errors.As(err, errorWithCode) || errors.As(err, &errorWithCode) {
+		if errorWithCode.StatusCode > 0 {
+			statusCode = errorWithCode.StatusCode
 		}
 	}
-	SendResponse(httpResponse, statusCode, operationOutcome)
+
+	diagnostics := http.StatusText(statusCode)
+	// Include error message for bad requests
+	if statusCode == http.StatusBadRequest {
+		diagnostics = err.Error()
+	}
+	return statusCode, fhir.OperationOutcome{
+		Issue: []fhir.OperationOutcomeIssue{
+			{
+				Severity:    fhir.IssueSeverityError,
+				Code:        fhir.IssueTypeProcessing,
+				Diagnostics: to.Ptr(fmt.Sprintf("%s failed: %s", desc, diagnostics)),
+			},
+		},
+	}
 }

--- a/orchestrator/lib/coolfhir/error_test.go
+++ b/orchestrator/lib/coolfhir/error_test.go
@@ -167,6 +167,12 @@ func TestSanitizeOperationOutcome(t *testing.T) {
 			assert.Equal(t, "upstream FHIR server error", *sanitized.Issue[0].Diagnostics)
 		})
 	}
+	t.Run("empty issue list gets a default issue (issue is 1..*, nil marshals as null)", func(t *testing.T) {
+		sanitized := SanitizeOperationOutcome(fhir.OperationOutcome{})
+		assert.Len(t, sanitized.Issue, 1)
+		assert.Equal(t, fhir.IssueTypeProcessing, sanitized.Issue[0].Code)
+		assert.Equal(t, "upstream FHIR server error", *sanitized.Issue[0].Diagnostics)
+	})
 	for _, code := range nonSanitizedCodes {
 		t.Run(code.String()+" should not be sanitized", func(t *testing.T) {
 			issue := fhir.OperationOutcomeIssue{


### PR DESCRIPTION
Upstream FHIR servers (e.g. Azure FHIR on 410 Gone) can return an OperationOutcome without any issue entries. The Go models marshal the nil slice as "issue": null, which strict FHIR parsers (Firely SDK) reject — and issue is 1..* in the spec anyway. SanitizeOperationOutcome now backfills a default processing issue, and WriteOperationOutcomeFromError sanitizes issueless outcomes on every status code.

Found via Zorgbijjou datahub: reading a hard-deleted Task through the CPC external FHIR proxy returned 410 with issue:null, crashing the Firely-based consumer.