### PR TITLE
DEV-2896 accept international phone numbers

### DIFF
--- a/deployments/dev/README.md
+++ b/deployments/dev/README.md
@@ -1,12 +1,148 @@
-# Usage
+# Running Orca locally (dev stack)
 
-Run `docker compose up` to start the development environment.
+This directory runs **everything in containers** — the Nuts node, FHIR store, both
+orchestrators, the enrollment frontend, the hospital EHR simulator and the clinic viewer.
+Use it to exercise a flow end-to-end without a debugger attached.
 
-URLs:
-- Hospital EHR (task sender): http://localhost:8081/ehr
-- Clinic EHR (task receiver): http://localhost:8082/viewer
+> Need breakpoints or trace inspection? Use [`../debug`](../debug) instead, which runs the
+> Go/Next.js applications from VS Code against Dockerized infrastructure.
+
+## Prerequisites
+
+- Docker Desktop (running)
+
+## Start
+
+```bash
+# from deployments/dev/ — the .env sets orca_dev_base=., so the relative
+# config mounts only resolve when compose runs from this directory
+docker compose up -d --build
+```
+
+The first build takes several minutes (two Go binaries and three Next.js apps).
+
+## What runs where
+
+| Component | Address |
+|---|---|
+| **Hospital EHR simulator** (start here) | http://localhost:8081/ehr |
+| Clinic viewer (task receiver) | http://localhost:8082/viewer |
+| Enrollment frontend (via hospital proxy) | http://localhost:8081/frontend |
+| Hospital orchestrator | http://localhost:8090 (API only, no page at `/`) |
+| HAPI FHIR store | http://localhost:9090/fhir |
+| Nuts node (internal API) | http://localhost:9081 |
+| Nuts admin UI | http://localhost:1405 |
+| Aspire dashboard (traces) | http://localhost:18888 |
+
+## Sanity checks
+
+```bash
+curl -o /dev/null -w "fhirstore: %{http_code}\n" http://localhost:9090/fhir/metadata  # 200
+curl -o /dev/null -w "nutsnode:  %{http_code}\n" http://localhost:9081/status          # 200
+curl -o /dev/null -w "ehr:       %{http_code}\n" http://localhost:8081/ehr             # 200
+
+# Both organizations must have a DID, or every app launch fails
+curl -s http://localhost:9081/internal/vdr/v2/subject
+# expect: {"clinic":["did:web:..."],"hospital":["did:web:..."]}
+```
+
+## Walkthrough: enrolling a patient
+
+1. Open the hospital EHR simulator at http://localhost:8081/ehr.
+2. **+** → fill in the patient (the phone and email fields are pre-filled with valid
+   defaults; overwrite them to test contact-detail validation) → **Create**.
+3. Click the clipboard icon in the patient's **Service Requests** column.
+4. **+** → pick a service and condition → **Create**.
+5. Click the **Enroll** icon on the ServiceRequest row.
+
+Step 5 opens the enrollment frontend in a **popup window**, so allow popups for
+`localhost:8081`. If the popup is blocked, or you are driving the flow from a script,
+build the launch URL yourself:
+
+```bash
+# ids come from the FHIR store: /Patient, /Practitioner, /ServiceRequest
+open "http://localhost:8081/orca/demo-app-launch?tenant=hospital\
+&patient=Patient%2F<id>&practitioner=Practitioner%2F<id>&serviceRequest=ServiceRequest%2F<id>"
+```
+
+The first screen (*Controleer patiëntgegevens*) shows the patient's contact details.
+Pressing **Volgende stap** creates the Patient at the CarePlanService — this is where
+contact-detail validation runs.
+
+## Testing patient contact-detail validation
+
+`orchestrator/careplanservice/validate_patient.go` gates enrollment on the patient's
+email and phone number, and reports failures as codes that
+`frontend/lib/fhirUtils.ts` turns into the Dutch banner on the confirmation screen:
+
+| Code | Meaning |
+|---|---|
+| `E0001` / `E0003` | email missing / not parseable |
+| `E0002` | no phone number at all |
+| `E0004` | a phone number is present, but none of them is usable |
+
+A number is usable when it normalizes to valid E.164 (`+<country><subscriber>`); a leading
+`00` is rewritten to `+` and a Dutch `06…` to `+316…`. Dutch numbers additionally have to
+be mobile, because enrollment reaches the patient by SMS.
+
+The fast loop — no stack needed:
+
+```bash
+cd orchestrator
+go test ./careplanservice/ -run TestPatientValidator_Validate -v
+```
+
+```bash
+cd frontend
+npx jest __tests__/app/enrollment/new __tests__/lib/fhirUtils.test.ts
+```
+
+To see it end-to-end, run the walkthrough above with the patient's phone set to:
+
+| Phone | Expected |
+|---|---|
+| `+31 6 12345678`, `0612345678` | accepted (Dutch mobile) |
+| `+33 6 12 34 56 78`, `0090 532 123 45 67` | accepted (international, `00` → `+`) |
+| `020-1234567`, `+31 20 1234567` | `E0004` — Dutch, but not mobile |
+| `+33 6 12` | `E0004` — too short for E.164 |
 
 ## Rebuilding
 
