### PR TITLE
Closes redirects that can be manipulated client side

### DIFF
--- a/orchestrator/careplancontributor/service.go
+++ b/orchestrator/careplancontributor/service.go
@@ -1338,13 +1338,7 @@ func (s Service) handleImport(httpRequest *http.Request) (*fhir.Bundle, error) {
 
 func (s *Service) handleLogout(httpResponse http.ResponseWriter, httpRequest *http.Request) {
 	s.SessionManager.Destroy(httpResponse, httpRequest)
-	// If there is a 'Referer' value in the header, redirect to that URL
-	if referer := httpRequest.Header.Get("Referer"); referer != "" {
-		http.Redirect(httpResponse, httpRequest, referer, http.StatusFound)
-	} else {
-		// This redirection will be handled by middleware in the frontend
-		http.Redirect(httpResponse, httpRequest, s.config.FrontendConfig.URL, http.StatusOK)
-	}
+	http.Redirect(httpResponse, httpRequest, s.config.FrontendConfig.URL, http.StatusFound)
 }
 
 func getIdentifierParameter(params fhir.Parameters, name string) (*fhir.Identifier, error) {

--- a/orchestrator/careplancontributor/service_test.go
+++ b/orchestrator/careplancontributor/service_test.go
@@ -735,8 +735,9 @@ func TestService_Proxy_ProxyToEHR_WithLogout(t *testing.T) {
 		Value: sessionID,
 	})
 	httpResponse, err = frontServer.Client().Do(httpRequest)
+	// The test client blindly follows 302s, so it goes and does a GET on '/', which is not registered -> 404 is expected.
 	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, httpResponse.StatusCode)
+	require.Equal(t, http.StatusNotFound, httpResponse.StatusCode)
 
 	httpRequest, _ = http.NewRequest("GET", frontServer.URL+"/cpc/test/ehr/fhir/Patient/1", nil)
 	httpRequest.AddCookie(&http.Cookie{


### PR DESCRIPTION
Fixes bug that would result in no redirect happening when the redirect headers value would be empty.