-- Browser applications hot reload on changes.
-- Golang applications need to be rebuilt and restarted: `docker compose up --build -d clinic_orchestrator hospital_orchestrator` (use `update.sh`)
+- The browser applications hot reload on changes.
+- Go applications need a rebuild: `./update.sh` (wraps
+  `docker compose up --build -d clinic_orchestrator hospital_orchestrator`).
+
+## Troubleshooting
+
+### `Expected 1 active organization, found 0`, or a blank *Internal Server Error* on app launch
+
+The orchestrator log also shows `Failed to refresh local identities using Nuts node …
+subject not found`. The Nuts node keeps its DIDs in the container's writable layer, which
+is **not** a volume — so recreating the container discards them, and every app launch
+fails until they are re-issued. `docker compose restart nutsnode` is safe; `docker compose
+down`, `--force-recreate`, and bringing individual services up (which can recreate the
+Nuts node as a dependency) are not.
+
+Re-run the bootstrap:
+
+```bash
+docker compose run --rm nutsnode-init
+curl -s http://localhost:9081/internal/vdr/v2/subject   # both DIDs back
+```
+
+### `hospital_frontend` exits with `Symlink node_modules is invalid, it points out of the filesystem root`
+
+`frontend/` is bind-mounted into the container, so a `node_modules` **symlink** on the host
+(handy for running jest in a git worktree) resolves outside the container's root and
+Turbopack panics. `hospital_proxy` then dies too, with `host not found in upstream
+"hospital_frontend:3000"`. Replace the symlink with a real `node_modules` (or delete it —
+the container ships its own) and bring both back up:
+
+```bash
+rm frontend/node_modules
+docker compose up -d hospital_frontend hospital_proxy
+```
+
+### `The "orca_dev_base" variable is not set`
+
+Run `docker compose` from `deployments/dev/`, not from the repository root.

--- a/frontend/__tests__/app/enrollment/new/components/validation-errors.test.tsx
+++ b/frontend/__tests__/app/enrollment/new/components/validation-errors.test.tsx
@@ -51,7 +51,7 @@ describe('ValidationErrors', () => {
 
     render(<ValidationErrors validationErrors={validationErrors} />);
 
-    expect(screen.getByText('Ongeldig telefoonnummer. Voor de aanmelding is minstens één mobiel nummer uit Nederland, België of Duitsland nodig. Controleer de telefoonnummers in het EPD en probeer het opnieuw.')).toBeInTheDocument();
+    expect(screen.getByText('Ongeldig telefoonnummer. Voor de aanmelding is minstens één Nederlands mobiel nummer of een geldig internationaal nummer nodig. Controleer de telefoonnummers in het EPD en probeer het opnieuw.')).toBeInTheDocument();
   });
 
   it('displays separate messages for multiple different error codes', () => {
@@ -60,7 +60,7 @@ describe('ValidationErrors', () => {
     render(<ValidationErrors validationErrors={validationErrors} />);
 
     expect(screen.getByText(/Er is geen e-mailadres/)).toBeInTheDocument();
-    expect(screen.getByText('Ongeldig telefoonnummer. Voor de aanmelding is minstens één mobiel nummer uit Nederland, België of Duitsland nodig. Controleer de telefoonnummers in het EPD en probeer het opnieuw.')).toBeInTheDocument();
+    expect(screen.getByText('Ongeldig telefoonnummer. Voor de aanmelding is minstens één Nederlands mobiel nummer of een geldig internationaal nummer nodig. Controleer de telefoonnummers in het EPD en probeer het opnieuw.')).toBeInTheDocument();
   });
 
   it('displays multiple paragraphs for individual errors', () => {
@@ -80,7 +80,7 @@ describe('ValidationErrors', () => {
     expect(screen.getByText(/Er is geen e-mailadres/)).toBeInTheDocument();
     expect(screen.getByText(/Er is geen telefoonnummer/)).toBeInTheDocument();
     expect(screen.getByText(/Controleer het e-mailadres/)).toBeInTheDocument();
-    expect(screen.getByText('Ongeldig telefoonnummer. Voor de aanmelding is minstens één mobiel nummer uit Nederland, België of Duitsland nodig. Controleer de telefoonnummers in het EPD en probeer het opnieuw.')).toBeInTheDocument();
+    expect(screen.getByText('Ongeldig telefoonnummer. Voor de aanmelding is minstens één Nederlands mobiel nummer of een geldig internationaal nummer nodig. Controleer de telefoonnummers in het EPD en probeer het opnieuw.')).toBeInTheDocument();
   });
 
   it('displays unknown error message for empty validation errors', () => {

--- a/frontend/__tests__/app/enrollment/new/page.test.tsx
+++ b/frontend/__tests__/app/enrollment/new/page.test.tsx
@@ -238,7 +238,7 @@ describe("enrollment validation test", () => {
       await waitFor(() => {
           expect(screen.getByText('Er gaat iets mis')).toBeInTheDocument();
           expect(screen.getByText(/Er is geen e-mailadres/)).toBeInTheDocument();
-          expect(screen.getByText(/Ongeldig telefoonnummer. Voor de aanmelding is minstens één mobiel nummer uit Nederland, België of Duitsland nodig. Controleer de telefoonnummers in het EPD en probeer het opnieuw./)).toBeInTheDocument();
+          expect(screen.getByText(/Ongeldig telefoonnummer. Voor de aanmelding is minstens één Nederlands mobiel nummer of een geldig internationaal nummer nodig. Controleer de telefoonnummers in het EPD en probeer het opnieuw./)).toBeInTheDocument();
       });
   });
 

--- a/frontend/lib/fhirUtils.ts
+++ b/frontend/lib/fhirUtils.ts
@@ -386,7 +386,7 @@ export function codingToMessage(codings: Coding[]): String[] {
 
 export enum MessageType {
     InvalidEmail = "Ongeldig e-mailadres. Controleer het e-mailadres van de patiënt in het EPD en probeer het opnieuw.",
-    InvalidPhone = "Ongeldig telefoonnummer. Voor de aanmelding is minstens één mobiel nummer uit Nederland, België of Duitsland nodig. Controleer de telefoonnummers in het EPD en probeer het opnieuw.",
+    InvalidPhone = "Ongeldig telefoonnummer. Voor de aanmelding is minstens één Nederlands mobiel nummer of een geldig internationaal nummer nodig. Controleer de telefoonnummers in het EPD en probeer het opnieuw.",
     NoEmail = "Er is geen e-mailadres van de patiënt gevonden. Dit is nodig voor de aanmelding. Voeg het e-mailadres toe in het EPD en probeer het opnieuw.",
     NoPhone = "Er is geen telefoonnummer van de patiënt gevonden. Dit is nodig voor de aanmelding. Voeg het telefoonnummer toe in het EPD en probeer het opnieuw.",
     Unknown = "Er is een onbekende fout opgetreden. Probeer het later opnieuw of neem contact op met de systeembeheerder: functioneelbeheer@zorgbijjou.nl. Vermeld daarbij de volgende code: "

--- a/orchestrator/careplanservice/validate_patient.go
+++ b/orchestrator/careplanservice/validate_patient.go
@@ -76,30 +76,46 @@ func validateEmail(email *string) *validation.Error {
 	return nil
 }
 
+var (
+	nonPhoneCharacters = regexp.MustCompile("[^0-9+]")
+	e164               = regexp.MustCompile(`^\+[1-9]\d{7,14}$`)
+)
+
 func validatePhone(phone *string) *validation.Error {
 	if phone == nil || *phone == "" {
 		return &validation.Error{Code: PhoneRequired}
 	}
 
-	normalised := regexp.MustCompile("[^0-9+]").ReplaceAllString(*phone, "")
+	normalised := normalisePhone(*phone)
 
-	// Dutch mobile: 06xxxxxxxx (10 digits) or +316xxxxxxxx (12 digits)
-	if (len(normalised) == 10 && strings.HasPrefix(normalised, "06")) ||
-		(len(normalised) == 12 && strings.HasPrefix(normalised, "+316")) {
-		return nil
+	// Dutch numbers still have to be mobile — we reach the patient by SMS.
+	if strings.HasPrefix(normalised, "+31") && !isDutchMobile(normalised) {
+		return &validation.Error{Code: InvalidPhone}
 	}
 
-	// Belgian mobile: +324xxxxxxxx (12 digits)
-	if len(normalised) == 12 && strings.HasPrefix(normalised, "+324") {
-		return nil
+	if !e164.MatchString(normalised) {
+		return &validation.Error{Code: InvalidPhone}
 	}
 
-	// German mobile: +4915x/+4916x/+4917x (13-14 digits)
-	if (len(normalised) == 13 || len(normalised) == 14) && (strings.HasPrefix(normalised, "+4915") || strings.HasPrefix(normalised, "+4916") || strings.HasPrefix(normalised, "+4917")) {
-		return nil
-	}
+	return nil
+}
 
-	return &validation.Error{Code: InvalidPhone}
+// normalisePhone strips formatting and rewrites the two national prefixes we see in EHR data to E.164.
+func normalisePhone(phone string) string {
+	cleaned := nonPhoneCharacters.ReplaceAllString(phone, "")
+
+	switch {
+	case strings.HasPrefix(cleaned, "00"):
+		return "+" + cleaned[2:]
+	case strings.HasPrefix(cleaned, "06"):
+		return "+31" + cleaned[1:]
+	default:
+		return cleaned
+	}
+}
+
+func isDutchMobile(normalised string) bool {
+	return strings.HasPrefix(normalised, "+316") && len(normalised) == 12
 }
 
 const (

--- a/orchestrator/careplanservice/validate_patient_test.go
+++ b/orchestrator/careplanservice/validate_patient_test.go
@@ -416,7 +416,7 @@ func TestPatientValidator_Validate(t *testing.T) {
 			expectedErr: nil,
 		},
 		{
-			name: "rejects invalid Belgian number (wrong prefix)",
+			name: "rejects national-format Belgian number",
 			patient: &fhir.Patient{
 				Telecom: []fhir.ContactPoint{
 					{
@@ -432,7 +432,7 @@ func TestPatientValidator_Validate(t *testing.T) {
 			expectedErr: []string{InvalidPhone},
 		},
 		{
-			name: "rejects invalid German number (wrong prefix)",
+			name: "rejects national-format German number",
 			patient: &fhir.Patient{
 				Telecom: []fhir.ContactPoint{
 					{
@@ -470,6 +470,166 @@ func TestPatientValidator_Validate(t *testing.T) {
 				},
 			},
 			expectedErr: nil,
+		},
+		{
+			name: "accepts dutch mobile with 0031 prefix",
+			patient: &fhir.Patient{
+				Telecom: []fhir.ContactPoint{
+					{
+						System: &emailSystem,
+						Value:  to.Ptr("test@example.com"),
+					},
+					{
+						System: &phoneSystem,
+						Value:  to.Ptr("0031 6 12345678"),
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "accepts French mobile",
+			patient: &fhir.Patient{
+				Telecom: []fhir.ContactPoint{
+					{
+						System: &emailSystem,
+						Value:  to.Ptr("test@example.com"),
+					},
+					{
+						System: &phoneSystem,
+						Value:  to.Ptr("+33 6 12 34 56 78"),
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "accepts Turkish mobile",
+			patient: &fhir.Patient{
+				Telecom: []fhir.ContactPoint{
+					{
+						System: &emailSystem,
+						Value:  to.Ptr("test@example.com"),
+					},
+					{
+						System: &phoneSystem,
+						Value:  to.Ptr("+90 532 123 45 67"),
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "accepts Moroccan number with 00 prefix",
+			patient: &fhir.Patient{
+				Telecom: []fhir.ContactPoint{
+					{
+						System: &emailSystem,
+						Value:  to.Ptr("test@example.com"),
+					},
+					{
+						System: &phoneSystem,
+						Value:  to.Ptr("00212 612 345 678"),
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "accepts Swiss number with 00 prefix",
+			patient: &fhir.Patient{
+				Telecom: []fhir.ContactPoint{
+					{
+						System: &emailSystem,
+						Value:  to.Ptr("test@example.com"),
+					},
+					{
+						System: &phoneSystem,
+						Value:  to.Ptr("0041 79 123 45 67"),
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "accepts UK number",
+			patient: &fhir.Patient{
+				Telecom: []fhir.ContactPoint{
+					{
+						System: &emailSystem,
+						Value:  to.Ptr("test@example.com"),
+					},
+					{
+						System: &phoneSystem,
+						Value:  to.Ptr("+44 7700 900123"),
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "accepts US number",
+			patient: &fhir.Patient{
+				Telecom: []fhir.ContactPoint{
+					{
+						System: &emailSystem,
+						Value:  to.Ptr("test@example.com"),
+					},
+					{
+						System: &phoneSystem,
+						Value:  to.Ptr("+1 650 555 1234"),
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "accepts German landline",
+			patient: &fhir.Patient{
+				Telecom: []fhir.ContactPoint{
+					{
+						System: &emailSystem,
+						Value:  to.Ptr("test@example.com"),
+					},
+					{
+						System: &phoneSystem,
+						Value:  to.Ptr("+49 30 12345678"),
+					},
+				},
+			},
+			expectedErr: nil,
+		},
+		{
+			name: "rejects dutch landline",
+			patient: &fhir.Patient{
+				Telecom: []fhir.ContactPoint{
+					{
+						System: &emailSystem,
+						Value:  to.Ptr("test@example.com"),
+					},
+					{
+						System: &phoneSystem,
+						Value:  to.Ptr("+31 20 1234567"),
+					},
+				},
+			},
+			expectedErr: []string{InvalidPhone},
+		},
+		{
+			name: "rejects international number that is too short",
+			patient: &fhir.Patient{
+				Telecom: []fhir.ContactPoint{
+					{
+						System: &emailSystem,
+						Value:  to.Ptr("test@example.com"),
+					},
+					{
+						System: &phoneSystem,
+						Value:  to.Ptr("+33 6 12"),
+					},
+				},
+			},
+			expectedErr: []string{InvalidPhone},
 		},
 	}
 


### PR DESCRIPTION
## Summary

- `validatePhone` no longer checks the number against an NL/BE/DE mobile-prefix allowlist. Anything that normalizes to valid E.164 (`^\+[1-9]\d{7,14}$`) is accepted.
- Dutch numbers keep the mobile-only rule (`+316…`, 12 chars) — enrollment reaches the patient by SMS.
- Normalization now rewrites a leading `00` to `+`, so `0032…`/`0090…` from the EHR are recognized instead of being rejected as non-E.164.
- The `E0004` message drops the "Nederland, België of Duitsland" wording.

## Context

Patients with a foreign mobile number could not be enrolled: a French, Turkish or Moroccan number failed validation  because its country code was not on the list. 
